### PR TITLE
adds protonet.io to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10728,10 +10728,6 @@ boxfuse.io
 // Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
 browsersafetymark.io
 
-// Protonet
-// Submitted by Martin Meier <admin@protonet.com>
-protonet.io
-
 // callidomus: https://www.callidomus.com/
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu
@@ -11596,6 +11592,10 @@ xen.prgmr.com
 // priv.at : http://www.nic.priv.at/
 // Submitted by registry <lendl@nic.at>
 priv.at
+
+// Protonet GmbH : http://protonet.io
+// Submitted by Martin Meier <admin@protonet.io>
+protonet.io
 
 // Publication Presse Communication SARL : https://ppcom.fr
 // Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10728,6 +10728,10 @@ boxfuse.io
 // Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
 browsersafetymark.io
 
+// Protonet
+// Submitted by Martin Meier <admin@protonet.com>
+protonet.io
+
 // callidomus: https://www.callidomus.com/
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu


### PR DESCRIPTION
We, Protonet Inc (https://protonet.com), provide a dynamic DNS service for our customers (under the domain protonet.io)
Allowing our users to register SSL Certificates using Let's Encrypt is a huge benefit for the security of our users.
