### PR TITLE
add *.stage.nodeart.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11740,6 +11740,11 @@ sytes.net
 webhop.me
 zapto.org
 
+// NodeArt : https://nodeart.io
+// Submitted by Konstantin Nosov <Nosov@nodeart.io>
+*.stage.nodeart.io
+
+
 // Nodum B.V. : https://nodum.io/
 // Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
 nodum.co


### PR DESCRIPTION
- Updated pull request from https://github.com/publicsuffix/list/pull/410 to current master of PSL
- changed pull request to avoid problems with adding whole domain to PSL (internal services use SSO, which will broke if we add root domain to PSL)
- Current request comply PSL purposes.

Under stage subdomain different clients can publish their apps, that allows 3rd party developers to steal cookies from another sub domain. Which is problem for HIPPA compatible app etc.
