### PR TITLE
Add inf.ua, ltd.ua and cc.ua to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11941,4 +11941,10 @@ za.org
 // Submitted by Olli Vanhoja <olli@zeit.co>
 now.sh
 
+// 1GB LLC : https://www.1gb.ua/
+// Submitted by 1GB LLC <noc@1gb.com.ua>
+inf.ua
+ltd.ua
+cc.ua
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11943,8 +11943,8 @@ now.sh
 
 // 1GB LLC : https://www.1gb.ua/
 // Submitted by 1GB LLC <noc@1gb.com.ua>
+cc.ua
 inf.ua
 ltd.ua
-cc.ua
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
We provide thousands of our (and not only our) users with domain names in .inf.ua, .ltd.ua and .cc.ua zones. So we belive these domains should be added to PRIVATE section of public suffix list. Thank you.