### PR TITLE
Adding xnbay.com,u2.xnbay.com,u2-local.xnbay.com to public_suffix_lis…

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12194,6 +12194,12 @@ remotewd.com
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
 
+// XnBay Technology : http://www.xnbay.com/
+// Submitted by XnBay Developer <developer.xncloud@gmail.com>
+xnbay.com
+u2.xnbay.com
+u2-local.xnbay.com
+
 // XS4ALL Internet bv : https://www.xs4all.nl/
 // Submitted by Daniel Mostertman <unixbeheer+publicsuffix@xs4all.net>
 cistron.nl


### PR DESCRIPTION
Hello PSL,

Our company makes personal cloud storage and we are willing to add xnbay.com to the list. The reasons are:

We have a lot of clients using .xnbay.com, u2.xnbay.com, u2-local.xnbay.com subdomains, so this will solve cookie problems.
We have recently integrated Let`s Encrypt SSLs to our system. Having .xnbay.com, u2.xnbay.com, u2-local.xnbay.com in the list will improve the signing process.

The requested TXT record has been added:
`dig TXT _psl.xnbay.com`
`"https://github.com/publicsuffix/list/pull/506"`

`dig TXT _psl.u2.xnbay.com`
`"https://github.com/publicsuffix/list/pull/506"`

`dig TXT _psl.u2-local.xnbay.com`
`"https://github.com/publicsuffix/list/pull/506"`

BR,
Sean