### PR TITLE
Add *.magentosite.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11317,6 +11317,10 @@ iki.fi
 biz.at
 info.at
 
+// Magento Commerce
+// Submitted by Damien Tournoud <dtournoud@magento.cloud>
+*.magentosite.cloud
+
 // Michau Enterprises Limited : http://www.co.pl/
 co.pl
 


### PR DESCRIPTION
Please add `*.magentosite.cloud` to the list.

This entry covers all the regional deployments of the Magento Cloud product (`us.magentosite.cloud`, `eu.magentosite.cloud`, `ap.magentosite.cloud`, etc.). The customer subdomains running arbitrary code are subdomains of these regional deployment domains, as in `myapp.us.magentosite.cloud`.