### PR TITLE
adding my provider's TLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5740,6 +5740,7 @@ ro
 arts.ro
 com.ro
 firm.ro
+go.ro
 info.ro
 nom.ro
 nt.ro


### PR DESCRIPTION
Trying to get an SSL certificate via letsencrypt but 'go.ro' is not in this list so getting “Maximal Certificate Requests reached for this domain name”.
```
% Whois Server Version 3.0 - whois.rotld.ro:43

% Rights restricted by copyright.
% Specifically, this data MAY ONLY be used for Internet operational
% purposes. It may not be used for targeted advertising or any
% other purpose.

% Este INTERZISA folosirea datelor de pe acest server in oricare
% alt scop decat operarea retelei. In special este INTERZISA
% folosirea lor in scopuri publicitare.

% Top Level Domain : ro
% Maintainance : www.rotld.ro

  Domain Name: go.ro
  Registered On: Before 2001
  Registrar: ICI - ROTLD
  Referral URL: http://www.rotld.ro

  DNSSEC: Inactive

  Nameserver: ns6.rcs-rds.ro
  Nameserver: ns5.rcs-rds.ro

  Domain Status: OK
```