### PR TITLE
Add pixolino.com domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11507,6 +11507,10 @@ se.leg.br
 sp.leg.br
 to.leg.br
 
+// intermetrics GmbH : https://pixolino.com/
+// Submitted by Wolfgang Schwarz <admin@intermetrics.de>
+pixolino.com
+
 // IPiFony Systems, Inc. : https://www.ipifony.com/
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net


### PR DESCRIPTION
[pixolino.com](https://pixolino.com) is a service where customers can build their own websites under a *.pixolino.com subdomain. We need to ensure the appropriate and secure handling of cookies.

Examples:
- [developers.pixolino.com](https://developers.pixolino.com)
- [demo.pixolino.com](https://demo.pixolino.com)