### PR TITLE
Adding ravendb.net subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11638,6 +11638,8 @@ herokussl.com
 
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
+ravendb.me
+myravendb.com
 *.dbs.ravendb.net
 *.live.ravendb.net
 *.local.ravendb.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11636,14 +11636,12 @@ hepforge.org
 herokuapp.com
 herokussl.com
 
-
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
 *.dbs.ravendb.net
 *.live.ravendb.net
 *.local.ravendb.net
 *.dbs.local.ravendb.net
-
 
 // Ici la Lune : http://www.icilalune.com/
 // Submitted by Simon Morvan <simon@icilalune.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11636,6 +11636,15 @@ hepforge.org
 herokuapp.com
 herokussl.com
 
+
+// Hibernating Rhinos
+// Submitted by Oren Eini <oren@ravendb.net>
+*.dbs.ravendb.net
+*.live.ravendb.net
+*.local.ravendb.net
+*.dbs.local.ravendb.net
+
+
 // Ici la Lune : http://www.icilalune.com/
 // Submitted by Simon Morvan <simon@icilalune.com>
 moonscale.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11638,6 +11638,9 @@ herokussl.com
 
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
+ravendb.run
+ravendb.community
+development.run
 ravendb.me
 myravendb.com
 *.dbs.ravendb.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11638,15 +11638,11 @@ herokussl.com
 
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
-ravendb.run
-ravendb.community
-development.run
-ravendb.me
 myravendb.com
-*.dbs.ravendb.net
-*.live.ravendb.net
-*.local.ravendb.net
-*.dbs.local.ravendb.net
+ravendb.community
+ravendb.me
+development.run
+ravendb.run
 
 // Ici la Lune : http://www.icilalune.com/
 // Submitted by Simon Morvan <simon@icilalune.com>


### PR DESCRIPTION
We provide users with the ability to host clusters of databases.
Typically these are in the form of:

* `https://node-a.user-1234.dbs.ravendb.net`
* `https://node-b.user-1234.dbs.ravendb.net`
* `https://node-c.user-1234.dbs.local.ravendb.net`

Each cluster (the `user-1234` portion) is per user, and then there is a subdomain below that for each node that is operated by them.
We want to get clear separation between different users.

