### PR TITLE
Added Lukanet Ltd domains in the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11532,6 +11532,17 @@ knightpoint.systems
 co.krd
 edu.krd
 
+// Lukanet Ltd : https://lukanet.com
+// Submitted by Anton Avramov <register@lukanet.com>
+barsy.bg
+barsyonline.com
+barsy.de
+barsy.eu
+barsy.in
+barsy.net
+barsy.online
+barsy.support
+
 // Magento Commerce
 // Submitted by Damien Tournoud <dtournoud@magento.cloud>
 *.magentosite.cloud


### PR DESCRIPTION
Those domains are used by our clients for accessing their private installations of our product http://www.barsy.bg 
Since each installation is on a separate server on the client premises they are also used as dynamic dns in case the client IP is changed. 
The information in the program contains sensitive financial information, so for security reasons cookies should not be shared between installations. 