### PR TITLE
added dynamic DNS provider afraid.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10721,6 +10721,16 @@ poivron.org
 potager.org
 sweetpepper.org
 
+// AFRAID : https://freedns.afraid.org/
+// Submitted by <manuel@iringweg41.com> for <dnsadmin@afraid.org>
+chickenkiller.com
+crabdance.com
+ignorelist.com
+jumpingcrab.com
+mooo.com
+strangled.com
+twilightparadox.com
+
 // ASUSTOR Inc. : http://www.asustor.com
 // Submitted by Vincent Tseng <vincenttseng@asustor.com>
 myasustor.com


### PR DESCRIPTION
I wrote this e-Mail to :dnsadmin@afraid.org

Hi,
I'd like to use letsencrypt for my homeservers but i get the error message:
There were too many requests of a given type :: Error creating new cert :: Too many certificates already issued for: mooo.com

I made a pull request for the public suffix list with the domains i know you are using. But there will be quite more I guess.
https://publicsuffix.org/

link to the pull request: 

kind regard
Manuel
