### PR TITLE
Add cya.gg to the private section.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11623,6 +11623,10 @@ zapto.org
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn
 
+// Octopodal Solutions, LLC. : https://ulterius.io//
+// Submitted by Andrew Sampson <andrew@ulterius.io>
+cya.gg
+
 // One Fold Media : http://www.onefoldmedia.com/
 // Submitted by Eddie Jones <eddie@onefoldmedia.com>
 nid.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11623,7 +11623,7 @@ zapto.org
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn
 
-// Octopodal Solutions, LLC. : https://ulterius.io//
+// Octopodal Solutions, LLC. : https://ulterius.io/
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
 


### PR DESCRIPTION
cya.gg is the routing domain that provides users of the FOSS project [Ulterius ](https://ulterius.io) with sub-domains that point to their self-hosted instances. Their sub-domain is generated when an account is registered, the software handles keeping their IP synced to their domain. 

A example domain for instance is: 2aafcc59.cya.gg, which would point to the public address of their server. 

The addition of cya.gg to the public suffix list will help ensure new and current users of Ulterius are able to keep their domains isolated from one another.