### PR TITLE
Adding quipelements.com domain for Quip.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11690,6 +11690,10 @@ dev-myqnapcloud.com
 alpha-myqnapcloud.com
 myqnapcloud.com
 
+// Quip : https://quip.com
+// Submitted by Patrick Linehan <plinehan@quip.com>
+*.quipelements.com
+
 // Rackmaze LLC : https://www.rackmaze.com
 // Submitted by Kirill Pertsev <kika@rackmaze.com>
 rackmaze.com


### PR DESCRIPTION
This domain is used to host customer applications on individual subdomains. We would like to prevent these applications from storing cookies both within their own subdomain and on the root domain.