### PR TITLE
Added *.*.howcode.org, cz.ie, zz.ie

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11379,6 +11379,12 @@ hepforge.org
 herokuapp.com
 herokussl.com
 
+// howCode : https://howcode.org
+// Submitted by Francis McNamee <francis@howcode.org>
+*.howcode.org
+cz.ie
+zz.ie
+
 // iki.fi
 // Submitted by Hannu Aronsson <haa@iki.fi>
 iki.fi

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11381,7 +11381,7 @@ herokussl.com
 
 // howCode : https://howcode.org
 // Submitted by Francis McNamee <francis@howcode.org>
-*.howcode.org
+auth.howcode.org
 cz.ie
 zz.ie
 


### PR DESCRIPTION
Domains and their uses:
***.howcode.org**
Used for all customer interactions with howcode.org, for example:
_customer-name.auth.howcode.org
customer-site.sandbox.howcode.org
unique-domain.verify.howcode.org_ etc ...

A TXT record exists for *.*.howcode.org that points to this Github Repository for verification.

**cz.ie**
Hosts customer domains in the form: customer-domain.cz.ie

A TXT record exists for *.cz.ie that points to this Github Repository for verification.

**zz.ie**
Hosts customer domains in the form: customer-domain.zz.ie

A TXT record exists for *.zz.ie that points to this Github Repository for verification.