### PR TITLE
Add Portal Cloud user domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11995,6 +11995,10 @@ on-web.fr
 *.platform.sh
 *.platformsh.site
 
+// Portal Cloud, Inc. : https://portal.cloud/
+// Submitted by Jeff Spencer <support@portal.cloud>
+portal.cloud
+
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com


### PR DESCRIPTION
The `portal.cloud` domain is being used for a public DNS and cloud hosting service.

We will verify using DNS TXT records referencing this PR, according to the guidelines.

Thank you for the project, we use and appreciate it!