### PR TITLE
Add Zitcom domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11973,6 +11973,14 @@ za.org
 // Submitted by Olli Vanhoja <olli@zeit.co>
 now.sh
 
+// Zitcom A/S : https://www.zitcom.dk
+// Submitted by Emil Stahl Pedersen <esp@zitcom.dk>
+curanetserver.dk
+enterprisecloud.nu
+scannetserver.dk
+virtualserver.io
+wannafindserver.dk
+
 // 1GB LLC : https://www.1gb.ua/
 // Submitted by 1GB LLC <noc@1gb.com.ua>
 cc.ua


### PR DESCRIPTION
Zitcom A/S is a hosting and cloud provider.

These domains are used for temporary URLs for our web hosting customers or as hostnames for our server customers.

You can find examples of this usage on Google:
https://www.google.com/#q=site:curanetserver.dk
https://www.google.com/#q=site:enterprisecloud.nu
https://www.google.com/#q=site:scannetserver.dk
https://www.google.com/#q=site:virtualserver.io
https://www.google.com/#q=site:wannafindserver.dk

DNS records for authentication are in place.
```
~ esp$ for i in curanetserver.dk enterprisecloud.nu scannetserver.dk virtualserver.io wannafindserver.dk; do echo $i $(dig +short _psl.$i TXT); done
curanetserver.dk "https://github.com/publicsuffix/list/pull/443"
enterprisecloud.nu "https://github.com/publicsuffix/list/pull/443"
scannetserver.dk "https://github.com/publicsuffix/list/pull/443"
virtualserver.io "https://github.com/publicsuffix/list/pull/443"
wannafindserver.dk "https://github.com/publicsuffix/list/pull/443"
```