### PR TITLE
Added dynamic domains for Yombo

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11879,13 +11879,13 @@ yolasite.com
 
 // Yombo : https://yombo.net
 // Submitted by Mitch Schwenk <mitch@yombo.net>
-homelink.one
 ybo.faith
+yombo.me
+homelink.one
 ybo.party
 ybo.review
 ybo.science
 ybo.trade
-yombo.me
 
 // ZaNiC : http://www.za.net/
 // Submitted by registry <hostmaster@nic.za.net>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11877,6 +11877,16 @@ wmflabs.org
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com
 
+// Yombo : https://yombo.net
+// Submitted by Mitch Schwenk <mitch@yombo.net>
+homelink.one
+ybo.faith
+ybo.party
+ybo.review
+ybo.science
+ybo.trade
+yombo.me
+
 // ZaNiC : http://www.za.net/
 // Submitted by registry <hostmaster@nic.za.net>
 za.net


### PR DESCRIPTION
These domains are used by users for dynamic DNS.  These domains need to be added since Yombo Gateway software will host websites. Requesting these be added to this so that cookies don't transfer between 3rd level (and lower) domains.

The domains in this pull request all use ns1.yombo.net and ns2.yombo.net as the name servers to validate that Yombo controls these domains.