### PR TITLE
RS.BA domain added

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -282,6 +282,9 @@ mil.ba
 net.ba
 org.ba
 
+// rs.ba : http://urc.rs/index.php/domen
+rs.ba
+
 // bb : https://en.wikipedia.org/wiki/.bb
 bb
 biz.bb


### PR DESCRIPTION
Added rs.ba domain to the list.

BA domain is for Bosnia and Herzegovina. RS.BA is for Republic of Srpska - one of three constitutional entities of Bosnia and Herzegovina.