### PR TITLE
Adding wedeploy.sh domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12186,6 +12186,7 @@ router.management
 // Submitted by Henrique Vicente <security@wedeploy.com>
 wedeploy.io
 wedeploy.me
+wedeploy.sh
 
 // Western Digital Technologies, Inc : https://www.wdc.com
 // Submitted by Jung Jin <jungseok.jin@wdc.com>


### PR DESCRIPTION
The reasoning is exactly the same as for my previous pull request https://github.com/publicsuffix/list/pull/420 (copied below).

> We allow costumers to create projects using the <project>.wedeploy.io (for production) and <project>.wedeploy.me for local development.
> Some examples:
> http://whatsapp.wedeploy.io/
> http://supermarket.wedeploy.io/
> http://boilerplate-auth.wedeploy.io/
> http://boilerplate-liferay.wedeploy.io/
> http://metrics.wedeploy.io/
> These are all different sites, from different costumers (in this case, they are demos), not related with each other (besides the fact they are run on our infrastructure).
> Docs: http://wedeploy.com/docs/

I will comment here when DNS authentication is ready and remove this comment.