### PR TITLE
Add xs4all.space to PSL (for XS4ALL Internet bv's access customers)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11871,6 +11871,10 @@ remotewd.com
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
 
+// XS4ALL Internet bv: https://www.xs4all.nl/
+// Submitted by Daniel Mostertman <unixbeheer+publicsuffix@xs4all.net>
+xs4all.space
+
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com


### PR DESCRIPTION
Hello!

Currently, our access (DSL/Fiber) customers can choose their subdomain under xs4all.nl to use for their own services.  We wish to move them to xs4all.space; the subdomains will be under control of our customers.

By listing them here, they will have all the benefits listed on https://publicsuffix.org/learn/.

As for authentication purposes, as the Guidelines describe, I added a TXT-record with the URL of the Pull-request to the zone:

```
_psl.xs4all.space.      86400   IN      TXT     "https://github.com/publicsuffix/list/pull/397"
```

Kind regards,

Daniël Mostertman,
System Engineer at XS4ALL Internet bv