### PR TITLE
Add QA2.com entry to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10613,6 +10613,10 @@ zakopane.pl
 // Submitted by registry <lendl@nic.at> 2008-06-09
 priv.at
 
+// QA2
+// Submitted by Daniel Dent (https://www.danieldent.com/) 2015-07-16
+qa2.com
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com> 2012-10-24
 rhcloud.com


### PR DESCRIPTION
If needed, confirmation of this request can be obtained by emailing a contact listed in whois for qa2.com.
