### PR TITLE
add nerdpol.ovh part of nsupdate.info dyndns service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11329,6 +11329,7 @@ nfshost.com
 // nsupdate.info : https://www.nsupdate.info/
 // Submitted by Thomas Waldmann <info@nsupdate.info>
 nsupdate.info
+nerdpol.ovh
 
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>


### PR DESCRIPTION
> we (and users of our nsupdate.info service) ran into issues with letsencrypt.org's rate limiting for tls certificate requests.

related (nerdpol.ovh is a dyndns domain for nsupdate.info) to https://github.com/publicsuffix/list/pull/93