### PR TITLE
Add Fedora People and Cloud domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11258,6 +11258,12 @@ map.fastlylb.net
 // Submitted by Simon Menke <simon@featherhead.xyz>
 fhapp.xyz
 
+// Fedora : https://fedoraproject.org/
+// submitted by Patrick Uiterwijk <puiterwijk@fedoraproject.org>
+cloud.fedoraproject.org
+fedorapeople.org
+fedorainfracloud.org
+
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com


### PR DESCRIPTION
These domains are used for contributor web pages (e.g. https://puiterwijk.fedorapeople.org/) and services that contributors run in our OpenStack cluster (e.g. https://copr.fedorainfracloud.org/).