### PR TITLE
Added com.ru, net.ru, org.ru, pp.ru, ru.net, exnet.su as Top Level Domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5690,6 +5690,14 @@ int.ru
 mil.ru
 test.ru
 
+// com.ru : https://www.nic.ru/dns/domain/en/com_ru.html
+com.ru
+net.ru
+org.ru
+pp.ru
+ru.net
+exnet.su
+
 // rw : http://www.nic.rw/cgi-bin/policy.pl
 rw
 gov.rw


### PR DESCRIPTION
Please add those domain to public suffix list. It is a common domain that is sold by registrars for users similar to domains "com.ua", "com.au", "com.pl" and so on. See https://www.nic.ru/dns/domain/en/com_ru.html