### PR TITLE
Add .jur.pro.br in Pivate Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10690,6 +10690,10 @@ myfritz.net
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com
 
+// bugzilla.org Attachment Subdomain Service
+// Submitted by Gervase Markham <gerv@gerv.net>
+*.bzattachments.org
+
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
 ae.org


### PR DESCRIPTION
Include the suffix .jur.pro.br in the private section of PublicSuffix.org