### PR TITLE
Add private registry .biz.ua to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6302,11 +6302,6 @@ zhytomyr.ua
 zp.ua
 zt.ua
 
-// Private registries in .ua : http://drs.ua
-biz.ua
-co.ua
-pp.ua
-
 // ug : https://www.registry.co.ug/
 ug
 co.ug
@@ -10609,6 +10604,12 @@ priv.at
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com> 2012-10-24
 rhcloud.com
+
+// Service Online LLC : http://drs.ua/
+// Submitted by Serhii Bulakh <support@drs.ua> 2015-07-30
+biz.ua
+co.ua
+pp.ua
 
 // SinaAppEngine : http://sae.sina.com.cn/
 // Submitted by SinaAppEngine <saesupport@sinacloud.com> 2015-02-02

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6302,7 +6302,8 @@ zhytomyr.ua
 zp.ua
 zt.ua
 
-// Private registries in .ua
+// Private registries in .ua : http://drs.ua
+biz.ua
 co.ua
 pp.ua
 


### PR DESCRIPTION
We are Service Online LLC company that provide private registries
.biz.ua, .co.ua and pp.ua.
Web-site: https://drs.ua

Our domains .co.ua and pp.ua. were added to PSL since 21 Feb 2012, but
for some reason our first domain .biz.ua was not added.

Official site of this domain zone (in Russian): www.biz.ua
(http://drs.ua/rus/policy/bizua.html)
Translated version:
http://translate.google.com/translate?hl=ru&sl=uk&tl=en&u=http%3A%2F%2Fdrs.ua%2Frus%2Fpolicy%2Fbizua.html&sandbox=1

Authoritative whois server:  whois.biz.ua port 43

Our registry named CUNIC (Central Ukraine Network Information Center)
is also registered at IANA EPP repository list:
https://www.iana.org/assignments/epp-repository-ids/epp-repository-ids.xhtml