### PR TITLE
Add opencraft.hosting

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11566,6 +11566,10 @@ nyc.mn
 // Submitted by Eddie Jones <eddie@onefoldmedia.com>
 nid.io
 
+// OpenCraft GmbH : http://opencraft.com/
+// Submitted by Sven Marnach <sven@opencraft.com>
+opencraft.hosting
+
 // Opera Software, A.S.A.
 // Submitted by Yngve Pettersen <yngve@opera.com>
 operaunite.com


### PR DESCRIPTION
We provide a hosting service, and subdomains of the domain are issued to mutually untrusting parties.  Customers can choose their subdomain during [registration](https://console.opencraft.com/registration/).