### PR TITLE
add daplie.me to PSL for dynamic dns

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10699,7 +10699,6 @@ cupcake.is
 // Daplie : https://daplie.com/
 // Submitted by AJ ONeal <aj@daplie.com> 2015-12-10
 daplie.me
-testing.letssecure.org
 
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com> 2012-10-02

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10696,6 +10696,11 @@ co.no
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io> 2013-10-08
 cupcake.is
 
+// Daplie : https://daplie.com/
+// Submitted by AJ ONeal <aj@daplie.com> 2015-12-10
+daplie.me
+testing.letssecure.org
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com> 2012-10-02
 dreamhosters.com


### PR DESCRIPTION
Daplie is offering daplie.me domains as Dynamic DNS with Let's Encrypt. We will also be offering hosting soon.

note that my email address on the whois record is currently coolaj86@gmail.com, but will be updated to aj@daplie.com shortly