### PR TITLE
Add uber.space

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11900,4 +11900,8 @@ cc.ua
 inf.ua
 ltd.ua
 
+// Uberspace : https://uberspace.de
+// Submitted by Moritz Werner <mwerner@jonaspasche.com>
+uber.space
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11848,6 +11848,10 @@ syno-ds.de
 synology-diskstation.de
 synology-ds.de
 
+// Uberspace : https://uberspace.de
+// Submitted by Moritz Werner <mwerner@jonaspasche.com>
+uber.space
+
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com>
 hk.com
@@ -11899,9 +11903,5 @@ now.sh
 cc.ua
 inf.ua
 ltd.ua
-
-// Uberspace : https://uberspace.de
-// Submitted by Moritz Werner <mwerner@jonaspasche.com>
-uber.space
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
We're a hosting company and we plan to use the domain `uber.space` for our customers. Every account will get its own `mydomain.uber.space` domain. For cookie isolation it would be great to get included in the public suffix list.