### PR TITLE
added shnbk.de by domain owner

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11289,6 +11289,10 @@ biz.ua
 co.ua
 pp.ua
 
+// shnbk : http://shnbk.de/
+// Submitted by Dirk Heilig <dirkheilig@shnbk.de> 2016-01-17
+shnbk.de
+
 // SinaAppEngine : http://sae.sina.com.cn/
 // Submitted by SinaAppEngine <saesupport@sinacloud.com> 2015-02-02
 sinaapp.com


### PR DESCRIPTION
Hi,
i'm planing to deploy some internet of things gadgets that will get a webinterface on a subdomain of shnbk.de,  having shnbk.de on the publixsuffix-list would make that better.

I am the owner of shnbk.de, but im not quite sure how to prove it since denic doesn't show the email-address in whois.

Sure you could send me a snail-mail, but that would be a hassle.
We could do that like google or some ssl-auth. do it, by putting somethin under a specific url, like i did with the commit-id:
http://shnbk.de/138f620e676819b4b337991145ff169605846716/
or via a dns-entry:

     shnbk.de.		86400	IN	TXT	"138f620e676819b4b337991145ff169605846716"
(which will propergate in the next few hour)

Or just tell me your favorite method.

Thanks, Dirk
