### PR TITLE
Add 1Password domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10585,6 +10585,12 @@ cc.ua
 inf.ua
 ltd.ua
 
+// AgileBits Inc : https://agilebits.com
+// Submitted by Roustem Karimov <roustem@agilebits.com>
+1password.ca
+1password.com
+1password.eu
+
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl


### PR DESCRIPTION
1Password service creates separate subdomain for every team and family account. For example, `https://agilebits.1password.com` and `https://anotherteam.1password.com` should be treated as different sites.

1Password has three geographical regions: 1password.ca, 1password.com, and 1password.eu.