### PR TITLE
remove .htc TLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -8374,9 +8374,6 @@ how
 // hsbc : 2014-10-24 HSBC Holdings PLC
 hsbc
 
-// htc : 2015-04-02 HTC corporation
-htc
-
 // hughes : 2015-07-30 Hughes Satellite Systems Corporation
 hughes
 


### PR DESCRIPTION
.htc has been removed effective 2017-10-24

sources:
1) https://www.iana.org/domains/root/db/htc.html
2) https://github.com/whois/ianawhois/commit/1691d737b8f30c1f217d8db64793e65234a6552b