### PR TITLE
Add apps.lair.io and stolos.io to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11770,6 +11770,11 @@ static.land
 dev.static.land
 sites.static.land
 
+// SourceLair PC : https://www.sourcelair.com
+// Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
+apps.lair.io
+*.stolos.io
+
 // SpaceKit : https://www.spacekit.io/
 // Submitted by Reza Akhavan <spacekit.io@gmail.com>
 spacekit.io


### PR DESCRIPTION
## apps.lair.io

We use this domain at [SourceLair](https://www.sourcelair.com) to provide domains for our users, so that they can view their websites. Possible domains:
- https://4fv6pjnu.apps.lair.io/
- https://ufwlp5am.apps.lair.io/
## Stolos.io

We use this domain at [SourceLair](https://www.sourcelair.com) for our https://stolos.io product, where each customer has it's own subdomain and can create dynamic subdomains below it. Possible domains:
- https://sourcelair.stolos.io/
- https://akalipetis.sourcelair.stolos.io/
