### PR TITLE
add scsbox.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -665,6 +665,7 @@ web.co
 
 // com : https://en.wikipedia.org/wiki/.com
 com
+scsbox.com
 
 // coop : https://en.wikipedia.org/wiki/.coop
 coop


### PR DESCRIPTION

I would like to add this domain to public suffix list because eaech device uses SSL keys provided by Let's Encrypt. Let's Encrypt doesn't limit certificate requests for domain listed here.