### PR TITLE
Add onesignal.com to public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11675,6 +11675,10 @@ cya.gg
 // Submitted by Eddie Jones <eddie@onefoldmedia.com>
 nid.io
 
+// OneSignal : https://onesignal.com/
+// Submitted by Jason Pang <jason@onesignal.com>
+onesignal.com
+
 // OpenCraft GmbH : http://opencraft.com/
 // Submitted by Sven Marnach <sven@opencraft.com>
 opencraft.hosting


### PR DESCRIPTION
OneSignal is a push notifications service, and we provide subdomains for customers sending web push notifications. 

Web push notifications in future Chrome versions (59+) on Mac OS X will be displayed in Mac's native notification UI:

![image](https://cloud.githubusercontent.com/assets/1015970/25832015/cb5c0a3a-341c-11e7-8b2e-d767aff2b692.png)

instead of Chrome's custom notification UI, which has been used until now:

![image](https://cloud.githubusercontent.com/assets/1015970/25832195/03e5eea6-341e-11e7-8e59-8ae9333c1a00.png)

[One change in beta Chrome versions is _only displaying the TLD + 1_ for the sending site](https://bugs.chromium.org/p/chromium/issues/detail?id=717725#c8), such that a notification sent from _subdomain.onesignal.com_ will only show up as _onesignal.com_:

![image](https://cloud.githubusercontent.com/assets/1015970/25832208/1312b86e-341e-11e7-8a8a-654bbbaef6e5.png)

^ The subdomain _wordpressdemo_ is missing in the above notification

For these notifications, it would be confusing for end-users to see notifications coming only from _onesignal.com_, instead of _subdomain.onesignal.com_. By adding our domain to the Public Suffix List, Chrome can display _subdomain.onesignal.com_ on each web push notification.