### PR TITLE
Add additional entries to .GY ccTLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1004,6 +1004,9 @@ gy
 co.gy
 com.gy
 net.gy
+org.gy
+edu.gy
+gov.gy
 
 // hk : https://www.hkdnr.hk
 // Submitted by registry <hk.tech@hkirc.hk> 2008-06-11

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1003,10 +1003,10 @@ gw
 gy
 co.gy
 com.gy
-net.gy
-org.gy
 edu.gy
 gov.gy
+net.gy
+org.gy
 
 // hk : https://www.hkdnr.hk
 // Submitted by registry <hk.tech@hkirc.hk> 2008-06-11


### PR DESCRIPTION
http://registry.gy states:
Presently, .gy; .co.gy; .com.gy; .org.gy; .net.gy; .edu.gy and .gov.gy domain names. are available for registration.