### PR TITLE
Add ipna.me to the private section.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11423,6 +11423,10 @@ se.leg.br
 sp.leg.br
 to.leg.br
 
+// IPName : https://ipna.me/
+// Submitted by Ben Schwartz <bemasc@ipna.me>
+ipna.me
+
 // Joyent : https://www.joyent.com/
 // Submitted by Brian Bennett <brian.bennett@joyent.com>
 *.triton.zone


### PR DESCRIPTION
[ipna.me](https://ipna.me) is an experimental service whose main purpose is to maximize use of TLS on the web.  If you are deploying a server with a static IP address, ipna.me makes it easy for you to acquire a certificate from a vendor like Let's Encrypt.  (I have spoken with Let's Encrypt, and they've confirmed that ipna.me is  an acceptable use of their service.)

Here's an example (empty) test server: https://104-131-62-56.ipna.me/

Adding ipna.me to the public suffix list will help ensure that users of ipna.me are correctly isolated from each other.