### PR TITLE
Add myjino.ru

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11635,6 +11635,14 @@ to.leg.br
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
 
+// Jino : https://www.jino.ru
+// Submitted by Sergey Ulyashin <ulyashin@jino.ru>
+myjino.ru
+*.hosting.myjino.ru
+*.landing.myjino.ru
+*.spectrum.myjino.ru
+*.vps.myjino.ru
+
 // Joyent : https://www.joyent.com/
 // Submitted by Brian Bennett <brian.bennett@joyent.com>
 *.triton.zone


### PR DESCRIPTION
jino.ru is a hosting provider. We give our customers free subdomains of myjino.ru domain.

Examples:
some-user.myjino.ru
project1.6e7oz.landing.myjino.ru
vps1.zm9y1.vps.myjino.ru

We need to restrict cookie sharing between these subdomains.