### PR TITLE
Add withyoutube.com as a new public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11019,6 +11019,7 @@ googleapis.com
 googlecode.com
 pagespeedmobilizer.com
 withgoogle.com
+withyoutube.com
 
 // Heroku : https://www.heroku.com/
 // Submitted by Tom Maher <tmaher@heroku.com> 2013-05-02


### PR DESCRIPTION
Please advise as to what verification is necessary to make this change (As FYI, I'm the same Phil Ames as the one that requested a similar change in https://bugzilla.mozilla.org/show_bug.cgi?id=965744)