### PR TITLE
Add we.bs domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11532,6 +11532,10 @@ knightpoint.systems
 co.krd
 edu.krd
 
+// LiquidNet Ltd : http://www.liquidnetlimited.com/
+// Submitted by Victor Velchev <admin@liquidnetlimited.com>
+we.bs
+
 // Magento Commerce
 // Submitted by Damien Tournoud <dtournoud@magento.cloud>
 *.magentosite.cloud


### PR DESCRIPTION
Hello PSL,

We are a hosting company and we are willing to add we.bs to the list. We are doing this for two reasons.

1. We have a lot of clients using .we.bs subdomains, so this will solve cookie problems.
2. We have recently integrated Let`s Encrypt SSLs to our system. Having we.bs in the list will improve the signing process.

The requested TXT record has been added:

> dig TXT _psl.we.bs 
> "htt<span>ps://github.com/publicsuffix/list/pull/452"

Regards,
Victor Velchev
admin@liquidnetlimited.com
