### PR TITLE
Add domains hosted by potager.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10682,6 +10682,13 @@ s3.eu-central-1.amazonaws.com
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
+// Association potager.org : https://potager.org/
+// Submitted by Lunar <jardiniers@potager.org>
+potager.org
+poivron.org
+sweetpepper.org
+pimienta.org
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net


### PR DESCRIPTION
potager.org is a French non-profit organization hosting websites run by independent groups and individuals.