### PR TITLE
add schokokeks.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12058,6 +12058,10 @@ sandcats.io
 logoip.de
 logoip.com
 
+// schokokeks.org GbR : https://schokokeks.org/
+// Submitted by Hanno Böck <hanno@schokokeks.org>
+schokokeks.net
+
 // Securepoint GmbH : https://www.securepoint.de
 // Submitted by Erik Anders <erik.anders@securepoint.de>
 firewall-gateway.com


### PR DESCRIPTION
This is a domain we use to host customer subdomains.

Each customer has a username and can create [username].schokokeks.net and [something].[username].schokokeks.net. Thus for security reasons it makes sense to separate them cookie-wise.