### PR TITLE
Add ticketswap.pizza to PRIVATE section [DNS verification added]

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11875,6 +11875,10 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// TicketSwap : https://www.ticketswap.com
+// Submitted by Ruud Kamphuis <ruud@ticketswap.com>
+*.ticketswap.pizza
+
 // TownNews.com : http://www.townnews.com
 // Submitted by Dustin Ward <dward@townnews.com>
 bloxcms.com


### PR DESCRIPTION
This subdomain is used to automatically assign hostnames to teammembers. They should not interfere with Let's Encrypt rate limiting on the parent domain or other subdomains. 

I am the systems administrator in charge of DNS under ticketswap.pizza and am authorized by the domain owner to request this change. As proof of domain control, I've added a TXT record under the registered domain:

```
dig txt _psl.ticketswap.pizza.

;; ANSWER SECTION:
_psl.ticketswap.pizza.	257	IN	TXT	"https://github.com/publicsuffix/list/pull/350"

```
