### PR TITLE
Adding co.krd and edu.krd per http://nic.krd/data/krd/Registration%20Policy.pdf

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -8637,6 +8637,8 @@ kpn
 
 // krd : 2013-12-05 KRG Department of Information Technology
 krd
+edu.krd
+co.krd
 
 // kred : 2013-12-19 KredTLD Pty Ltd
 kred


### PR DESCRIPTION
Adding edu.krd (educational institutions and service providers) and co.krd (commercial institutions). nic.krd documents these as public domains in http://nic.krd/data/krd/Registration%20Policy.pdf