### PR TITLE
Update 2nd level city domain for publicsuffixlist

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -464,9 +464,7 @@ sc.gov.br
 se.gov.br
 sp.gov.br
 to.gov.br
-// add domain by NIC.BR on 2018-08-07 12:00 GMT -3:00
 gru.br
-// end edit, credits Lucas Penco. tks
 imb.br
 ind.br
 inf.br

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -464,6 +464,9 @@ sc.gov.br
 se.gov.br
 sp.gov.br
 to.gov.br
+// add domain by NIC.BR on 2018-08-07 12:00 GMT -3:00
+gru.br
+// end edit, credits Lucas Penco. tks
 imb.br
 ind.br
 inf.br


### PR DESCRIPTION
Please, update the public suffix list, to add the 2nd level city domain GRU.BR. @fnevesbr is a representative of the registry and he can confirm the PR from your authoritative email.

This domain was released on 2018-08-07 12:00 GMT -03:00 Brasil.

Best Regards, Lucas Penco.