### PR TITLE
add nsupdate.info dyndns service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11297,6 +11297,10 @@ ngrok.io
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com
 
+// nsupdate.info : https://www.nsupdate.info/
+// Submitted by Thomas Waldmann <info@nsupdate.info>
+nsupdate.info
+
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn


### PR DESCRIPTION
we (and users of our nsupdate.info service) ran into issues with letsencrypt.org's rate limiting for tls certificate requests.

it might also help for other purposes, so people can know these hosts do not all belong to me / to the nsupdate.info domain, but shall be considered independent. 