### PR TITLE
Added d.gt private domain to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10869,6 +10869,10 @@ cloudns.pro
 cloudns.pw
 cloudns.us
 
+// Code404 S.L. : http://code404.es
+// Submitted by Aleix Canal <contact@code404.es>
+*.d.gt
+
 // CoDNS B.V.
 co.nl
 co.no


### PR DESCRIPTION
The *.d.gt namespace is open by all advertisers of the displaybit.com (d.gt) website.