### PR TITLE
Remove ro.com from Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11380,7 +11380,6 @@ gitlab.io
 
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
-ro.com
 ro.im
 shop.ro
 


### PR DESCRIPTION
We are the owner of ro.com. It's a domain name and we have build a website on it. It's not a public suffix. Please merge this pr, so that we can apply https cert for our domain.