### PR TITLE
Add channelsdvr.net to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11400,7 +11400,7 @@ vologda.su
 
 // Fancy Bits, LLC : http://getchannels.com
 // Submitted by Aman Gupta <aman@getchannels.com>
-remote.getchannels.com
+channelsdvr.net
 
 // Fastly Inc. : http://www.fastly.com/
 // Submitted by Fastly Security <security@fastly.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11398,6 +11398,10 @@ vladikavkaz.su
 vladimir.su
 vologda.su
 
+// Fancy Bits, LLC : http://getchannels.com
+// Submitted by Aman Gupta <aman@getchannels.com>
+remote.getchannels.com
+
 // Fastly Inc. : http://www.fastly.com/
 // Submitted by Fastly Security <security@fastly.com>
 fastlylb.net


### PR DESCRIPTION
We are setting up a dynamic dns service for users of our server software, which is installed by the user on a computer in their home. For example I might register a domain like tmm1.remote.getchannels.com, for easy remote access to the server I setup at home. 

Since we use the getchannels.com domain for marketing and subscription purposes, the intent of this PR is to ensure that cookies are not shared between user sub-domains and our root domain, nor across different user domains (by using a `.remote.getchannels.com` supercookie).

My understanding is that a cookie set on `.getchannels.com` would _not_ be made available to `tmm1.remote.getchannels.com`, but I would appreciate if someone can confirm my understanding of how the PSL works.

We also plan to use Let's Encrypt to issue SSL certificates for these user domains.