### PR TITLE
Add onion

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5280,6 +5280,9 @@ net.om
 org.om
 pro.om
 
+// onion : https://tools.ietf.org/html/rfc7686
+onion
+
 // org : https://en.wikipedia.org/wiki/.org
 org
 


### PR DESCRIPTION
While "onion" does not appear within the root zone database, per RFC 7686, it is set aside as a special-use domain name, and explicitly called out as suitable for inclusion by IANA within the root zone database. Unlike other special-use domain names at this time, onion names that comply with RFC 7686 meet the definition of ICP-3 for both community process and a globally unique namespace (through being bound to keys in a process that ensures two clients end up with the same resolution).

Closes #374