### PR TITLE
add private domain in public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11175,6 +11175,14 @@ eu-2.evennode.com
 us-1.evennode.com
 us-2.evennode.com
 
+// eDirect Corp. : https://hosting.url.com.tw/
+// Submitted by C.S. chang <cschang@corp.url.com.tw>
+twmail.cc
+twmail.net
+twmail.org
+mymailer.com.tw
+url.tw
+
 // Facebook, Inc.
 // Submitted by Peter Ruibal <public-suffix@fb.com>
 apps.fbsbx.com
@@ -11900,11 +11908,4 @@ cc.ua
 inf.ua
 ltd.ua
 
-// eDirect Corp. : https://hosting.url.com.tw/
-// Submitted by C.S. chang <cschang@corp.url.com.tw>
-twmail.cc
-twmail.net
-twmail.org
-mymailer.com.tw
-url.tw
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11902,10 +11902,10 @@ ltd.ua
 
 // eDirect Corp. : https://hosting.url.com.tw/
 // Submitted by C.S. chang <cschang@corp.url.com.tw>
-url.tw
-mymailer.com.tw
 twmail.cc
 twmail.net
 twmail.org
+mymailer.com.tw
+url.tw
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11900,4 +11900,12 @@ cc.ua
 inf.ua
 ltd.ua
 
+// Company : https://hosting.url.com.tw/
+// Submitted by C.S. chang <cschang@corp.url.com.tw>
+url.tw
+mymailer.com.tw
+twmail.cc
+twmail.net
+twmail.org
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11900,7 +11900,7 @@ cc.ua
 inf.ua
 ltd.ua
 
-// Company : https://hosting.url.com.tw/
+// eDirect Corp. : https://hosting.url.com.tw/
 // Submitted by C.S. chang <cschang@corp.url.com.tw>
 url.tw
 mymailer.com.tw

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11907,5 +11907,4 @@ twmail.net
 twmail.org
 mymailer.com.tw
 url.tw
-
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
we will use letsencrypt to give us free domain users

submitted by whois contact email
we have added TXT records

[root@r310 kencorp]#
[root@r310 kencorp]# dig txt _psl.url.tw +short
"https://github.com/publicsuffix/list/pull/398"
[root@r310 kencorp]# dig txt _psl.mymailer.com.tw +short
"https://github.com/publicsuffix/list/pull/398"
[root@r310 kencorp]# dig txt _psl.twmail.cc +short
"https://github.com/publicsuffix/list/pull/398"
[root@r310 kencorp]# dig txt _psl.twmail.net +short
"https://github.com/publicsuffix/list/pull/398"
[root@r310 kencorp]# dig txt _psl.twmail.org +short
"https://github.com/publicsuffix/list/pull/398"

and this passed Travis-CI check  
we have set the status checks. But for the old pull request no way to show

https://travis-ci.org/publicsuffix/list/builds/201746015

Is it possible to guide us? Is there a link that is why we did not notice and lead us to fail
