### PR TITLE
add localhost.daplie.me for client-side applications

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10792,6 +10792,7 @@ cyon.site
 // Daplie, Inc : https://daplie.com
 // Submitted by AJ ONeal <aj@daplie.com>
 daplie.me
+localhost.daplie.me
 
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>


### PR DESCRIPTION
*.daplie.me is used by users who are registering publicly accessible domains. *.localhost.daplie.me is used for corresponding client-side applications running locally that in some cases directly mirror the *.daplie.me domains. We do not want the localhost application cookies, local storage, etc to be shared among apps as they are by different authors and should not necessarily have access to the same data.

We are aware that similar results could be achieved by using localhost.*.daplie.me, however, there are also applications in which localhost.foo-user.daplie.me should be secured from foo-user.daplie.me, so we're covering both use cases.