### PR TITLE
Add domain chaostreff.at for Chaostreff Salzburg

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10792,6 +10792,10 @@ c.la
 // Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org
 
+// Chaostreff Salzburg
+// Submitted by Alexander Huemer <alexander.huemer@xx.vu>
+chaostreff.at
+
 // Citrix : https://citrix.com
 // Submitted by Alex Stoddard <alex.stoddard@citrix.com>
 xenapponazure.com


### PR DESCRIPTION
Closes #220 