### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11063,7 +11063,6 @@ home-webserver.de
 dyn.home-webserver.de
 myhome-server.de
 ddnss.org
-
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
 dynv6.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11052,6 +11052,20 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
+// ddnss.de : https://www.ddnss.de/
+// Submitted by Robert Niedziela <webmaster@ddnss.de> 2016-03-14
+
+ddnss.de
+ddnss.org
+dyn.ddnss.de  
+dyndns.ddnss.de  
+dyndns1.de
+dyn-ip24.de
+home-webserver.de  
+myhome-server.de  
+dyn.home-webserver.de
+
+
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
 dynv6.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11054,7 +11054,6 @@ writesthisblog.com
 
 // ddnss.de . : https://www.ddnss.de/
 // Submitted by Robert Niedziela <webmaster@ddnss.de>
-ddnss.org
 ddnss.de
 dyn.ddnss.de
 dyndns.ddnss.de
@@ -11063,6 +11062,8 @@ dyn-ip24.de
 home-webserver.de
 dyn.home-webserver.de
 myhome-server.de
+ddnss.org
+
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
 dynv6.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11053,7 +11053,7 @@ worse-than.tv
 writesthisblog.com
 
 // ddnss.de : https://www.ddnss.de/
-// Submitted by Robert Niedziela <webmaster@ddnss.de> 2016.11.07
+// Submitted by Robert Niedziela <webmaster@ddnss.de>
 ddnss.de
 dyn.ddnss.de
 dyndns.ddnss.de

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11052,8 +11052,8 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
-// ddnss.de . : https://www.ddnss.de/
-// Submitted by Robert Niedziela <webmaster@ddnss.de>
+// ddnss.de : https://www.ddnss.de/
+// Submitted by Robert Niedziela <webmaster@ddnss.de> 2016.11.07
 ddnss.de
 dyn.ddnss.de
 dyndns.ddnss.de
@@ -11063,6 +11063,7 @@ home-webserver.de
 dyn.home-webserver.de
 myhome-server.de
 ddnss.org
+
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
 dynv6.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11052,20 +11052,17 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
-// ddnss.de : https://www.ddnss.de/
-// Submitted by Robert Niedziela <webmaster@ddnss.de> 2016-03-14
-
-ddnss.de
+// ddnss.de . : https://www.ddnss.de/
+// Submitted by Robert Niedziela <webmaster@ddnss.de>
 ddnss.org
-dyn.ddnss.de  
-dyndns.ddnss.de  
+ddnss.de
+dyn.ddnss.de
+dyndns.ddnss.de
 dyndns1.de
 dyn-ip24.de
-home-webserver.de  
-myhome-server.de  
+home-webserver.de
 dyn.home-webserver.de
-
-
+myhome-server.de
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
 dynv6.net


### PR DESCRIPTION
Add DynDNS -Service Domains to public suffix List 

DynDNS Service is an dynamic DNS services under the Domains ddnss.org
ddnss.de
dyn.ddnss.de
dyndns.ddnss.de
dyndns1.de
dyn-ip24.de
home-webserver.de
dyn.home-webserver.de
myhome-server.de

For security reasons (cookie isolation) and to provide them with the ability to create Let's Encrypt certificates, we would like to add those domains to the public suffix list.
