### PR TITLE
add subdomains for .zw TLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5316,7 +5316,10 @@ org.pf
 edu.pf
 
 // pg : https://en.wikipedia.org/wiki/.pg
-*.pg
+// co.pg : http://www.zispa.org.zw/
+co.zw
+ac.zw
+org.zw
 
 // ph : http://www.domains.ph/FAQ2.asp
 // Submitted by registry <jed@email.com.ph>


### PR DESCRIPTION
.co.zw is handled by http://www.zispa.org.zw/
.ac.zw is at least exists at http://www.uz.ac.zw/
.org.zw is at least registrant itself...