### PR TITLE
Remove nic.in

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1217,7 +1217,6 @@ net.in
 org.in
 gen.in
 ind.in
-nic.in
 ac.in
 edu.in
 res.in


### PR DESCRIPTION
nic.in is considered as an eTLD which makes it diificult for us to monitor the domains under nic.in.