### PR TITLE
Update .JP as requested by info@jprs.jp

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -2545,7 +2545,6 @@ hitoyoshi.kumamoto.jp
 kamiamakusa.kumamoto.jp
 kashima.kumamoto.jp
 kikuchi.kumamoto.jp
-kosa.kumamoto.jp
 kumamoto.kumamoto.jp
 mashiki.kumamoto.jp
 mifune.kumamoto.jp


### PR DESCRIPTION
Remove kosa.kumamoto.jp as requested on June 17th.

> While we registered a domain name,
> please update the "jp" section of PUBLIC SUFFIX LIST.
> (remove "kosa.kumamoto.jp")
> 
> The following three files relevant to update the list are attached to
> this e-mail.
> 
>    - public_suffix_list.dat.original.txt   (original list, 2016/6/17)
>    - public_suffix_list.dat.new.txt        (updated list)
>    - public_suffix_list.dat.diff.txt       (diff file)
