### PR TITLE
Add happyfuntimes.net to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11251,6 +11251,11 @@ pagespeedmobilizer.com
 withgoogle.com
 withyoutube.com
 
+// Happyfuntimes : http://www.happyfuntimes.net
+// Submitted by Gregg Tavares <psl@greggman.com>
+happyfuntimes.net
+games.happyfuntimes.net
+
 // Hashbang : https://hashbang.sh
 hashbang.sh
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11253,7 +11253,6 @@ withyoutube.com
 
 // Happyfuntimes : http://www.happyfuntimes.net
 // Submitted by Gregg Tavares <psl@greggman.com>
-happyfuntimes.net
 games.happyfuntimes.net
 
 // Hashbang : https://hashbang.sh


### PR DESCRIPTION
happyfuntimes generates dynamic dns subdomains per game to direct local players to the local games.