### PR TITLE
Add asuscomm.com dynamic dns service for ASUS routers

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11282,6 +11282,9 @@ familyds.com
 familyds.net
 familyds.org
 
+// Dynamic DNS for ASUS  routers
+asuscomm.com
+
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl
 gdansk.pl


### PR DESCRIPTION
asuscomm.com is root domain of Dynamic DNS for ASUS routers