### PR TITLE
Add stackspace.space

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11641,6 +11641,10 @@ beta.bounty-full.com
 // Submitted by Reza Akhavan <spacekit.io@gmail.com>
 spacekit.io
 
+// Stackspace : https://www.stackspace.io/
+// Submitted by Lina He <info@stackspace.io>
+stackspace.space
+
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>
 diskstation.me


### PR DESCRIPTION
Stackspace allows customers to launch and use big data tools hosted on subdomains of stackspace.space.