### PR TITLE
Add Teachable domains to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12159,6 +12159,12 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// Teachable : https://www.teachable.com/
+// Submitted by Noah Pryor <noah@teachable.com>
+teachable.com
+usefedora.com
+zeachable.com
+
 // Thingdust AG : https://thingdust.com/
 // Submitted by Adrian Imboden <adi@thingdust.com>
 cust.dev.thingdust.io


### PR DESCRIPTION
We're a course hosting company where every subdomain is its own site. 
We were previously called usefedora, and use zeachable.com for testing/staging

