### PR TITLE
Add vapor.cloud to list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11690,7 +11690,7 @@ dev-myqnapcloud.com
 alpha-myqnapcloud.com
 myqnapcloud.com
 
-// Qutheory : http://qutheory.io
+// Qutheory LLC : http://qutheory.io
 // Submitted by Jonas Schwartz <jonas@qutheory.io>
 vapor.cloud
 vaporcloud.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11690,6 +11690,11 @@ dev-myqnapcloud.com
 alpha-myqnapcloud.com
 myqnapcloud.com
 
+// Qutheory : http://qutheory.io
+// Submitted by Jonas Schwartz <jonas@qutheory.io>
+vapor.cloud
+vaporcloud.io
+
 // Rackmaze LLC : https://www.rackmaze.com
 // Submitted by Kirill Pertsev <kika@rackmaze.com>
 rackmaze.com


### PR DESCRIPTION
Adding vapor.cloud and vaporcloud.io to the list.

Clients are going to create subdomains, and we are providing Let's Encrypt certificates. I can't explain much here because of NDA, for further details, contact me directly.

Example domains:

subdomain1.vapor.cloud
subdomain2.vapor.cloud
sub1.subdomains1.vapor.cloud
sub2.subdomains2.vapor.cloud

The same goes for vaporcloud.io