### PR TITLE
Update of .RU subdomains (net.ru, org.ru, pp.ru from ANO "MSK-IX")

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10696,6 +10696,11 @@ in.net
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 us.org
 
+//  ANO "MSK-IX", http://net.ru/documents.html
+net.ru
+org.ru
+pp.ru
+
 // co.com Registry, LLC : https://registry.co.com
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 co.com


### PR DESCRIPTION
NET.RU, ORG.RU, PP.RU deleted by https://github.com/publicsuffix/list/pull/359, but it reserved for subdomain registrations by ANO "MSK-IX" (http://net.ru/documents.html).