### PR TITLE
Add compute.estate and alces.network for Alces Software Ltd

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10621,6 +10621,11 @@ zuerich
 // ===BEGIN PRIVATE DOMAINS===
 // (Note: these are in alphabetical order by company name)
 
+// Alces Software Ltd: http://alces-software.com
+// Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com> 2015-12-23
+*.compute.estate
+*.alces.network
+
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com>
 cloudfront.net


### PR DESCRIPTION
These two domains are used to provide subdomains for different users.

Confirmation may be sought at the admin email address or registrant email address for these domains.