### PR TITLE
Add certmgr.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10757,6 +10757,7 @@ co.com
 c.la
 
 // certmgr.org : https://certmgr.org
+// Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org
 
 // Citrix : https://citrix.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10756,6 +10756,9 @@ co.com
 // c.la : http://www.c.la/
 c.la
 
+// certmgr.org : https://certmgr.org
+certmgr.org
+
 // Citrix : https://citrix.com
 // Submitted by Alex Stoddard <alex.stoddard@citrix.com>
 xenapponazure.com


### PR DESCRIPTION
certmgr.org is supposed to become an aiding domain for server management. Any server operator is supposed to be able to obtain a subdomain *.certmgr.org for his server pointing back to the server under the operator's control. In order to avoid the misuse of content on foreign subdomains, strict cookie separation is required.