### PR TITLE
Added on-web.fr (planet-work.com)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11333,6 +11333,10 @@ mypep.link
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com
 
+// on-web.fr : https://www.planet-work.com/
+// Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
+on-web.fr
+
 // priv.at : http://www.nic.priv.at/
 // Submitted by registry <lendl@nic.at>
 priv.at


### PR DESCRIPTION
on-web.fr is the subdomain for our shared hosting customers.