### PR TITLE
add dnshome.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10740,6 +10740,10 @@ co.no
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
 
+// DNShome : https://www.dnshome.de/
+// Submitted by Martin Mazur <mail@martin-mazur.net>
+dnshome.de
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com


### PR DESCRIPTION
Please add dnshome.de to the list.

dnshome.de is a German dDNS service. Before creating this issue I contacted the owner of the domain dnshome.de and asked for this approval to be added to the list. He has given the approval

Thanks :-)