### PR TITLE
Added enonic.io domain to the private list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11219,6 +11219,11 @@ dynv6.net
 // Submitted by Vladimir Dudr <info@e4you.cz>
 e4.cz
 
+// Enonic : http://enonic.com/
+// Submitted by Erik Kaareng-Sunde <esu@enonic.com>
+enonic.io
+customer.enonic.io
+
 // EU.org https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>
 eu.org


### PR DESCRIPTION
Enonic is using Enonic.io as a base for out Cloud hosting service, and every customer project is delegated its own domain name under enonic.io and customer.enonic.io. To get cookie handling rignt and to circumvent lets encrypts rate limits, we need to add enonic.io and customer.enonic.io to the public suffix list.