### PR TITLE
nic.it - update regions and provinces

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1416,6 +1416,10 @@ at.it
 av.it
 avellino.it
 ba.it
+balsan-sudtirol.it
+// balsan-südtirol.it
+xn--balsan-sdtirol-nsb.it
+balsan-suedtirol.it
 balsan.it
 bari.it
 barletta-trani-andria.it
@@ -1430,13 +1434,23 @@ bl.it
 bn.it
 bo.it
 bologna.it
+bolzano-altoadige.it
 bolzano.it
+bozen-sudtirol.it
+// bozen-südtirol.it
+xn--bozen-sdtirol-2ob.it
+bozen-suedtirol.it
 bozen.it
 br.it
 brescia.it
 brindisi.it
 bs.it
 bt.it
+bulsan-sudtirol.it
+// bulsan-südtirol.it
+xn--bulsan-sdtirol-nsb.it
+bulsan-suedtirol.it
+bulsan.it
 bz.it
 ca.it
 cagliari.it
@@ -1454,7 +1468,11 @@ catanzaro.it
 cb.it
 ce.it
 cesena-forli.it
+// cesena-forlì.it
+xn--cesena-forl-mcb.it
 cesenaforli.it
+// cesenaforlì.it
+xn--cesenaforl-i8a.it
 ch.it
 chieti.it
 ci.it
@@ -1485,7 +1503,11 @@ florence.it
 fm.it
 foggia.it
 forli-cesena.it
+// forlì-cesena.it
+xn--forl-cesena-fcb.it
 forlicesena.it
+// forlìcesena.it
+xn--forlcesena-c8a.it
 fr.it
 frosinone.it
 ge.it
@@ -1616,6 +1638,8 @@ sp.it
 sr.it
 ss.it
 suedtirol.it
+// südtirol.it
+xn--sdtirol-n2a.it
 sv.it
 ta.it
 taranto.it

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1259,10 +1259,8 @@ int.is
 it
 gov.it
 edu.it
-// Reserved geo-names:
-// http://www.nic.it/documenti/regolamenti-e-linee-guida/regolamento-assegnazione-versione-6.0.pdf
-// There is also a list of reserved geo-names corresponding to Italian municipalities
-// http://www.nic.it/documenti/appendice-c.pdf, but it is not included here.
+// Reserved geo-names (regions and provinces):
+// http://www.nic.it/sites/default/files/docs/Regulation_assignation_v7.1.pdf
 // Regions
 abr.it
 abruzzo.it
@@ -1316,6 +1314,14 @@ sicily.it
 taa.it
 tos.it
 toscana.it
+trentin-sud-tirol.it
+// trentin-süd-tirol.it
+xn--trentin-sd-tirol-rzb.it
+trentin-sudtirol.it
+// trentin-südtirol.it
+xn--trentin-sdtirol-7vb.it
+trentin-sued-tirol.it
+trentin-suedtirol.it
 trentino-a-adige.it
 trentino-aadige.it
 trentino-alto-adige.it
@@ -1323,9 +1329,14 @@ trentino-altoadige.it
 trentino-s-tirol.it
 trentino-stirol.it
 trentino-sud-tirol.it
+// trentino-süd-tirol.it
+xn--trentino-sd-tirol-c3b.it
 trentino-sudtirol.it
+// trentino-südtirol.it
+xn--trentino-sdtirol-szb.it
 trentino-sued-tirol.it
 trentino-suedtirol.it
+trentino.it
 trentinoa-adige.it
 trentinoaadige.it
 trentinoalto-adige.it
@@ -1333,9 +1344,21 @@ trentinoaltoadige.it
 trentinos-tirol.it
 trentinostirol.it
 trentinosud-tirol.it
+// trentinosüd-tirol.it
+xn--trentinosd-tirol-rzb.it
 trentinosudtirol.it
+// trentinosüdtirol.it
+xn--trentinosdtirol-7vb.it
 trentinosued-tirol.it
 trentinosuedtirol.it
+trentinsud-tirol.it
+// trentinsüd-tirol.it
+xn--trentinsd-tirol-6vb.it
+trentinsudtirol.it
+// trentinsüdtirol.it
+xn--trentinsdtirol-nsb.it
+trentinsued-tirol.it
+trentinsuedtirol.it
 tuscany.it
 umb.it
 umbria.it
@@ -1350,7 +1373,17 @@ valleaosta.it
 valled-aosta.it
 valledaosta.it
 vallee-aoste.it
+// vallée-aoste.it
+xn--valle-aoste-ebb.it
+vallee-d-aoste.it
+// vallée-d-aoste.it
+xn--valle-d-aoste-ehb.it
 valleeaoste.it
+// valléeaoste.it
+xn--valleaoste-e7a.it
+valleedaoste.it
+// valléedaoste.it
+xn--valledaoste-ebb.it
 vao.it
 vda.it
 ven.it
