### PR TITLE
Add official public suffixes for .bd domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -300,7 +300,7 @@ ac.bd
 com.bd
 edu.bd
 net.bd
-org.bg
+org.bd
 // gov.bd - registration not allowed
 // mil.bd - registration not allowed
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -295,7 +295,14 @@ store.bb
 tv.bb
 
 // bd : https://en.wikipedia.org/wiki/.bd
-*.bd
+bd
+ac.bd
+com.bd
+edu.bd
+net.bd
+org.bg
+// gov.bd - registration not allowed
+// mil.bd - registration not allowed
 
 // be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -294,15 +294,18 @@ org.bb
 store.bb
 tv.bb
 
-// bd : https://en.wikipedia.org/wiki/.bd
-bd
+// bd : http://www.registry.com.bd/extensions.aspx
 ac.bd
+co.bd
 com.bd
 edu.bd
+gov.bd
+info.bd
+mil.bd
 net.bd
 org.bd
-// gov.bd - registration not allowed
-// mil.bd - registration not allowed
+tv.bd
+ws.bd
 
 // be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/.bd, the .bd domain includes following
official subdomains: .com.bd, .net.bd, ..., while they are omitted from
existing PSL.