### PR TITLE
Add cloudfunctions.net to Google, Inc. section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11151,6 +11151,7 @@ blogspot.td
 blogspot.tw
 blogspot.ug
 blogspot.vn
+cloudfunctions.net
 codespot.com
 googleapis.com
 googlecode.com


### PR DESCRIPTION
cloudfunctions.net is to be used to host 3-rd party code.