### PR TITLE
Add user.party.eus to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10725,6 +10725,10 @@ s3-website.us-east-2.amazonaws.com
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
+// Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
+// Submitted by Hector Martin <marcan@euskalencounter.org>
+user.party.eus
+
 // Association potager.org : https://potager.org/
 // Submitted by Lunar <jardiniers@potager.org>
 pimienta.org


### PR DESCRIPTION
This subdomain is used to automatically assign hostnames to event attendees. They should not be allowed to set cookies on the parent domain or interfere with Let's Encrypt rate limiting on the parent domain or other subdomains. Users can effectively trigger arbitrary domain registration under this subdomain.

I am the systems administrator in charge of DNS under party.eus and am authorized by the domain owner to request this change. As proof of domain control, I've added a TXT record under the registered domain:

```
$ dig TXT party.eus
[...]
party.eus.              600     IN      TXT     "Please add user.party.eus to the PSL (marcan@euskalencounter.org / GitHub marcan-euskal)"
```

Please let me know if this is sufficient documentation.