### PR TITLE
Request to add TwoDNS TLD's used by users

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11822,6 +11822,22 @@ townnews-staging.com
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
 tuxfamily.org
 
+// TwoDNS : https://www.twodns.de/
+// Submitted by TwoDNS-Support <support@two-dns.de>
+dd-dns.de
+diskstation.eu
+diskstation.org
+dray-dns.de
+draydns.de
+dyn-vpn.de
+dynvpn.de
+mein-vigor.de
+my-vigor.de
+my-wan.de
+syno-ds.de
+synology-diskstation.de
+synology-ds.de
+
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com>
 hk.com


### PR DESCRIPTION
Hi. My name is Alf from the TwoDNS Support Team. TwoDNS is a Dynamic DNS Service located in Germany. All the domains to add are used by our users. Over the last period of time we got more and more requests, to add our domains to the public suffix list. The main purpose is the usage of the Let's Encrypt Service.

The DNS records are set, just need to edit the number for the pull - the domain sort order hopefully fits, too. By the way I had problems to get the wanted result by using dig, maybe my cache - but with host -t on our ns1.register-it.net it shows up. Hope that will be fine for validation.