### PR TITLE
Use Travis-CI for testing with libpsl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: c
+compiler:
+  - gcc
+# Change this to your needs
+script:
+  - DIR=`pwd`
+  - git clone https://github.com/rockdaboot/libpsl
+  - cd libpsl
+  - echo "EXTRA_DIST =" >gtk-doc.make
+  - echo "CLEANFILES =" >>gtk-doc.make
+  - autoreconf --install --force --symlink
+  - OPTIONS="--with-psl-file=$DIR/public_suffix_list.dat --with-psl-testfile=$DIR/tests/test_psl.txt"
+# Test PSL data with libicu (IDNA2008 UTS#46)
+  - ./configure -C --enable-runtime=libicu --enable-builtin=libicu $OPTIONS && make clean && make check -j4
+# TEST PSL data with libidn2 (IDNA2008)
+  - ./configure -C --enable-runtime=libidn2 --enable-builtin=libidn2 $OPTIONS && make clean && make check -j4
+# TEST PSL data with libidn (IDNA2003)
+  - ./configure -C --enable-runtime=libidn --enable-builtin=libidn $OPTIONS && make clean && make check -j4
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get -q install autoconf automake autopoint libtool gettext libidn11 libidn11-dev libidn2-0 libidn2-0-dev libicu48 libicu-dev libunistring0 libunistring-dev


### PR DESCRIPTION
* .travis.yml: Add file

When hooked to Travis-CI, public_suffix_list.dat and tests/test_psl.txt
will be tested using https://github.com/rockdaboot/libpsl.
The tests includes testing with libicu (IDNA2008 UTS#46),
libidn2 (IDNA2008) and libidn (IDNA2003).