### PR TITLE
Add resin.io device domains as public suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11982,6 +11982,11 @@ rackmaze.net
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com
 
+// Resin.io : https://resin.io
+// Submitted by Tim Perry <tim@resin.io>
+resindevice.io
+devices.resinstaging.io
+
 // RethinkDB : https://www.rethinkdb.com/
 // Submitted by Chris Kastorff <info@rethinkdb.com>
 hzc.io


### PR DESCRIPTION
We expose our users' device-hosted web services at `<device id>.resindevice.io` and in our staging environment at `<device id>.devices.resinstaging.io`. We'd like to ensure these devices are isolated from one another in browsers.

~~I'm organising authentication for these domains at the moment, I'll update here shortly once we've got the `_ps1` TXT records set up.~~ `_ps1` TXT records for these domains are now live.