### PR TITLE
Add Filegear domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11302,6 +11302,10 @@ fedorainfracloud.org
 fedorapeople.org
 cloud.fedoraproject.org
 
+// Filegear Inc. : https://www.filegear.com
+// Submitted by Jason Zhu <jason@owtware.com>
+filegear.me
+
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com


### PR DESCRIPTION
Adding domain for filegear.me

filegear.me is used by Filegear Inc. (www.filegear.com) for our customer's devices. Each of these device has a sub-domain name that is generated dynamically during device initialization and registration, e.g. vxnaowas.filegear.me.