### PR TITLE
Add *.platformsh.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10746,10 +10746,6 @@ cloudns.us
 co.nl
 co.no
 
-// Commerce Guys, SAS
-// Submitted by Damien Tournoud <damien@commerceguys.com>
-*.platform.sh
-
 // COSIMO GmbH http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
 dyn.cosidns.de
@@ -11723,6 +11719,11 @@ mypep.link
 // Planet-Work : https://www.planet-work.com/
 // Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
 on-web.fr
+
+// Platform.sh : https://platform.sh
+// Submitted by Nikola Kotur <nikola@platform.sh>
+*.platform.sh
+*.platformsh.site
 
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>


### PR DESCRIPTION
Please add `*.platformsh.site` to the list.

This entry covers additional regional deployments of Platform.sh product (notably `nl-1.platform.sh`, `de-1.platform.sh`, etc). These subdomains run arbitrary code.