### PR TITLE
Add official.academy to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12261,6 +12261,10 @@ cistron.nl
 demon.nl
 xs4all.space
 
+// YesCourse Pty Ltd : https://yescourse.com
+// Submitted by Atul Bhouraskar <atul@yescourse.com>
+official.academy
+
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com


### PR DESCRIPTION
YesCourse (https://yescourse.com) allows users to create online Academies which are hosted on our servers but can be available on the users own domain or a sub domain of official.academy chosen by them
eg.
https://yescourse.official.academy/ 
https://courseschool.official.academy/
...

Adding official.academy to the PSL will prevent any sub-domain from setting cookies on official.academy