### PR TITLE
added *.i.ng. http://psg.com/dns/ng/ is currently unavailable to conf…

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4430,6 +4430,7 @@ sch.ng
 gov.ng
 mil.ng
 mobi.ng
+i.ng
 
 // ni : http://www.nic.ni/
 com.ni


### PR DESCRIPTION
…irm, but these are available to purchase at https://www.101domain.com/i_ng.htm