### PR TITLE
Add flynnhosting.net for Flynn

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11309,6 +11309,7 @@ firebaseapp.com
 // Flynn : https://flynn.io
 // Submitted by Jonathan Rudenberg <jonathan@flynn.io>
 flynnhub.com
+flynnhosting.net
 
 // Freebox : http://www.freebox.fr
 // Submitted by Romain Fliedel <rfliedel@freebox.fr>


### PR DESCRIPTION
Subdomains of this domain are used by completely independent entities to host arbitrary websites.