### PR TITLE
pcloud.host

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11889,7 +11889,7 @@ nodum.co
 nodum.io
 
 // Nucleos Inc. : https://nucleos.com
-// Submitted by Piotr Zduniak <piotr@zduniak.net>
+// Submitted by Piotr Zduniak <piotr@nucleos.com>
 pcloud.host
 
 // NYC.mn : http://www.information.nyc.mn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11888,6 +11888,10 @@ stage.nodeart.io
 nodum.co
 nodum.io
 
+// Nucleos Inc. : https://nucleos.com
+// Submitted by Piotr Zduniak <piotr@zduniak.net>
+pcloud.host
+
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn


### PR DESCRIPTION
[Nucleos Inc](https://nucleos.com) is a company behind [PortableCloud](https://portablecloud.net), a "local cloud solution" (currently something like a platform with an app store so that non-technical users can easily set up whatever software they want on our custom server devices), which is currently expanding its featureset to remote access, supporting SSL certificates, even in LANs and so on. Currently our software is deployed at various schools in Zimbabwe, India and evaluated in countries like Mauritius, rural Mexico and so on.

I can't _really_ give you proper examples due to the nature of our platform (no proper authentication yet and so on), but every device is given its own domain under the pcloud.host suffix (like piotr.pcloud.host, which is currently routed to a tunnelling server, which does not do anything useful _yet_). The domain is currently mostly used for local access to our devices, upon proper configuration to the network, you can access applications hosted on the device by going to something.[yourdevice].pcloud.host, which has its own HTTPS certificate generated by querying our tunnelling server with a CSR, which is then passed on to Let's Encrypt to generate a cert that contains all DNS names in the SAN field.

Other than that there's the obvious issue of cookies, but we believe that for now it should be enough to only add pcloud.host to the list.