### PR TITLE
Add hashbang.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11158,6 +11158,10 @@ pagespeedmobilizer.com
 withgoogle.com
 withyoutube.com
 
+// Hashbang : https://hashbang.sh
+// Hashbang is a non-profit that provides shells and various other services.
+hashbang.sh
+
 // Heroku : https://www.heroku.com/
 // Submitted by Tom Maher <tmaher@heroku.com> 2013-05-02
 herokuapp.com


### PR DESCRIPTION
This is in preparation of our DNS & HTTP(S) rollout, that will enable users to serve content on `${username}.hashbang.sh`.

I am part of #!'s sysadmin team.