### PR TITLE
Add serveo.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11979,4 +11979,8 @@ cc.ua
 inf.ua
 ltd.ua
 
+// Serveo : https://www.serveo.net/
+// Submitted by Serveo admin <t@serveo.net>
+serveo.net
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11809,6 +11809,10 @@ spdns.org
 // Submitted by Fabien Potencier <fabien.potencier@sensiolabs.com>
 *.sensiosite.cloud
 
+// Serveo : https://www.serveo.net/
+// Submitted by Serveo admin <t@serveo.net>
+serveo.net
+
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua
@@ -11978,9 +11982,5 @@ now.sh
 cc.ua
 inf.ua
 ltd.ua
-
-// Serveo : https://www.serveo.net/
-// Submitted by Serveo admin <t@serveo.net>
-serveo.net
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Customer domains will be hosted as subdomains of serveo.net. For example, foo.serveo.net or wow.serveo.net may be provisioned to customers and should have no way to share cookies.