### PR TITLE
Add wmflabs.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11708,6 +11708,10 @@ inc.hk
 // Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management
 
+// Wikimedia Labs: https://wikitech.wikimedia.org
+// Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
+wmflabs.org
+
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com


### PR DESCRIPTION
Part of [Wikimedia Labs](https://wikitech.wikimedia.org/wiki/Portal:Wikimedia_Labs), allows users to
run arbitrary code on both [*.wmflabs.org](https://wikitech.wikimedia.org/wiki/Help:Proxy)
as well as [*.*.wmflabs.org](https://wikitech.wikimedia.org/wiki/Help:Addresses).