### PR TITLE
Add daplie.me

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10760,6 +10760,10 @@ cupcake.is
 cyon.link
 cyon.site
 
+// Daplie, Inc https://daplie.com
+// Submitted by AJ ONeal <aj@daplie.com>
+daplie.me
+
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>
 biz.dk


### PR DESCRIPTION
Daplie, Inc provides Domains, Dynamic DNS, and a home Cloud server. Subdomains of daplie.me are available to DIY users, hobbyists, and developers.