### PR TITLE
Include gwiddle.co.uk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12141,6 +12141,10 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// The Gwiddle Foundation : https://gwiddlefoundation.org.uk
+// Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
+gwiddle.co.uk
+
 // Thingdust AG : https://thingdust.com/
 // Submitted by Adrian Imboden <adi@thingdust.com>
 cust.dev.thingdust.io


### PR DESCRIPTION
Gwiddle.co.uk is a privately-owned domain. The Gwiddle Foundation issues subdomains to mutually-untrusting parties for the purposes of free student web hosting, and as such we request that it is added to the private section of the Public Suffix List.