### PR TITLE
Add Netlify domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11629,6 +11629,11 @@ cloudapp.net
 // Submitted by glob <glob@mozilla.com>
 bmoattachments.org
 
+// Netlify : https://www.netlify.com
+// Submitted by Jessica Parsons <jessica@netlify.com>
+netlify.com
+bitballoon.com
+
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz>
 4u.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11631,8 +11631,8 @@ bmoattachments.org
 
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
-netlify.com
 bitballoon.com
+netlify.com
 
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz>


### PR DESCRIPTION
Netlify deploys websites for customers under subdomains at *.netlify.com and *.bitballoon.com.

Examples:
* https://opensmc.netlify.com/
* https://special-tester.bitballoon.com

Adding DNS records when we have a PR number.