### PR TITLE
Fix alwaysdata.net.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10596,7 +10596,7 @@ beep.pl
 
 // alwaysdata : https://www.alwaysdata.com
 // Submitted by Cyril <admin@alwaysdata.com>
-*.alwaysdata.net
+alwaysdata.net
 
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com>


### PR DESCRIPTION
I made a mistake when I added alwaysdata.net in #292: our customers have their own subdomain foo.alwaysdata.net, so the suffix is actually alwaysdata.net, not *.alwaysdata.net.