### PR TITLE
Added boxfuse.io domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10662,6 +10662,10 @@ s3.eu-central-1.amazonaws.com
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com
 
+// Boxfuse : https://boxfuse.com
+// Submitted by Axel Fontaine <axel@boxfuse.com>
+boxfuse.io
+
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
 ae.org


### PR DESCRIPTION
Boxfuse users receive boxfuse.io subdomains which can optionally be secured by Let's Encrypt certificates