### PR TITLE
Adding public PageKite and Mailpile service domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11322,6 +11322,13 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// The Beanstalks Project ehf : https://pagekite.net/
+// Submitted by Bjarni R. Einarsson <bre@pagekite.net> 2016-01-28
+pagekite.me
+testing.is
+302.is
+my-mailpile.is
+
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com> 2014-11-07
 hk.com


### PR DESCRIPTION
This are the current PageKite and Mailpile service domains. All but the Mailpile domain have been open to the public for registrations for many years, the Mailpile service will go live later this year.