### PR TITLE
Add myfusion.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11306,6 +11306,10 @@ fbxos.fr
 freebox-os.fr
 freeboxos.fr
 
+// Fusion Intranet : https://www.fusion-intranet.com
+// Submitted by Matthias Burtscher <matthias.burtscher@fusonic.net>
+myfusion.cloud
+
 // Futureweb OG : http://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 futuremailing.at


### PR DESCRIPTION
Our domain `myfusion.cloud` is used to provide custom sub-domains in the form of `acme.myfusion.cloud` to our SaaS customers for product "Fusion Intranet" (www.fusion-intranet.com).

The customers using the service have no affiliation to each other and should therefore be separated.