### PR TITLE
Add fastvps-server.com for FASTVPS EESTI OU

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11461,6 +11461,11 @@ a.ssl.fastly.net
 b.ssl.fastly.net
 global.ssl.fastly.net
 
+// FASTVPS EESTI OU : https://fastvps.ru/
+// Submitted by Likhachev Vasiliy <lihachev@fastvps.ru>
+fastpanel.direct
+fastvps-server.com
+
 // Featherhead : https://featherhead.xyz/
 // Submitted by Simon Menke <simon@featherhead.xyz>
 fhapp.xyz


### PR DESCRIPTION
FASTVPS EESTI OU (https://fastvps.ru/) provides technical domains for it's customers.
fastvps-server.com - for the server itself, so customer can use domain like s056579f2.fastvps-server.com
fastpanel.direct - for our hosting panel, that can be installed on the server

These 3-rd level domains are not related with each other and should not trust each other.
Every domain is used by different server and typically by different customer.