### PR TITLE
Add CampaignChain SaaS solution

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10697,6 +10697,10 @@ co.com
 // c.la : http://www.c.la/
 c.la
 
+// CampaignChain, Inc. : http://www.campaignchain.com/
+// Submitted by Sandro Groganz <sandro@campaignchain.com> 2016-01-26
+campaignchain.net
+
 // cloudControl : https://www.cloudcontrol.com/
 // Submitted by Tobias Wilken <tw@cloudcontrol.com> 2013-07-23
 cloudcontrolled.com


### PR DESCRIPTION
CampaignChain launches its beta on first of February using subdomains
under campaignchain.net (eg. betauser123.campaignchain.net). Since
CampaignChain can be extended with custom code by end users, we would
like the browsers to prevent setting cookies on campaignchain.net.
Additionally we have a letsencrypt.org implementation for
campaignchain.net ready, which we can not use (at the moment) due to
letsencrypt.org's domain limit (5 per 7 days, as of making this PR).

A validation email, referencing this PR, is under way to team at
publicsuffix dot org.