### PR TITLE
Add nh-serv.co.uk to list file

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11726,6 +11726,10 @@ netlify.com
 // Submitted by Alan Shreve <alan@ngrok.com>
 ngrok.io
 
+// Nimbus Hosting Ltd. : https://www.nimbushosting.co.uk/
+// Submitted by Nicholas Ford <nick@nimbushosting.co.uk>
+nh-serv.co.uk
+
 // NFSN, Inc. : https://www.NearlyFreeSpeech.NET/
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com


### PR DESCRIPTION
Nimbus Hosting (nimbushosting.co.uk) are a web hosting company and we use `*.nh-serv.co.uk` for server hostnames.
