### PR TITLE
Add Combell domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10873,6 +10873,11 @@ cloudns.us
 co.nl
 co.no
 
+// Combell.com : https://www.combell.com
+// Submitted by Thomas Wouters <thomas.wouters@combellgroup.com>
+webhosting.be
+hosting-cluster.nl
+
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
 dyn.cosidns.de


### PR DESCRIPTION
Request to add `webhosting.be` and `hosting-cluster.nl` as private domains.

Customers get a subdomain assigned for each purchased hosting package which can be used to access their website.