### PR TITLE
Correctly sort DNSHome before Dreamhost

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10801,13 +10801,13 @@ store.dk
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
-// DreamHost : http://www.dreamhost.com/
-// Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
-dreamhosters.com
-
 // DNShome : https://www.dnshome.de/
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de
+
+// DreamHost : http://www.dreamhost.com/
+// Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
+dreamhosters.com
 
 // Drobo : http://www.drobo.com/
 // Submitted by Ricardo Padilha <rpadilha@drobo.com>


### PR DESCRIPTION
While merging #212 I missed that the sort order was incorrect; fix it.