### PR TITLE
Added pgfog.com to the public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11359,6 +11359,10 @@ ownprovider.com
 // Submitted by Charly Coste <changaco@changaco.oy.lc>
 oy.lc
 
+// Pagefog : https://pagefog.com/
+// Submitted by Derek Myers <derek@pagefog.com>
+pgfog.com
+
 // Pagefront : https://www.pagefronthq.com/
 // Submitted by Jason Kriss <jason@pagefronthq.com>
 pagefrontapp.com


### PR DESCRIPTION
[Pagefog](http://pagefog.com) is a hosting service that provisions cloud servers and sets up website hosting, DNS with the `pgfg.com` domain, and SSL certificates with LetsEncrypt.

## Verification

```bash
$ host -t TXT _psl.pgfog.com
_psl.pgfog.com descriptive text "https://github.com/publicsuffix/list/pull/141"
```