### PR TITLE
Adding c66.me customer domain for Cloud66

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11421,6 +11421,10 @@ hepforge.org
 herokuapp.com
 herokussl.com
 
+// Cloud66 : https://www.cloud66.com/
+// Submitted by Khash Sajadi <khash@cloud66.com>
+c66.me
+
 // iki.fi
 // Submitted by Hannu Aronsson <haa@iki.fi>
 iki.fi

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10678,6 +10678,10 @@ xenapponazure.com
 // Submitted by Leon Rowland <leon@clearvox.nl>
 virtueeldomein.nl
 
+// Cloud66 : https://www.cloud66.com/
+// Submitted by Khash Sajadi <khash@cloud66.com>
+c66.me
+
 // cloudControl : https://www.cloudcontrol.com/
 // Submitted by Tobias Wilken <tw@cloudcontrol.com>
 cloudcontrolled.com
@@ -11420,10 +11424,6 @@ hepforge.org
 // Submitted by Tom Maher <tmaher@heroku.com>
 herokuapp.com
 herokussl.com
-
-// Cloud66 : https://www.cloud66.com/
-// Submitted by Khash Sajadi <khash@cloud66.com>
-c66.me
 
 // iki.fi
 // Submitted by Hannu Aronsson <haa@iki.fi>


### PR DESCRIPTION
c66.me is the domain used by Cloud 66 (www.cloud66.com) customers to power their websites.