### PR TITLE
Update .zw extensions

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6825,9 +6825,14 @@ net.zm
 org.zm
 sch.zm
 
-// zw : https://en.wikipedia.org/wiki/.zw
-*.zw
-
+// zw : https://www.potraz.gov.zw/
+// Confirmed by registry <bmtengwa@potraz.gov.zw> 2017-01-25
+zw
+ac.zw
+co.zw
+gov.zw
+mil.zw
+org.zw
 
 // List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2016-11-29T01:06:51Z
 


### PR DESCRIPTION
I know the guidelines say that I must cite an official website among other things. Unfortunately, I cannot find such information anywhere. I'm thinking about putting up a site educating people about Zimbabwe's DNS system but I doubt such a site would be deemed official for the purposes of this list.

I have been putting off submitting this pull request for over a week now since I do not have the correct references to cite but this has been nagging me. See, domains are kind of my thing and Zimbabwe is my beloved country :) I would love to have an accurate representation of our domain extensions in this list.

I work for Web Enchanter P/L, a company which runs [Name.co.zw](https://www.name.co.zw), one of the biggest domain registrars in Zimbabwe. I also maintain a [Rust library](https://github.com/rushmorem/publicsuffix) for this list.

Zimbabwe has 5 domain extensions, `.co.zw`, `.org.zw`, `.ac.zw`, `.gov.zw` and `.mil.zw`. At first, `.zw` was briefly available for registration before it was subdivided into those 5 extensions and then closed. In that time only one domain was registered, that is _mango.zw_. It is the only domain name in Zimbabwe which has `.zw` as its suffix. They have a webmail URL at [webmail.mango.zw](https://webmail.mango.zw). They used to have a website on mango.zw as well but they have since pulled it down. The current rules do not recognise this site.

The `.zw` namespace is delegated to [Potraz](http://www.potraz.gov.zw). However, Potraz assigned the management of the various extensions to various organisations. For example, `.co.zw` is managed by the Zimbabwe Internet Service Providers Association ([ZISPA](http://zispa.org.zw)), `.org.zw` by [Telone](http://www.telone.co.zw/) and `.ac.zw` by the University of Zimbabwe ([UZ](http://www.uz.ac.zw)).