### PR TITLE
Add beep.pl into PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10627,6 +10627,10 @@ zuerich
 // ===BEGIN PRIVATE DOMAINS===
 // (Note: these are in alphabetical order by company name)
 
+// Agnat sp. z o.o. : https://domena.pl
+// Submitted by Przemyslaw Plewa <it-admin@domena.pl>
+beep.pl
+
 // Alces Software Ltd : http://alces-software.com
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate


### PR DESCRIPTION
Agnat sp o.o. is a hosting provider that provides its customers
websites within beep.pl domain, DNS, and SSL Certificates with
LetsEncrypt