### PR TITLE
Add xenapponazure.com to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10649,6 +10649,10 @@ za.com
 // Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
 africa.com
 
+// Citrix : https://citrix.com
+// Submitted by Alex Stoddard <alex.stoddard@citrix.com> 2015-12-16
+xenapponazure.com
+
 // iDOT Services Limited : http://www.domain.gr.com
 // Submitted by Gavin Brown <gavin.brown@centralnic.com> 2014-02-04
 gr.com


### PR DESCRIPTION
Citrix is offering subdomains under xenapponazure.com which resolve to customer managed deployments of Citrix XenApp.