### PR TITLE
Add sandcats.io dynamic DNS service as public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10802,6 +10802,10 @@ qa2.com
 // Submitted by Tim Kramer <tkramer@rhcloud.com> 2012-10-24
 rhcloud.com
 
+// Sandstorm Development Group, Inc. : https://sandcats.io/
+// Submitted by Asheesh Laroia <asheesh@sandstorm.io> 2015-07-21
+sandcats.io
+
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua> 2015-07-30
 biz.ua


### PR DESCRIPTION
I'm on the sandstorm.io team, where we maintain a public dynamic DNS service at sandcats.io.

@kentonv is the listed domain owner. Let me know what we should do to fully confirm the domain name to your satisfaction.