### PR TITLE
Update for ddnss.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10751,6 +10751,10 @@ cupcake.is
 cyon.link
 cyon.site
 
+// ddnss.de : https://ddnss.de/
+// Submitted on behalf of Robert Niedziela <webmaster@megacomputing.de>
+ddnss.de
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com


### PR DESCRIPTION
Please include this domain to the List. I'm not sure if I placed it right. If not, feel free to move it to the right position.
Why the request? I'm using ddnss.de since a long time. It is very reliable and works well with my router.
I recently discovered let's encrypt but unfortunately the rate limit is always reached as more and more people are using it.
I asked the owner of ddnss.de to add the service to this list. In return he asked me to do it on his behalf since his requests have been denied.
Please let me know the reason, should this request be denied as well.