### PR TITLE
Remove unsa.ba and unbi.ba

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -274,8 +274,6 @@ net.ba
 edu.ba
 gov.ba
 mil.ba
-unsa.ba
-unbi.ba
 co.ba
 com.ba
 rs.ba


### PR DESCRIPTION
These are not publicly available suffixes, but regular domains owned by University of Sarajevo and University of Bihać respectively. They were listed 10 years ago on www.nic.ba by mistake and this propagated to wikipedia and now Mozilla... Feel free to contact support@utic.ba for confirmation (utic.ba is official .ba ccTLD administrator)