### PR TITLE
Add mytuleap.com domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11119,6 +11119,10 @@ dynv6.net
 // Submitted by Vladimir Dudr <info@e4you.cz>
 e4.cz
 
+// Enalean SAS: https://www.enalean.com
+// Submitted by Thomas Cottier <thomas.cottier@enalean.com>
+mytuleap.com
+
 // Enonic : http://enonic.com/
 // Submitted by Erik Kaareng-Sunde <esu@enonic.com>
 enonic.io


### PR DESCRIPTION
Customers of the mytuleap solution will have a subdomain like customer.mytuleap.com to host their forge.

We want to be sure cookies are correctly set.