### PR TITLE
Add Revitalised Limited private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11648,9 +11648,9 @@ hzc.io
 
 // Revitalised Limited : http://www.revitalised.co.uk
 // Submitted by Jack Price <jack@revitalised.co.uk>
-wellbeingzone.co.uk
 wellbeingzone.eu
 ptplus.fit
+wellbeingzone.co.uk
 
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11646,6 +11646,12 @@ rhcloud.com
 // Submitted by Chris Kastorff <info@rethinkdb.com>
 hzc.io
 
+// Revitalised Limited : http://www.revitalised.co.uk
+// Submitted by Jack Price <jack@revitalised.co.uk>
+wellbeingzone.co.uk
+wellbeingzone.eu
+ptplus.fit
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io


### PR DESCRIPTION
Domains under `wellbeingzone.co.uk`, `wellbeingzone.eu` and `ptplus.fit` are issued to Revitalised Ltd. customers to serve our SaaS instances.

For example; `customer.wellbeingzone.co.uk`.

DNS verification will be added once I get the pull request ID.