### PR TITLE
Add mypep.link to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11272,6 +11272,7 @@ pantheon.io
 gotpantheon.com
 
 // Peplink | Pepwave : http://peplink.com/
+// Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
 
 // prgmr.com : https://prgmr.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11271,6 +11271,9 @@ zakopane.pl
 pantheon.io
 gotpantheon.com
 
+// Peplink | Pepwave : http://peplink.com/
+mypep.link
+
 // prgmr.com : https://prgmr.com/
 // Changed by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com


### PR DESCRIPTION
Peplink and Pepwave routers use *.mypep.link for DDNS service.