### PR TITLE
Remove .an domains from the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -155,13 +155,6 @@ org.al
 // am : http://en.wikipedia.org/wiki/.am
 am
 
-// an : http://www.una.an/an_domreg/default.asp
-an
-com.an
-net.an
-org.an
-edu.an
-
 // ao : http://en.wikipedia.org/wiki/.ao
 // http://www.dns.ao/REGISTR.DOC
 ao


### PR DESCRIPTION
Regarding to [wikipedia](https://en.wikipedia.org/wiki/.an) and a [source document](http://www.versgeperst.com/nieuws/268890/internetextensie-an-stopt-per-31-juli.html), `.an` domains has been discontinued.