### PR TITLE
Add bplaced network domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -395,6 +395,15 @@ net.bo
 mil.bo
 tv.bo
 
+// bplaced : https://www.bplaced.net/
+// Submitted by Miroslav Bozic <security@bplaced.net>
+square7.ch
+bplaced.com
+bplaced.de
+square7.de
+bplaced.net
+square7.net
+
 // br : http://registro.br/dominio/categoria.html
 // Submitted by registry <fneves@registro.br>
 br

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -395,15 +395,6 @@ net.bo
 mil.bo
 tv.bo
 
-// bplaced : https://www.bplaced.net/
-// Submitted by Miroslav Bozic <security@bplaced.net>
-square7.ch
-bplaced.com
-bplaced.de
-square7.de
-bplaced.net
-square7.net
-
 // br : http://registro.br/dominio/categoria.html
 // Submitted by registry <fneves@registro.br>
 br
@@ -10622,6 +10613,15 @@ bnr.la
 // Boxfuse : https://boxfuse.com
 // Submitted by Axel Fontaine <axel@boxfuse.com>
 boxfuse.io
+
+// bplaced : https://www.bplaced.net/
+// Submitted by Miroslav Bozic <security@bplaced.net>
+square7.ch
+bplaced.com
+bplaced.de
+square7.de
+bplaced.net
+square7.net
 
 // BrowserSafetyMark
 // Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>


### PR DESCRIPTION
hello at PSL!

as a shared hosting provider we have interest in a PSL listing for multiple reasons.

1. customers have their own subdomains (possibly for one or all of the given domains) assigned upon registration. Preventing privacy-damaging "supercookies" is a main goal here. We have more than 200k of such subdomains at the moment.
2. also we plan to use let's encrypt here, having these domains in the PSL allows great advantages for the signing process.
3. document.domain property restrictions are considered an advantage as well.

you may contact me via "security @bplaced dot n-e-t" as given by the guidelines, also the DNS records were set up.
Thanks a bunch!

kind regards,
Miroslav Bozic
bplaced CEO
https://www.bplaced.net/