### PR TITLE
Add user-content domain for MyClientGlobal.com Ltd

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11188,6 +11188,10 @@ cloudapp.net
 // Submited by glob <glob@mozilla.com> 2015-07-06
 bmoattachments.org
 
+// MyClientGlobal.com Ltd : https://www.myclientglobal.com/
+// Submitted by Mason <mason@myclientglobal.com> 2015-12-07
+servermanagerpro.com
+
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz> 2015-04-23
 4u.com


### PR DESCRIPTION
Hi!

Our company offers subdomains under `servermanagerpro.com` for each individual user. It's analogous to, say, `github.io` entry already in the list.

Would it be possible to consider this domain as a public suffix?