### PR TITLE
we use *.nodeart.io with lots of dynamic subdomains, most of them rep…

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11607,6 +11607,10 @@ sytes.net
 webhop.me
 zapto.org
 
+// NodeArt : https://nodeart.io
+// Submitted by Konstantin Nosov <Nosov@nodeart.io>
+*.nodeart.io
+
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn


### PR DESCRIPTION
We use *.nodeart.io with lots of dynamic subdomains, most of them represent staging builds or different branch builds, or some internal services (like PBX, with personal cert for each device). We issue certificate to each of used subdomains. Unfortunately we need to use different certificates for each domain (wildcard is good, but not in our case). And we were suggested to add our domain to that list to issue more certificates at letsencrypt.