### PR TITLE
Adding homeoffice.gov.uk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11379,6 +11379,10 @@ gist.githubcloud.com
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
 
+// UKHomeOffice : https://www.gov.uk/government/organisations/home-office
+// Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
+homeoffice.gov.uk
+
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
 ro.com


### PR DESCRIPTION
Adding in homeoffice.gov.uk for organisational subdomain management,
also relates to GDS principles https://www.gov.uk/service-manual/technology/managing-domain-names