### PR TITLE
Private listing for Fullrate ISP.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11275,6 +11275,11 @@ fbxos.fr
 freebox-os.fr
 freeboxos.fr
 
+// Fullrate : https://www.fullrate.dk
+// Submitted by Lasse Luttermann <llp@fullrate.dk>
+fullrate.dk
+fullrate.ninja
+
 // Fusion Intranet : https://www.fusion-intranet.com
 // Submitted by Matthias Burtscher <matthias.burtscher@fusonic.net>
 myfusion.cloud


### PR DESCRIPTION
Fullrate is an ISP, these domains are used for our public website (https://www.fullrate.dk/) as well as customer A, AAAA and PTR records.