### PR TITLE
Add gitlab.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11275,6 +11275,10 @@ githubcloud.com
 gist.githubcloud.com
 *.githubcloudusercontent.com
 
+// GitLab, Inc.
+// Submitted by Alex Hanselka <alex@gitlab.com>
+gitlab.io
+
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
 ro.com


### PR DESCRIPTION
GitLab.io is used for GitLab Pages and thus allows arbitrary users to have subdomains. You can see the official request to add GitLab.io on [our issue tracker](https://gitlab.com/gitlab-com/infrastructure/issues/230).