### PR TITLE
Move lib.de.us to the private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6526,7 +6526,7 @@ lib.ca.us
 lib.co.us
 lib.ct.us
 lib.dc.us
-lib.de.us
+// lib.de.us - Moved to Private section at request of Ed Moore <Ed.Moore@lib.de.us>
 lib.fl.us
 lib.ga.us
 lib.gu.us
@@ -11652,6 +11652,10 @@ hk.com
 hk.org
 ltd.hk
 inc.hk
+
+// .US
+// Submitted by Ed Moore <Ed.Moore@lib.de.us>
+lib.de.us
 
 // Viprinet Europe GmbH : http://www.viprinet.com
 // Submitted by Simon Kissel <hostmaster@viprinet.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6526,7 +6526,7 @@ lib.ca.us
 lib.co.us
 lib.ct.us
 lib.dc.us
-// lib.de.us - Moved to Private section at request of Ed Moore <Ed.Moore@lib.de.us>
+// lib.de.us  Issue #243 - Moved to Private section at request of Ed Moore <Ed.Moore@lib.de.us>
 lib.fl.us
 lib.ga.us
 lib.gu.us


### PR DESCRIPTION
> This email is to authenticate the request to remove lib.de.us
> from the PUBLIC section of the public suffix list and to add
> it to the PRIVATE section only.
> We need this done because Chrome does not respect wildcards
> for names in the ICANN (public) section, but they do in the
> PRIVATE section.

Closes https://github.com/publicsuffix/list/issues/243

/cc @sleevi @gerv can you please cross-review?
/cc @ehmoore