### PR TITLE
Add Exosite.com [PS]aaS domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11096,6 +11096,11 @@ tr.eu.org
 uk.eu.org
 us.eu.org
 
+// Exosite LLC https://exosite.com/
+// Submitted by C Anthony Risinger <anthonyrisinger@exosite.com>
+exosite-dev.io
+exosite.io
+
 // Facebook, Inc.
 // Submitted by Peter Ruibal <public-suffix@fb.com>
 apps.fbsbx.com


### PR DESCRIPTION
These domains automatically provision certificates via Let's Encrypt for clients on Exosite's platform.