### PR TITLE
Add byen.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11953,6 +11953,7 @@ protonet.io
 // Publication Presse Communication SARL : https://ppcom.fr
 // Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
 chirurgiens-dentistes-en-france.fr
+*.byen.site
 
 // QA2
 // Submitted by Daniel Dent (https://www.danieldent.com/)

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11953,7 +11953,7 @@ protonet.io
 // Publication Presse Communication SARL : https://ppcom.fr
 // Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
 chirurgiens-dentistes-en-france.fr
-*.byen.site
+byen.site
 
 // QA2
 // Submitted by Daniel Dent (https://www.danieldent.com/)


### PR DESCRIPTION
P.P.COM (ppcom.fr via byen.site) offers our customers a website hosted in a domain *.byen.site
E.g.:  dupond-pierre-taxi.byen.site

Reason for inclusion
Cookie isolation. Each customer can partially modify himself his site so cookie isolation is needed for security reason.