### PR TITLE
Add hzc.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11350,6 +11350,10 @@ rackmaze.net
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com
 
+// RethinkDB : https://www.rethinkdb.com/
+// Submitted by Chris Kastorff <info@rethinkdb.com>
+hzc.io
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io


### PR DESCRIPTION
hzc.io will soon be hosting arbitrary users' sites underneath it, and each of them could have different login mechanisms. For cookie isolation, we'd like to put it on the PSL.