### PR TITLE
Add transurl.nl

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11693,6 +11693,10 @@ sopot.pl
 bloxcms.com
 townnews-staging.com
 
+// TransIP : htts://www.transip.nl
+// Submitted by Rory Breuk <rbreuk@transip.nl>
+transurl.nl
+
 // TuxFamily : http://tuxfamily.org
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
 tuxfamily.org

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11698,9 +11698,6 @@ townnews-staging.com
 *.transurl.be
 *.transurl.eu
 *.transurl.nl
-co.uk.transurl.be
-co.uk.transurl.eu
-co.uk.transurl.nl
 
 // TuxFamily : http://tuxfamily.org
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11695,9 +11695,12 @@ townnews-staging.com
 
 // TransIP : htts://www.transip.nl
 // Submitted by Rory Breuk <rbreuk@transip.nl>
-transurl.be
-transurl.eu
-transurl.nl
+*.transurl.be
+*.transurl.eu
+*.transurl.nl
+co.uk.transurl.be
+co.uk.transurl.eu
+co.uk.transurl.nl
 
 // TuxFamily : http://tuxfamily.org
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11695,6 +11695,8 @@ townnews-staging.com
 
 // TransIP : htts://www.transip.nl
 // Submitted by Rory Breuk <rbreuk@transip.nl>
+transurl.be
+transurl.eu
 transurl.nl
 
 // TuxFamily : http://tuxfamily.org


### PR DESCRIPTION
TransIP provides different internet services, among them domain name registration and webhosting. When a customer registers a domain name and webhosting packet, we also provide an additional domain name containing the transurl{.nl, .be, .eu} suffix _(so if a customer uses the domain example.nl, we would provide example.nl.transurl.nl)_. This extra domain name will also point to the customer's website.

Many different websites are hosted on subdomains under the transurl{.nl, .be, .eu} suffix and customers have almost full control over what they will be hosting. The main reason that we want our suffixes to be added is to prevent customers to make super cookies. 