### PR TITLE
adding dynv6 dynamic DNS service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11014,6 +11014,10 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
+// dynv6 : https://dynv6.com
+// Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
+dynv6.net
+
 // EU.org https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org> 2015-04-17
 


### PR DESCRIPTION
Added dynv6.net as public suffix for the dynv6.com service.

Will update a TXT record pointing to this PR URI for verification. Feel free to contact me at dom@digineo.de.