### PR TITLE
Add ru.net as defined by nic.ru

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5683,6 +5683,7 @@ int.ru
 net.ru
 org.ru
 pp.ru
+ru.net
 // Geographical domains
 adygeya.ru
 altai.ru


### PR DESCRIPTION
nic.ru is now offerring .ru.net domains https://www.nic.ru/dns/domain/en/ru_net.html