### PR TITLE
Added 0emm.com to Google's list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11217,6 +11217,7 @@ goip.de
 
 // Google, Inc.
 // Submitted by Eduardo Vela <evn@google.com>
+0emm.com
 *.0emm.com
 appspot.com
 blogspot.ae


### PR DESCRIPTION
Hi Eduardo (@sirdarckcat),
This request is to add the root 0emm.com as well.
If *.0emm.com added last time already implied its root domain, please just ignore.

Thank you very much!
Scott Wu