### PR TITLE
add cloud.goog

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11441,6 +11441,7 @@ blogspot.tw
 blogspot.ug
 blogspot.vn
 cloudfunctions.net
+cloud.goog
 codespot.com
 googleapis.com
 googlecode.com


### PR DESCRIPTION
Customers of Google's Cloud Platform will have the option of creating a Public DNS name, e.g. foo.cloud.goog., for a customer project with name "foo". To avoid cross-project cookie interference, we add cloud.goog to the PSL.
