### PR TITLE
Add Fedora Openshift app domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11470,6 +11470,8 @@ fhapp.xyz
 fedorainfracloud.org
 fedorapeople.org
 cloud.fedoraproject.org
+app.os.fedoraproject.org
+app.os.stg.fedoraproject.org
 
 // Filegear Inc. : https://www.filegear.com
 // Submitted by Jason Zhu <jason@owtware.com>


### PR DESCRIPTION
These domains are used by the production and staging OpenShift instances run by Fedora Infrastructure and run apps by various application owners.