### PR TITLE
Add netlib.re, public domain name registrar

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5697,6 +5697,7 @@ sch.qa
 re
 asso.re
 com.re
+netlib.re
 nom.re
 
 // ro : http://www.rotld.ro/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5697,6 +5697,8 @@ sch.qa
 re
 asso.re
 com.re
+// Association Alsace Réseau Neutre: https://www.arn-fai.net
+// Submitted by Philippe Pittoli <admins@arn-fai.net>
 netlib.re
 nom.re
 


### PR DESCRIPTION
netlib.re is a public domain name registrar for non experienced users willing to have a name on the Internet.

Reason for inclusion
Cookie isolation. Each user can partially modify himself his site so cookie isolation is needed for security reason. Also, certificates are a problem, they all need to be able to own their own.