### PR TITLE
Added AixConcepts dyndns.de and mnspro.online domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10647,6 +10647,11 @@ zuerich
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl
 
+// AixConcept GmbH: http://www.aixconcept.de 
+// Submitted by Sebastian Fillinger <sfillinger@aixconcept.de> 2016-06-10
+dynmns.de
+mnspro.online
+
 // Alces Software Ltd : http://alces-software.com
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate
@@ -11180,12 +11185,6 @@ webhop.net
 webhop.org
 worse-than.tv
 writesthisblog.com
-
-
-// AixConcept GmbH: http://www.aixconcept.de 
-// Submitted by Sebastian Fillinger <sfillinger@aixconcept.de> 2016-05-10
-dynmns.de
-mnspro.online
 
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11181,6 +11181,12 @@ webhop.org
 worse-than.tv
 writesthisblog.com
 
+
+// AixConcept GmbH: http://www.aixconcept.de 
+// Submitted by Sebastian Fillinger <sfillinger@aixconcept.de> 2016-05-10
+dynmns.de
+mnspro.online
+
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de> 2016-01-18
 dynv6.net


### PR DESCRIPTION
Sorry, first PR 312 was at the wrong position, now it should be correct.
We still have an issue with mnspro.online that we cant set the correct TXT entry right now.
Please dig TXT mnspro.online or _spl._spl.mnspro.online to verify.
