### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3658,7 +3658,6 @@ edu.mg
 mil.mg
 com.mg
 co.mg
-net.mg
 
 // mh : http://en.wikipedia.org/wiki/.mh
 mh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3647,7 +3647,7 @@ gov.me
 its.me
 priv.me
 
-// mg : http://www.nic.mg/tarif.htm
+// mg : http://nic.mg/nicmg/?page_id=39
 mg
 org.mg
 nom.mg
@@ -3657,6 +3657,8 @@ tm.mg
 edu.mg
 mil.mg
 com.mg
+co.mg
+net.mg
 
 // mh : http://en.wikipedia.org/wiki/.mh
 mh


### PR DESCRIPTION
co.mg and net.mg are second level of .mg domains that are owned by the main registry NIC MG (whois on these domains could help to prove), and sold by registrars as 3rd level.
reference to co.mg can be seen on the web page http://nic.mg/nicmg/?page_id=39
NIC MG seems to have forgot to include reference to net.mg in its materials.
A google search on net.mg [ https://www.google.com/search?q=net.mg ] could also indicate that many registrars are able to sell .net.mg 3rd level domains.