### PR TITLE
add static.land

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11594,6 +11594,12 @@ bounty-full.com
 alpha.bounty-full.com
 beta.bounty-full.com
 
+// staticland : https://static.land
+// Submitted by Seth Vincent <sethvincent@gmail.com>
+static.land
+dev.static.land
+sites.static.land
+
 // SpaceKit : https://www.spacekit.io/
 // Submitted by Reza Akhavan <spacekit.io@gmail.com>
 spacekit.io


### PR DESCRIPTION
static.land lets users create sites at *.static.land, *.dev.static.land, and *.sites.static.land.

Creating the needed TXT records now.