### PR TITLE
update tests/test_psl.txt since .cy is no longer wildcarded

### DIFF
--- a/tests/test_psl.txt
+++ b/tests/test_psl.txt
@@ -38,10 +38,10 @@ checkPublicSuffix('b.example.uk.com', 'example.uk.com');
 checkPublicSuffix('a.b.example.uk.com', 'example.uk.com');
 checkPublicSuffix('test.ac', 'test.ac');
 // TLD with only 1 (wildcard) rule.
-checkPublicSuffix('cy', null);
-checkPublicSuffix('c.cy', null);
-checkPublicSuffix('b.c.cy', 'b.c.cy');
-checkPublicSuffix('a.b.c.cy', 'b.c.cy');
+checkPublicSuffix('il', null);
+checkPublicSuffix('c.il, null);
+checkPublicSuffix('b.c.il', 'b.c.il');
+checkPublicSuffix('a.b.c.il', 'b.c.il');
 // More complex TLD.
 checkPublicSuffix('jp', null);
 checkPublicSuffix('test.jp', 'test.jp');


### PR DESCRIPTION
1bb3c8c34b17e9afe34e308069daeffac91380b2 resolved
https://github.com/publicsuffix/list/issues/7 by removing the *.cy
wildcard in favor of an explicit listing.

However, it did not update test_psl.txt to match, so any tests that
use it would fail.  This patch updates the test suite to use *.il
instead of *.cy.