### PR TITLE
Add tuxfamily.org domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11627,6 +11627,10 @@ sopot.pl
 bloxcms.com
 townnews-staging.com
 
+// TuxFamily domains http://tuxfamily.org
+// Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
+tuxfamily.org
+
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com>
 hk.com


### PR DESCRIPTION
TuxFamily is now automatically provisioning certificates via Let's Encrypt for their users on thousands of subdomains of tuxfamily.org. We don't use cookies on the main site (tuxfamily.org) so being added here is perfectly fine for us.