### PR TITLE
Added .ni as a valid user registerable domain.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4440,6 +4440,7 @@ org.ng
 sch.ng
 
 // ni : http://www.nic.ni/
+ni
 com.ni
 gob.ni
 edu.ni


### PR DESCRIPTION
These domains have now been made available to Nicaraguan corporations.

Examples of this are:
- loto.ni
- nic.ni