### PR TITLE
add b-OX.cloud in addition to b-OX.de and b-OX.biz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10641,8 +10641,9 @@ s3.eu-central-1.amazonaws.com
 
 // b-tix b-OX: http://b-tix.de http://www.b-OX.de
 // Submitted by Markus Heussen <heussen@b-tix.de> 2016-01-28
-b-ox.de
 b-ox.biz
+b-ox.cloud
+b-ox.de
 
 // BetaInABox
 // Submitted by adrian@betainabox.com 2012-09-13

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10639,6 +10639,11 @@ s3-us-west-2.amazonaws.com
 s3.cn-north-1.amazonaws.com.cn
 s3.eu-central-1.amazonaws.com
 
+// b-tix b-OX: http://b-tix.de http://www.b-OX.de
+// Submitted by Markus Heussen <heussen@b-tix.de> 2016-01-28
+b-ox.de
+b-ox.biz
+
 // BetaInABox
 // Submitted by adrian@betainabox.com 2012-09-13
 betainabox.com


### PR DESCRIPTION
This is an extension to the previous pull request #119:
We (b-tix GmbH) just added b-OX.cloud to the list of domains (previously being b-OX.de and b-OX.net).
For explanation, see #119.

Verification: http://whois.domaintools.com/b-ox.cloud returns:
Registrant Email: heussen@b-tix.de
from where email can be answered or sent upon request.
