### PR TITLE
Add nom.nc - official second-level domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4398,6 +4398,7 @@ name
 // nc : http://www.cctld.nc/
 nc
 asso.nc
+nom.nc
 
 // ne : https://en.wikipedia.org/wiki/.ne
 ne


### PR DESCRIPTION
There is another reserved extension directly attached on nc TLD: nom.nc
See http://www.cctld.nc/ind?man=2
.nc : generic extension
.asso.nc : reserved for associations
.nom.nc : reserved for the private individuals who shall wish to to deposit their surname.
