### PR TITLE
Add greatnet.de, greatnet.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11289,6 +11289,11 @@ pagespeedmobilizer.com
 withgoogle.com
 withyoutube.com
 
+// Greatnet : https://greatnet.de
+// Submitted by Johannes Matheis <info@greatnet.de>
+greatnet.de
+greatnet.com
+
 // Hashbang : https://hashbang.sh
 hashbang.sh
 


### PR DESCRIPTION
Customers get a subdomain to use their webspace and servers without the need to register an own domain.