### PR TITLE
Please add myqnapcloud domain to publicsuffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11408,6 +11408,12 @@ chirurgiens-dentistes-en-france.fr
 // Submitted by Daniel Dent (https://www.danieldent.com/)
 qa2.com
 
+// QNAP System Inc : https://www.qnap.com
+// Submitted by Nick Chang <nickchang@qnap.com>
+dev-myqnapcloud.com
+alpha-myqnapcloud.com
+myqnapcloud.com
+
 // Rackmaze LLC : https://www.rackmaze.com
 // Submitted by Kirill Pertsev <kika@rackmaze.com>
 rackmaze.com


### PR DESCRIPTION
QNAP is providing dyndns services to their customers on the .myqnapcloud.com domain. I work in QNAP. Please add myqnapcloud domain to public suffix list 