### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11284,6 +11284,10 @@ zakopane.pl
 pantheon.io
 gotpantheon.com
 
+// Pivotal Software Inc. : https://pivotal.io/
+// Submitted by Logan Lee <lolee@pivotal.io>
+cfapps.io
+
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com


### PR DESCRIPTION
Publicly available domain used on Pivotal Web Services.