### PR TITLE
Remove altoadige.it from list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1361,7 +1361,6 @@ agrigento.it
 al.it
 alessandria.it
 alto-adige.it
-altoadige.it
 an.it
 ancona.it
 andria-barletta-trani.it


### PR DESCRIPTION
altoadige.it is not a TLD