@@ -1601,7 +1634,6 @@ trani-barletta-andria.it
 traniandriabarletta.it
 tranibarlettaandria.it
 trapani.it
-trentino.it
 trento.it
 treviso.it
 trieste.it

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1315,11 +1315,9 @@ taa.it
 tos.it
 toscana.it
 trentin-sud-tirol.it
-// trentin-süd-tirol.it
-xn--trentin-sd-tirol-rzb.it
+trentin-süd-tirol.it
 trentin-sudtirol.it
-// trentin-südtirol.it
-xn--trentin-sdtirol-7vb.it
+trentin-südtirol.it
 trentin-sued-tirol.it
 trentin-suedtirol.it
 trentino-a-adige.it
@@ -1329,11 +1327,9 @@ trentino-altoadige.it
 trentino-s-tirol.it
 trentino-stirol.it
 trentino-sud-tirol.it
-// trentino-süd-tirol.it
-xn--trentino-sd-tirol-c3b.it
+trentino-süd-tirol.it
 trentino-sudtirol.it
-// trentino-südtirol.it
-xn--trentino-sdtirol-szb.it
+trentino-südtirol.it
 trentino-sued-tirol.it
 trentino-suedtirol.it
 trentino.it
@@ -1344,19 +1340,15 @@ trentinoaltoadige.it
 trentinos-tirol.it
 trentinostirol.it
 trentinosud-tirol.it
-// trentinosüd-tirol.it
-xn--trentinosd-tirol-rzb.it
+trentinosüd-tirol.it
 trentinosudtirol.it
-// trentinosüdtirol.it
-xn--trentinosdtirol-7vb.it
+trentinosüdtirol.it
 trentinosued-tirol.it
 trentinosuedtirol.it
 trentinsud-tirol.it
-// trentinsüd-tirol.it
-xn--trentinsd-tirol-6vb.it
+trentinsüd-tirol.it
 trentinsudtirol.it
-// trentinsüdtirol.it
-xn--trentinsdtirol-nsb.it
+trentinsüdtirol.it
 trentinsued-tirol.it
 trentinsuedtirol.it
 tuscany.it
@@ -1373,17 +1365,13 @@ valleaosta.it
 valled-aosta.it
 valledaosta.it
 vallee-aoste.it
-// vallée-aoste.it
-xn--valle-aoste-ebb.it
+vallée-aoste.it
 vallee-d-aoste.it
-// vallée-d-aoste.it
-xn--valle-d-aoste-ehb.it
+vallée-d-aoste.it
 valleeaoste.it
-// valléeaoste.it
-xn--valleaoste-e7a.it
+valléeaoste.it
 valleedaoste.it
-// valléedaoste.it
-xn--valledaoste-ebb.it
+valléedaoste.it
 vao.it
 vda.it
 ven.it
@@ -1417,8 +1405,7 @@ av.it
 avellino.it
 ba.it
 balsan-sudtirol.it
-// balsan-südtirol.it
-xn--balsan-sdtirol-nsb.it
+balsan-südtirol.it
 balsan-suedtirol.it
 balsan.it
 bari.it
@@ -1437,8 +1424,7 @@ bologna.it
 bolzano-altoadige.it
 bolzano.it
 bozen-sudtirol.it
-// bozen-südtirol.it
-xn--bozen-sdtirol-2ob.it
+bozen-südtirol.it
 bozen-suedtirol.it
 bozen.it
 br.it
@@ -1447,8 +1433,7 @@ brindisi.it
 bs.it
 bt.it
 bulsan-sudtirol.it
-// bulsan-südtirol.it
-xn--bulsan-sdtirol-nsb.it
+bulsan-südtirol.it
 bulsan-suedtirol.it
 bulsan.it
 bz.it
@@ -1468,11 +1453,9 @@ catanzaro.it
 cb.it
 ce.it
 cesena-forli.it
-// cesena-forlì.it
-xn--cesena-forl-mcb.it
+cesena-forlì.it
 cesenaforli.it
-// cesenaforlì.it
-xn--cesenaforl-i8a.it
+cesenaforlì.it
 ch.it
 chieti.it
 ci.it
@@ -1503,11 +1486,9 @@ florence.it
 fm.it
 foggia.it
 forli-cesena.it
-// forlì-cesena.it
-xn--forl-cesena-fcb.it
+forlì-cesena.it
 forlicesena.it
-// forlìcesena.it
-xn--forlcesena-c8a.it
+forlìcesena.it
 fr.it
 frosinone.it
 ge.it
@@ -1638,8 +1619,7 @@ sp.it
 sr.it
 ss.it
 suedtirol.it
-// südtirol.it
-xn--sdtirol-n2a.it
+südtirol.it
 sv.it
 ta.it
 taranto.it


### PR DESCRIPTION
Update TLDs from nic.it in compliance with version 7.1 of Italian Regulation assignation.
In particular:

regions are listed in Appendix A;
provinces are listed in Appendix B.


Municipalities are omitted due to limits and constraints of PSL. See also #519 for further discussions.