### PR TITLE
Update .MZ suffixes according to registry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4367,9 +4367,17 @@ edu.my
 mil.my
 name.my
 
-// mz : http://www.gobin.info/domainname/mz-template.doc
-*.mz
-!teledata.mz
+// mz : http://www.uem.mz/
+// Submitted by registry <antonio@uem.mz>
+mz
+ac.mz
+adv.mz
+co.mz
+edu.mz
+gov.mz
+mil.mz
+net.mz
+org.mz
 
 // na : http://www.na-nic.com.na/
 // http://www.info.na/domain/


### PR DESCRIPTION
This is the response I got from the registry:

> We have the following second level domains:
> 
>     co.mz, net.mz, org.mz, ac.mz, gov.mz, adv.mz,
>     mil.mz and edu.mz.
> 
> But we also have some domain names which are directly registered
> under .mz like uem.mz, tvcabo.mz, the domains are mostly operators
> like ISPs, but they are few because we are not registering under
> .MZ anymore.

I added all the suffixes in the patch, and I also listed mz as there are some domains registered at the second level domain.

/cc @gerv @sleevi 