### PR TITLE
Add now.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11759,4 +11759,8 @@ yolasite.com
 za.net
 za.org
 
+// Zeit, Inc. : https://zeit.domains/
+// Submitted by Olli Vanhoja <olli@zeit.co>
+now.sh
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
We issue subdomains of now.sh to our customers for their deployments.
