### PR TITLE
Add shiftedit.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11663,7 +11663,7 @@ pp.ua
 
 // ShiftEdit : https://shiftedit.net/
 // Submitted by Adam Jimenez <adam@shiftcreate.com>
-shiftedit.net
+shiftedit.io
 
 // Shopblocks : http://www.shopblocks.com/
 // Submitted by Alex Bowers <alex@shopblocks.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11661,6 +11661,10 @@ biz.ua
 co.ua
 pp.ua
 
+// ShiftEdit : https://shiftedit.net/
+// Submitted by Adam Jimenez <adam@shiftcreate.com>
+shiftedit.net
+
 // Shopblocks : http://www.shopblocks.com/
 // Submitted by Alex Bowers <alex@shopblocks.com>
 myshopblocks.com


### PR DESCRIPTION
Subdomains under shiftedit.io are issued to shiftedit users.
e.g: customer.shiftedit.io

DNS verification added
