### PR TITLE
Add cs260.net & cs261.net, roots for student-issued domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10740,6 +10740,11 @@ co.no
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
 
+// DigiPen Networking Classes : http://www.digipen.edu
+// Submitted by Stephen Beeman <stephen.beeman@digipen.edu>
+cs260.net
+cs261.net
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com


### PR DESCRIPTION
I use the domains cs260.net and cs261.net to issue subdomains to students in my networking classes at DigiPen. Since I own these domains privately, I've placed TXT records clarifying their ownership and usage in their DNS. Thanks!