### PR TITLE
Adds chirurgiens-dentistes-en-france.fr to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11338,7 +11338,7 @@ gotpantheon.com
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
 
-// Publication Presse Communication SARL https://ppcom.fr
+// Publication Presse Communication SARL : https://ppcom.fr
 // Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
 chirurgiens-dentistes-en-france.fr
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11346,10 +11346,6 @@ gotpantheon.com
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
 
-// Publication Presse Communication SARL : https://ppcom.fr
-// Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
-chirurgiens-dentistes-en-france.fr
-
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com
@@ -11357,6 +11353,10 @@ xen.prgmr.com
 // priv.at : http://www.nic.priv.at/
 // Submitted by registry <lendl@nic.at>
 priv.at
+
+// Publication Presse Communication SARL : https://ppcom.fr
+// Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
+chirurgiens-dentistes-en-france.fr
 
 // QA2
 // Submitted by Daniel Dent (https://www.danieldent.com/)

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11329,8 +11329,8 @@ gotpantheon.com
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
 
-// P. P. COM (Publication Presse Communication SARL): ppcom.fr
-// submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
+// Publication Presse Communication SARL https://ppcom.fr
+// Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
 chirurgiens-dentistes-en-france.fr
 
 // prgmr.com : https://prgmr.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11304,6 +11304,10 @@ zakopane.pl
 pantheon.io
 gotpantheon.com
 
+// P. P. COM (Publication Presse Communication SARL): ppcom.fr
+// submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
+chirurgiens-dentistes-en-france.fr
+
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com


### PR DESCRIPTION
P.P.COM (ppcom.fr via denti.site) offers our dentist customers in France a website hosted in a domain *.chirurgiens-dentistes-en-france.fr.
Specifically, each dentist has a domain in the form of dr-<firstname>-<lastname>.chirurgiens-dentistes-en-france.fr
E.g.: dr-dupond-pierre.chirurgiens-dentistes-en-france.fr
One can see other examples of sites in denti.site

Reason for inclusion

Cookie isolation. Each dentist can partially modify himself his site so cookie isolation is needed for security reason.
We could also get rid of our wildchar certificate and obtain easily (using Let's Encrypt for instance) a certificate per active website