### PR TITLE
Add lima-city/TrafficPlex domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11893,6 +11893,28 @@ sopot.pl
 bloxcms.com
 townnews-staging.com
 
+// TrafficPlex GmbH : https://www.trafficplex.de/
+// Submitted by Phillipp Röll <phillipp.roell@trafficplex.de>
+12hp.at
+2ix.at
+4lima.at
+lima-city.at
+12hp.ch
+2ix.ch
+4lima.ch
+lima-city.ch
+trafficplex.cloud
+de.cool
+12hp.de
+2ix.de
+4lima.de
+lima-city.de
+1337.pictures
+clan.rip
+lima-city.rocks
+webspace.rocks
+lima.zone
+
 // TransIP : htts://www.transip.nl
 // Submitted by Rory Breuk <rbreuk@transip.nl>
 *.transurl.be


### PR DESCRIPTION
Hi,

we're a web hosting provider and cloud company and have multiple domains where customers can freely register subdomains. We have over 400k subdomains currently active on the listed domains.

We'd like to be included in the PSL for security concerns (mainly cookies).

DNS-Records will be set up soon.

Best,
Phillipp