### PR TITLE
Add nodum.io aPaas

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11615,6 +11615,11 @@ sytes.net
 webhop.me
 zapto.org
 
+// nodum : https://nodum.io/
+// Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
+nodum.io
+nodum.co
+
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11617,8 +11617,8 @@ zapto.org
 
 // nodum : https://nodum.io/
 // Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
-nodum.io
 nodum.co
+nodum.io
 
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11617,8 +11617,8 @@ zapto.org
 
 // nodum : https://nodum.io/
 // Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
-nodum.co
-nodum.io
+*.nodum.co
+*.nodum.io
 
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11615,10 +11615,10 @@ sytes.net
 webhop.me
 zapto.org
 
-// nodum : https://nodum.io/
+// Nodum B.V. : https://nodum.io/
 // Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
-*.nodum.co
-*.nodum.io
+nodum.co
+nodum.io
 
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>


### PR DESCRIPTION
Reason: x-domain, browsers. Customers generate their own subdomains. Contact: hello@nodum.io