### PR TITLE
Add debian.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10897,6 +10897,10 @@ firm.dk
 reg.dk
 store.dk
 
+// Debian : https://www.debian.org/
+// Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
+debian.net
+
 // deSEC : https://desec.io/
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io


### PR DESCRIPTION
The debian.net namespace is open for registration by all members of the
Debian project.  Services underneath debian.net should not necessarily
trust each other.