### PR TITLE
DynamicDNS and Portmapping Service Feste-IP.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10835,9 +10835,9 @@ co.no
 
 // COSIMO GmbH http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
+dyn.cosidns.de
 dynamisches-dns.de
 dnsupdater.de
-dyn.cosidns.de
 internet-dns.de
 l-o-g-i-n.de
 dynamic-dns.info

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11267,7 +11267,7 @@ fhapp.xyz
 // Submitted by Rene Marticke <support@feste-ip.net>
 
 dynamic-dns.info
-daynamisches-dns.de
+dynamisches-dns.de
 dnsupdater.de
 dyn.cosimo.de
 feste-ip.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11265,13 +11265,12 @@ fhapp.xyz
 
 // DynamicDNS Service by http://www.feste-ip.net
 // Submitted by Rene Marticke <support@feste-ip.net>
-
-dynamic-dns.info
 dynamisches-dns.de
 dnsupdater.de
 dyn.cosimo.de
-feste-ip.net
 l-o-g-i-n.de
+dynamic-dns.info
+feste-ip.net
 static-access.net
 
 // Firebase, Inc.

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10833,6 +10833,18 @@ co.no
 // Submitted by Damien Tournoud <damien@commerceguys.com>
 *.platform.sh
 
+// COSIMO GmbH http://www.cosimo.de
+// Submitted by Rene Marticke <rmarticke@cosimo.de>
+dynamisches-dns.de
+dnsupdater.de
+dyn.cosidns.de
+internet-dns.de
+l-o-g-i-n.de
+dynamic-dns.info
+feste-ip.net
+knx-server.net
+static-access.net
+
 // Craynic, s.r.o. : http://www.craynic.com/
 // Submitted by Ales Krajnik <ales.krajnik@craynic.com>
 realm.cz
@@ -11262,16 +11274,6 @@ global.prod.fastly.net
 // Featherhead : https://featherhead.xyz/
 // Submitted by Simon Menke <simon@featherhead.xyz>
 fhapp.xyz
-
-// DynamicDNS Service by http://www.feste-ip.net
-// Submitted by Rene Marticke <support@feste-ip.net>
-dynamisches-dns.de
-dnsupdater.de
-dyn.cosimo.de
-l-o-g-i-n.de
-dynamic-dns.info
-feste-ip.net
-static-access.net
 
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11263,6 +11263,17 @@ global.prod.fastly.net
 // Submitted by Simon Menke <simon@featherhead.xyz>
 fhapp.xyz
 
+// DynamicDNS Service by http://www.feste-ip.net
+// Submitted by Rene Marticke <support@feste-ip.net>
+
+dynamic-dns.info
+daynamisches-dns.de
+dnsupdater.de
+dyn.cosimo.de
+feste-ip.net
+l-o-g-i-n.de
+static-access.net
+
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com


### PR DESCRIPTION
Subdomains of these zones are used by our DynamicDNS and IPv4/6 Portmapping Service feste-ip.net

TXT Records for all zones are set.
