### PR TITLE
Adding asuscomm.com domain to the public list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10622,6 +10622,9 @@ elasticbeanstalk.com
 // Submitted by Scott Vidmar <svidmar@amazon.com> 2013-03-27
 elb.amazonaws.com
 
+// Asuscomm
+asuscomm.com
+
 // Amazon S3 : https://aws.amazon.com/s3/
 // Submitted by Eric Kinolik <kilo@amazon.com> 2015-04-08
 s3.amazonaws.com


### PR DESCRIPTION
Adding this extension as it is used by Asus routers for DynDNS.