### PR TITLE
Add info.cx

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11477,6 +11477,10 @@ iki.fi
 biz.at
 info.at
 
+// info.cx http://info.cx
+// Submitted by Jacob Slater <whois@igloo.to>
+info.cx
+
 // Interlegis : http://www.interlegis.leg.br
 // Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
 ac.leg.br

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11477,7 +11477,7 @@ iki.fi
 biz.at
 info.at
 
-// info.cx http://info.cx
+// info.cx : http://info.cx
 // Submitted by Jacob Slater <whois@igloo.to>
 info.cx
 


### PR DESCRIPTION
info.cx offers free sub domains through afraid.org. I would like to add the domain to the suffix list to ensure cookies are handled properly.