### PR TITLE
Added Slovak government domain (gov.sk).

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5857,6 +5857,7 @@ sj
 // sk : http://en.wikipedia.org/wiki/.sk
 // list of 2nd level domains ?
 sk
+gov.sk
 
 // sl : http://www.nic.sl
 // Submitted by registry <adam@neoip.com> 2008-06-12


### PR DESCRIPTION
Added Slovak government domain (gov.sk).

Some example domains:
http://www.finance.gov.sk/
http://www.telecom.gov.sk/
http://www.employment.gov.sk/