### PR TITLE
Add redpanda.zone Domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11773,6 +11773,10 @@ rackmaze.net
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com
 
+// Red Panda Solutions LLC : http://pandawins.com/
+// Submitted by Brandon Chapman <admin@pandawins.com>
+redpanda.zone
+
 // RethinkDB : https://www.rethinkdb.com/
 // Submitted by Chris Kastorff <info@rethinkdb.com>
 hzc.io
@@ -11978,9 +11982,5 @@ now.sh
 cc.ua
 inf.ua
 ltd.ua
-
-// Red Panda Solutions LLC : http://pandawins.com/
-//Submitted by Brandon Chapman <admin@pandawins.com>
-redpanda.zone
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11979,4 +11979,8 @@ cc.ua
 inf.ua
 ltd.ua
 
+// Red Panda Solutions LLC : http://pandawins.com/
+//Submitted by Brandon Chapman <admin@pandawins.com>
+redpanda.zone
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Red Panda Solutions is LLC registered in Texas SOS# 0802671198 TAXID# 32063134657. We provide SaaS with subdomains for redpanda.zone. LLC has two members Brandon Chapman and Connor Davis. 

 `dig TXT _pls.redpanda.zone` provides `_pls.redpanda.zone.     59      IN      TXT     "https://github.com/publicsuffix/list/pull/440"`

My first request was not keeping to alphabetical order. Second change corrected this.

foo.redpanda.zone & bar.redpanda.zone should be incapable of setting cookies towards each other. 