### PR TITLE
Removed sector-based .fr domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -922,23 +922,7 @@ prd.fr
 presse.fr
 tm.fr
 // domaines sectoriels : http://www.afnic.fr/obtenir/chartes/nommage-fr/annexe-sectoriels
-aeroport.fr
-assedic.fr
-avocat.fr
-avoues.fr
-cci.fr
-chambagri.fr
-chirurgiens-dentistes.fr
-experts-comptables.fr
-geometre-expert.fr
 gouv.fr
-greta.fr
-huissier-justice.fr
-medecin.fr
-notaires.fr
-pharmacien.fr
-port.fr
-veterinaire.fr
 
 // ga : https://en.wikipedia.org/wiki/.ga
 ga

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -915,14 +915,12 @@ fo
 // fr : http://www.afnic.fr/
 // domaines descriptifs : http://www.afnic.fr/obtenir/chartes/nommage-fr/annexe-descriptifs
 fr
-com.fr
 asso.fr
+com.fr
+gouv.fr
 nom.fr
 prd.fr
-presse.fr
 tm.fr
-// domaines sectoriels : http://www.afnic.fr/obtenir/chartes/nommage-fr/annexe-sectoriels
-gouv.fr
 
 // ga : https://en.wikipedia.org/wiki/.ga
 ga


### PR DESCRIPTION
Sector-based .fr domains are now simple domains owned by private users/companies. The change was operated in 2009:

- https://www.afnic.fr/en/products-and-services/the-fr-tld/sector-based-fr-domains-4.html (English)
- https://www.afnic.fr/fr/produits-et-services/le-fr/les-domaines-sectoriels-en-fr-11.html# (French)
- https://www.afnic.fr/en/about-afnic/news/operations-news/8172/showOperational/sector-based-domaines-migration-avocat-fr-2-1.html (French)
- https://www.afnic.fr/fr/l-afnic-en-bref/actualites/actualites-operationnelles/5493/showOperational/migration-des-sous-domaines-sectoriels-avoues-fr-1.html (French)
- https://www.afnic.fr/fr/l-afnic-en-bref/actualites/actualites-operationnelles/3333/showOperational/migration-des-sous-domaines-sectoriels.html (French)