### PR TITLE
add backplaneapp.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10708,6 +10708,10 @@ sweetpepper.org
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net
 
+// backplane : https://www.backplane.io
+// Submitted by Anthony Voutas <anthony@backplane.io>
+backplaneapp.io
+
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com


### PR DESCRIPTION
At backplane we issue subdomains of backplaneapp.io to customers in order to bootstrap configuration and testing. These customers are mutually-untrusting. We do not intend to ever serve anything on the backplaneapp.io apex domain directly.