### PR TITLE
Added on-web.fr (Planet-Work shared hosting)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11734,6 +11734,10 @@ gotpantheon.com
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link
 
+// Planet-Work : https://www.planet-work.com/
+// Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
+on-web.fr
+
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com


### PR DESCRIPTION
on-web.fr is the subdomain for our shared hosting customers.