### PR TITLE
Adds bytemark customer suffixes to private suffixes list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10656,6 +10656,12 @@ s3.eu-central-1.amazonaws.com
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com
 
+// Bytemark Hosting
+// Submitted by Nathan Lasseter <nathan@bytemark.co.uk>
+dh.bytemark.co.uk
+vm.bytemark.co.uk
+*.*.uk0.bigv.io
+
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
 ae.org


### PR DESCRIPTION
Adds to the suffix list the domains that Bytemark Hosting (www.bytemark.co.uk) use for customer machines.