### PR TITLE
Add taifun-dns.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11707,6 +11707,10 @@ i234.me
 myds.me
 synology.me
 
+// TAIFUN Software AG : http://taifun-software.de
+// Submitted by Bjoern Henke <dev-server@taifun-software.de>
+taifun-dns.de
+
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl
 gdansk.pl


### PR DESCRIPTION
Add domain taifun-dns.de to public_suffix_list.dat.
This domain provides dynamic dns for our customers.