### PR TITLE
Add temp-dns.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11862,7 +11862,7 @@ storj.farm
 
 // Sub 6 Limited: http://www.sub6.com
 // Submitted by Dan Miller <dm@sub6.com>
-*.temp-dns.com
+temp-dns.com
 
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11860,6 +11860,10 @@ stackspace.space
 // Submitted by Philip Hutchins <hostmaster@storj.io>
 storj.farm
 
+// Sub 6 Limited: http://www.sub6.com
+// Submitted by Dan Miller <dm@sub6.com>
+*.temp-dns.com
+
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>
 diskstation.me


### PR DESCRIPTION
Subdomain variants of this domain name are used across our network to provide legitimate temporary staging environments to our customers.

Sub 6 Limited is the parent company that owns this domain name.