### PR TITLE
callidomus: please add mycd.eu

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10701,6 +10701,10 @@ myfritz.net
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com
 
+// callidomus: https://www.callidomus.com/
+// Submitted by Marcus Popp <admin@callidomus.com>
+mycd.eu
+
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
 ae.org


### PR DESCRIPTION
callidomus is providing it's customers access to their homes with dyndns and https (with let's encrypt cert).
They are using XXXX.mycd.eu to access their homes.