### PR TITLE
Add FAITID domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5690,6 +5690,27 @@ int.ru
 mil.ru
 test.ru
 
+// ru subTLDs : https://faitid.org/ru/node/346
+adygeya.ru
+bashkiria.ru
+bir.ru
+cbg.ru
+com.ru
+dagestan.ru
+grozny.ru
+kalmykia.ru
+kustanai.ru
+marine.ru
+mordovia.ru
+msk.ru
+mytis.ru
+nalchik.ru
+nov.ru
+pyatigorsk.ru
+spb.ru
+vladikavkaz.ru
+vladimir.ru
+
 // rw : http://www.nic.rw/cgi-bin/policy.pl
 rw
 gov.rw
@@ -5859,35 +5880,55 @@ principe.st
 saotome.st
 store.st
 
-// su : https://en.wikipedia.org/wiki/.su
+// su : https://faitid.org/ru/node/346
 su
+abkhazia.su
 adygeya.su
+aktyubinsk.su
 arkhangelsk.su
+armenia.su
+ashgabad.su
+azerbaijan.su
 balashov.su
 bashkiria.su
 bryansk.su
+bukhara.su
+chimkent.su
 dagestan.su
+east-kazakhstan.su
+exnet.su
+georgia.su
 grozny.su
 ivanovo.su
+jambyl.su
 kalmykia.su
 kaluga.su
+karacol.su
+karaganda.su
 karelia.su
 khakassia.su
 krasnodar.su
 kurgan.su
+kustanai.su
 lenug.su
+mangyshlak.su
 mordovia.su
 msk.su
 murmansk.su
 nalchik.su
+navoi.su
+north-kazakhstan.su
 nov.su
 obninsk.su
 penza.su
 pokrovsk.su
 sochi.su
 spb.su
+tashkent.su
+termez.su
 togliatti.su
 troitsk.su
+tselinograd.su
 tula.su
 tuva.su
 vladikavkaz.su

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5690,27 +5690,6 @@ int.ru
 mil.ru
 test.ru
 
-// ru subTLDs : https://faitid.org/ru/node/346
-adygeya.ru
-bashkiria.ru
-bir.ru
-cbg.ru
-com.ru
-dagestan.ru
-grozny.ru
-kalmykia.ru
-kustanai.ru
-marine.ru
-mordovia.ru
-msk.ru
-mytis.ru
-nalchik.ru
-nov.ru
-pyatigorsk.ru
-spb.ru
-vladikavkaz.ru
-vladimir.ru
-
 // rw : http://www.nic.rw/cgi-bin/policy.pl
 rw
 gov.rw
@@ -5880,60 +5859,8 @@ principe.st
 saotome.st
 store.st
 
-// su : https://faitid.org/ru/node/346
+// su : https://en.wikipedia.org/wiki/.su
 su
-abkhazia.su
-adygeya.su
-aktyubinsk.su
-arkhangelsk.su
-armenia.su
-ashgabad.su
-azerbaijan.su
-balashov.su
-bashkiria.su
-bryansk.su
-bukhara.su
-chimkent.su
-dagestan.su
-east-kazakhstan.su
-exnet.su
-georgia.su
-grozny.su
-ivanovo.su
-jambyl.su
-kalmykia.su
-kaluga.su
-karacol.su
-karaganda.su
-karelia.su
-khakassia.su
-krasnodar.su
-kurgan.su
-kustanai.su
-lenug.su
-mangyshlak.su
-mordovia.su
-msk.su
-murmansk.su
-nalchik.su
-navoi.su
-north-kazakhstan.su
-nov.su
-obninsk.su
-penza.su
-pokrovsk.su
-sochi.su
-spb.su
-tashkent.su
-termez.su
-togliatti.su
-troitsk.su
-tselinograd.su
-tula.su
-tuva.su
-vladikavkaz.su
-vladimir.su
-vologda.su
 
 // sv : http://www.svnet.org.sv/niveldos.pdf
 sv
@@ -11244,6 +11171,80 @@ us-2.evennode.com
 // Facebook, Inc.
 // Submitted by Peter Ruibal <public-suffix@fb.com>
 apps.fbsbx.com
+
+// FAITID : https://faitid.org/ru/node/346
+com.ru
+exnet.su
+ru.net
+abkhazia.su
+adygeya.ru
+adygeya.su
+aktyubinsk.su
+arkhangelsk.su
+armenia.su
+ashgabad.su
+azerbaijan.su
+balashov.su
+bashkiria.ru
+bashkiria.su
+bir.ru
+bryansk.su
+bukhara.su
+cbg.ru
+chimkent.su
+dagestan.ru
+dagestan.su
+east-kazakhstan.su
+georgia.su
+grozny.ru
+grozny.su
+ivanovo.su
+kalmykia.ru
+jambyl.su
+kalmykia.su
+kaluga.su
+karacol.su
+karaganda.su
+karelia.su
+khakassia.su
+krasnodar.su
+kurgan.su
+kustanai.ru
+kustanai.su
+lenug.su
+mangyshlak.su
+marine.ru
+mordovia.ru
+mordovia.su
+msk.ru
+msk.su
+murmansk.su
+mytis.ru
+nalchik.ru
+nalchik.su
+navoi.su
+north-kazakhstan.su
+nov.ru
+nov.su
+obninsk.su
+penza.su
+pokrovsk.su
+pyatigorsk.ru
+sochi.su
+spb.ru
+spb.su
+tashkent.su
+termez.su
+togliatti.su
+troitsk.su
+tselinograd.su
+tula.su
+tuva.su
+vladikavkaz.ru
+vladikavkaz.su
+vladimir.ru
+vladimir.su
+vologda.su
 
 // Fastly Inc. http://www.fastly.com/
 // Submitted by Vladimir Vuksan <vladimir@fastly.com>


### PR DESCRIPTION
List of reserved .RU and .SU subdomains that are officially managed by faitid.org (Foundation for Assistance for Internet Technologies and Infrastructure Development).
Valid as of 10.01.2017.

This pull request makes obsolete this publicsuffix/list/pull/334 and probably this publicsuffix/list/pull/379