### PR TITLE
Add hasura-app.io to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11247,6 +11247,10 @@ withyoutube.com
 // Hashbang : https://hashbang.sh
 hashbang.sh
 
+// Hasura : https://hasura.io
+// Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura-app.io
+
 // Heroku : https://www.heroku.com/
 // Submitted by Tom Maher <tmaher@heroku.com>
 herokuapp.com
@@ -11401,9 +11405,5 @@ yolasite.com
 // Submitted by registry <hostmaster@nic.za.net>
 za.net
 za.org
-
-// Hasura : https://hasura.io
-// Submitted by Shahidh K Muhammed <shahidh@hasura.io>
-hasura-app.io
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11402,4 +11402,8 @@ yolasite.com
 za.net
 za.org
 
+// Hasura : https://hasura.io
+// Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura-app.io
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Hasura issues sub-domain based project urls to its customers. These projects should not be able to set cookie anywhere else other than on their own root domain. Like herokuapp.com