### PR TITLE
Add ras.ru domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11956,6 +11956,10 @@ protonet.io
 chirurgiens-dentistes-en-france.fr
 byen.site
 
+// Russian Academy of Sciences
+// Submitted by Tech Support <support@rasnet.ru>
+ras.ru
+
 // QA2
 // Submitted by Daniel Dent (https://www.danieldent.com/)
 qa2.com


### PR DESCRIPTION
The institutes of the Russian Academy of Sciences use a custom subdomains of **ras.ru**