### PR TITLE
Add drayddns.com to public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10796,6 +10796,10 @@ dedyn.io
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de
 
+// DrayTek Corp. : https://www.draytek.com/
+// Submitted by Paul Fang <mis@draytek.com>
+drayddns.com
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com


### PR DESCRIPTION
Greeting Sir.
Our company is going to provide service to let customers register the domain name and get the certificate from Let's Encrypt.
Because the Let's Encrypt is using the Public Suffix List to calculate the domain and limit the certificates.
By adding the "drayddns.com" into Public Suffix List, the Let's Encrypt and browsers could identify our domain name correctly.

The examples of our domain name list below:
~~https://example1.drayddns.com~~
~~https://example2.drayddns.com~~
Update the list in next comment.

Thank you, sir.