### PR TITLE
AWS ap-south-1 EC2 and S3 domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10661,52 +10661,66 @@ beep.pl
 cloudfront.net
 
 // Amazon Elastic Compute Cloud: https://aws.amazon.com/ec2/
-// Submitted by Philip Allchin <pallchin@amazon.com>
-compute.amazonaws.com
-ap-northeast-1.compute.amazonaws.com
-ap-northeast-2.compute.amazonaws.com
-ap-southeast-1.compute.amazonaws.com
-ap-southeast-2.compute.amazonaws.com
-eu-central-1.compute.amazonaws.com
-eu-west-1.compute.amazonaws.com
-sa-east-1.compute.amazonaws.com
-us-gov-west-1.compute.amazonaws.com
-us-west-1.compute.amazonaws.com
-us-west-2.compute.amazonaws.com
-compute-1.amazonaws.com
-z-1.compute-1.amazonaws.com
-z-2.compute-1.amazonaws.com
+// Submitted by Luke Wells <lawells@amazon.com>
+*.compute.amazonaws.com
+*.compute-1.amazonaws.com
+*.compute.amazonaws.com.cn
 us-east-1.amazonaws.com
-compute.amazonaws.com.cn
-cn-north-1.compute.amazonaws.com.cn
 
 // Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
-// Submitted by Adam Stein <astein@amazon.com>
-elasticbeanstalk.com
+// Submitted by Luke Wells <lawells@amazon.com>
+elasticbeanstalk.cn-north-1.amazonaws.com.cn
+*.elasticbeanstalk.com
 
 // Amazon Elastic Load Balancing : https://aws.amazon.com/elasticloadbalancing/
-// Submitted by Scott Vidmar <svidmar@amazon.com>
-elb.amazonaws.com
+// Submitted by Luke Wells <lawells@amazon.com>
+*.elb.amazonaws.com
+*.elb.amazonaws.com.cn
 
 // Amazon S3 : https://aws.amazon.com/s3/
 // Submitted by Luke Wells <lawells@amazon.com>
 s3.amazonaws.com
 s3-ap-northeast-1.amazonaws.com
 s3-ap-northeast-2.amazonaws.com
+s3-ap-south-1.amazonaws.com
 s3-ap-southeast-1.amazonaws.com
 s3-ap-southeast-2.amazonaws.com
 s3-eu-central-1.amazonaws.com
 s3-eu-west-1.amazonaws.com
 s3-external-1.amazonaws.com
-s3-external-2.amazonaws.com
 s3-fips-us-gov-west-1.amazonaws.com
 s3-sa-east-1.amazonaws.com
 s3-us-gov-west-1.amazonaws.com
+s3-us-east-2.amazonaws.com
 s3-us-west-1.amazonaws.com
 s3-us-west-2.amazonaws.com
 s3.ap-northeast-2.amazonaws.com
+s3.ap-south-1.amazonaws.com
 s3.cn-north-1.amazonaws.com.cn
 s3.eu-central-1.amazonaws.com
+s3.us-east-2.amazonaws.com
+s3.dualstack.ap-northeast-1.amazonaws.com
+s3.dualstack.ap-northeast-2.amazonaws.com
+s3.dualstack.ap-south-1.amazonaws.com
+s3.dualstack.ap-southeast-1.amazonaws.com
+s3.dualstack.ap-southeast-2.amazonaws.com
+s3.dualstack.eu-central-1.amazonaws.com
+s3.dualstack.eu-west-1.amazonaws.com
+s3.dualstack.sa-east-1.amazonaws.com
+s3.dualstack.us-east-1.amazonaws.com
+s3.dualstack.us-east-2.amazonaws.com
+s3-website-us-east-1.amazonaws.com
+s3-website-us-west-1.amazonaws.com
+s3-website-us-west-2.amazonaws.com
+s3-website-ap-northeast-1.amazonaws.com
+s3-website-ap-southeast-1.amazonaws.com
+s3-website-ap-southeast-2.amazonaws.com
+s3-website-eu-west-1.amazonaws.com
+s3-website-sa-east-1.amazonaws.com
+s3-website.ap-northeast-2.amazonaws.com
+s3-website.ap-south-1.amazonaws.com
+s3-website.eu-central-1.amazonaws.com
+s3-website.us-east-2.amazonaws.com
 
 // Aptible : https://www.aptible.com/
 // Submitted by Thomas Orozco <thomas@aptible.com>


### PR DESCRIPTION
*Adding ap-south-1.compute.amazonaws.com EC2 domain
*Adding s3-ap-south-1.amazonaws.com and s3.ap-south-1.amazonaws.com S3 domains
