### PR TITLE
Add LubMAN UMCS suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11704,6 +11704,17 @@ svn-repos.de
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>
 we.bs
 
+// LubMAN sp. z o.o. : https://lubman.pl
+// Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
+24ok.pl
+iphost.pl
+krasnik.pl
+leczna.pl
+lubartow.pl
+lublin.pl
+poniatowa.pl
+swidnik.pl
+
 // Lukanet Ltd : https://lukanet.com
 // Submitted by Anton Avramov <register@lukanet.com>
 barsy.bg

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11704,7 +11704,7 @@ svn-repos.de
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>
 we.bs
 
-// LubMAN sp. z o.o. : https://lubman.pl
+// LubMAN UMCS sp. z o.o. : https://lubman.pl
 // Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
 24ok.pl
 iphost.pl


### PR DESCRIPTION
LubMAN UMCS sp. z o.o. is hosting provider that provides to its customers website services, DNS and SSL certificates with LetsEncrypt within following domains: 24ok.pl, iphost.pl, krasnik.pl, leczna.pl, lubartow.pl, lublin.pl, poniatowa.pl and swidnik.pl