### PR TITLE
Add Advisor Websites domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10588,6 +10588,11 @@ myasustor.com
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net
 
+// AW AdvisorWebsites.com Software Inc : https://advisorwebsites.com
+// Submitted by James Kennedy <domains@advisorwebsites.com>
+*.awdev.ca
+*.advisor.ws
+
 // backplane : https://www.backplane.io
 // Submitted by Anthony Voutas <anthony@backplane.io>
 backplaneapp.io


### PR DESCRIPTION
We provide application hosting services to customers using subdomains like `[customername].[shared server].awdev.ca` and `[customername].[shared server].advisor.ws`
For example, `james0208.force1.awdev.ca` and `james.us1.advisor.ws`