### PR TITLE
Adding scrysec.com to public suffix to properly partition publicly created subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12058,6 +12058,10 @@ sandcats.io
 logoip.de
 logoip.com
 
+// Scry Security : http://www.scrysec.com
+// Submitted by Shante Adam <shante@skyhat.io>
+scrysec.com
+
 // Securepoint GmbH : https://www.securepoint.de
 // Submitted by Erik Anders <erik.anders@securepoint.de>
 firewall-gateway.com


### PR DESCRIPTION
Public users will be able to spool up a personal environment which should not share cookies etc... with other subdomains.