### PR TITLE
Add celtra-test.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11675,4 +11675,8 @@ yolasite.com
 za.net
 za.org
 
+// Celtra Inc.: http://www.celtra.com/
+// Submitted by Jaka Jancar <jaka@celtra.com>
+celtra-test.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Our developers and QA use `<developer>.celtra-test.com` for personal testing stacks. Cookies should not be shared and, most importantly, Lets Encrypt should tread them as separate registered domains.
