### PR TITLE
Add Now-DNS suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11789,30 +11789,30 @@ nfshost.com
 
 // Now-DNS : https://now-dns.com
 // Submitted by Steve Russell <steve@now-dns.com>
+dnsking.ch
+mypi.co
+n4t.co
 001www.com
+ddnslive.com
+myiphost.com
+forumz.info
 16-b.it
 32-b.it
 64-b.it
-crafting.xyz
-ddnslive.com
-dnsking.ch
-dnsup.net
-dynserv.org
-forumz.info
-freeddns.us
-hicam.net
-myiphost.com
-mypi.co
-n4t.co
-now-dns.net
-now-dns.org
-now-dns.top
-ntdll.top
-ownip.net
 soundcast.me
 tcp4.me
+dnsup.net
+hicam.net
+now-dns.net
+ownip.net
 vpndns.net
+dynserv.org
+now-dns.org
 x443.pw
+now-dns.top
+ntdll.top
+freeddns.us
+crafting.xyz
 zapto.xyz
 
 // nsupdate.info : https://www.nsupdate.info/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11787,6 +11787,34 @@ ngrok.io
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com
 
+// Now-DNS : https://now-dns.com
+// Submitted by Steve Russell <steve@now-dns.com>
+001www.com
+16-b.it
+32-b.it
+64-b.it
+crafting.xyz
+ddnslive.com
+dnsking.ch
+dnsup.net
+dynserv.org
+forumz.info
+freeddns.us
+hicam.net
+myiphost.com
+mypi.co
+n4t.co
+now-dns.net
+now-dns.org
+now-dns.top
+ntdll.top
+ownip.net
+soundcast.me
+tcp4.me
+vpndns.net
+x443.pw
+zapto.xyz
+
 // nsupdate.info : https://www.nsupdate.info/
 // Submitted by Thomas Waldmann <info@nsupdate.info>
 nsupdate.info


### PR DESCRIPTION
Now-DNS is a free provider of Dynamic DNS domains that users can register sub domains against. This pull request covers all our current domains.