### PR TITLE
Add Meteor Galaxy managed domains (meteorapp.com)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11387,6 +11387,11 @@ info.at
 // Submitted by Damien Tournoud <dtournoud@magento.cloud>
 *.magentosite.cloud
 
+// Meteor Development Group : https://www.meteor.com/hosting
+// Submitted by Pierre Carrier <pierre@meteor.com>
+meteorapp.com
+eu.meteorapp.com
+
 // Michau Enterprises Limited : http://www.co.pl/
 co.pl
 


### PR DESCRIPTION
Customers can freely add subdomains of those domains to their apps on our hosting platform, Galaxy.