### PR TITLE
Add "reserved" TLDs (RFC 2606) to the PSL.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -8382,6 +8382,15 @@ zip
 zone
 
 // ===END ICANN DOMAINS===
+// ===BEGIN RESERVED DOMAINS===
+
+// Reserved Top Level DNS Names (RFC 2606): https://tools.ietf.org/html/rfc2606
+test
+example
+invalid
+localhost
+
+// ===END RESERVED DOMAINS===
 // ===BEGIN PRIVATE DOMAINS===
 
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/


### PR DESCRIPTION
RFC 2606 reserves the following top level DNS names
(https://tools.ietf.org/html/rfc2606#section-2):

* test
* example
* invalid
* localhost

This patch adds them to the public suffix list, ensuring
similar behavior to other top level domains.