### PR TITLE
Add logoip.de and logoip.com domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11337,6 +11337,11 @@ rhcloud.com
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io
 
+// SBE network solutions GmbH : https://www.sbe.de/
+// Submitted by Norman Meilick <nm@sbe.de>
+logoip.de
+logoip.com
+
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua


### PR DESCRIPTION
SBE network solutions GmbH offers our customers (mostly schools) dynamic DNS services under the domains logoip.de and logoip.com (e.g., hostname.logoip.de).

For security reasons (cookie isolation) and to provide them with the ability to create Let's Encrypt certificates, we would like to add those domains to the public suffix list.