### PR TITLE
Cleanup bad entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10653,12 +10653,12 @@ sa-east-1.compute.amazonaws.com
 us-gov-west-1.compute.amazonaws.com
 us-west-1.compute.amazonaws.com
 us-west-2.compute.amazonaws.com
-us-east-1.amazonaws.com
 compute-1.amazonaws.com
 z-1.compute-1.amazonaws.com
 z-2.compute-1.amazonaws.com
+us-east-1.amazonaws.com
 compute.amazonaws.com.cn
-cn-north-1.compute.amazonaws.com.cn 
+cn-north-1.compute.amazonaws.com.cn
 
 // Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
 // Submitted by Adam Stein <astein@amazon.com>
@@ -10694,10 +10694,10 @@ on-aptible.com
 
 // Association potager.org : https://potager.org/
 // Submitted by Lunar <jardiniers@potager.org>
-potager.org
-poivron.org
-sweetpepper.org
 pimienta.org
+poivron.org
+potager.org
+sweetpepper.org
 
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>


### PR DESCRIPTION
* Fix the sorting for potager.org
* Remove trailing whitespace from cn-north-1.compute.amazonaws.com.cn
* Fix the sorting for Amazon AWS