### PR TITLE
Neocities: add neocities.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11330,6 +11330,10 @@ cloudapp.net
 // Submitted by glob <glob@mozilla.com>
 bmoattachments.org
 
+// Neocities : https://neocities.org/
+// Submitted by Kyle Drake <kyle@neocities.org>
+neocities.org
+
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz>
 4u.com


### PR DESCRIPTION
This adds neocities.org to the public suffix list.

Neocities allows anyone to run arbitrary code on our subdomains, and we enforce a strict cookie separation between neocities.org and *.neocities.org.