### PR TITLE
Add boomla.net domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10657,6 +10657,10 @@ betainabox.com
 // Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
 bnr.la
 
+// Boomla : https://boomla.com
+// Submitted by Tibor Halter <thalter@boomla.com>
+boomla.net
+
 // Boxfuse : https://boxfuse.com
 // Submitted by Axel Fontaine <axel@boxfuse.com>
 boxfuse.io


### PR DESCRIPTION
Boomla ([boomla.com](https://boomla.com/)) allows anyone to create and host websites on `*.boomla.net` subdomains. We want to prevent users from adding cookies to `boomla.net`.

Example customer domain: [psl.boomla.net](http://psl.boomla.net/)