### PR TITLE
BoltN NIC semi-TLDs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12285,4 +12285,9 @@ za.org
 // Submitted by Olli Vanhoja <olli@zeit.co>
 now.sh
 
+// BoltN NIC semi-TLDs
+mcmod.pro
+dev.srl
+bltn.gdn
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
On these domains subdomains are delegated down to customers using NS DNS records.