### PR TITLE
Add ro.im and shop.ro

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11294,6 +11294,8 @@ gitlab.io
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
 ro.com
+ro.im
+shop.ro
 
 // GoIP DNS Services : http://www.goip.de
 // Submitted by Christian Poulter <milchstrasse@goip.de>


### PR DESCRIPTION
Add ro.im and shop.ro private domains. We allow registration of second level domains using ro.im and shop.ro.