### PR TITLE
Adds cyon.link and cyon.site to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10740,6 +10740,11 @@ co.no
 // Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
 cupcake.is
 
+// cyon GmbH : https://www.cyon.ch/
+// Submitted by Dominic Luechinger <dol@cyon.ch>
+cyon.link
+cyon.site
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com


### PR DESCRIPTION
## cyon.link
We offer our webhosting customers a so called preview domain to view their website. This helps to test the website before changing the name server. Each customer gets a *.cyon.link domain.
E.g.: My website http://snowgarden.ch/ can also be reached on http://snowgard.cyon.link/

## cyon.site
We offer our webhosting customers a site creation tool (aka sitebuilder). Similar too cyon.link we offer each sitebuilder customer their own publish subdomain => *.cyon.site.
E.g.: An example site that one of my coworkers put together can be found on http://hasi.cyon.site/index.html

### Reason for inclusion
Cookie isolation. An other beneficial reason is that we can issue SSL certificates with Let's Encrypt [1] more easily and not hitting the per domain rate limit.
The use case can be compared to herokuapp.com or herokussl.com. https://devcenter.heroku.com/articles/cookies-and-herokuapp-com

[1] cyon is a sponsor of https://letsencrypt.org/