### PR TITLE
Adding `app.lmpm.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12285,4 +12285,8 @@ za.org
 // Submitted by Olli Vanhoja <olli@zeit.co>
 now.sh
 
+// Lightmaker Property Manager, Inc. : https://app.lmpm.com/
+// Submitted by Greg Holland <greg.holland@lmpm.com>
+app.lmpm.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
We provide subdomains for our clients which should not share cookies, saved passwords, etc

**Example**
customer1.app.lmpm.com
customer2.app.lmpm.com

The above two domains should be treated separately. 