### PR TITLE
Add alwaysdata.net.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10644,6 +10644,10 @@ beep.pl
 *.compute.estate
 *.alces.network
 
+// alwaysdata : https://www.alwaysdata.com
+// Submitted by Cyril <admin@alwaysdata.com>
+*.alwaysdata.net
+
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com>
 cloudfront.net


### PR DESCRIPTION
[alwaysdata](https://www.alwaysdata.com) is a web hosting company. Each of our customers has a alwaysdata.net subdomain.