### PR TITLE
 Add Asus wireless router Dynamic DNS services

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11306,4 +11306,9 @@ yolasite.com
 za.net
 za.org
 
+// asuscomm : http://asus.com
+// Asus provides DDNS in Asus NAT router.
+// Submitted by Munho Lee <nuclearism@gmail.com> 2015-12-17
+asuscomm.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Added asuscomm.com
This domain is used for DDNS service provided by Asus wireless router.
