### PR TITLE
add freeboxos domains to public_suffic_list.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11181,6 +11181,15 @@ firebaseapp.com
 // Submitted by Jonathan Rudenberg <jonathan@flynn.io>
 flynnhub.com
 
+// Freebox http://www.freebox.fr
+// Submitted by Romain Fliedel <rfliedel@freebox.fr> 2016-02-02
+fbx-os.fr
+fbxos.fr
+freebox-os.com
+freeboxos.com
+freebox-os.fr
+freeboxos.fr
+
 // GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
 // Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk>
 service.gov.uk


### PR DESCRIPTION
Freebox offer its customers the ability to reserve a custom
subdomain {yourname}.freeboxos.fr to access their router.