### PR TITLE
Update .ke suffixes to include second-level domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3492,8 +3492,18 @@ uenohara.yamanashi.jp
 yamanakako.yamanashi.jp
 yamanashi.yamanashi.jp
 
-// ke : http://www.kenic.or.ke/index.php?option=com_content&task=view&id=117&Itemid=145
-*.ke
+// ke : http://www.kenic.or.ke/index.php/en/policies-procedure/status-of-existing-second-level-domains
+// http://www.kenic.or.ke/index.php/en/ke-second-level-domain/second-level-domain
+ke
+ac.ke
+co.ke
+go.ke
+info.ke
+me.ke
+mobi.ke
+ne.ke
+or.ke
+sc.ke
 
 // kg : http://www.domain.kg/dmn_n.html
 kg

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3492,8 +3492,7 @@ uenohara.yamanashi.jp
 yamanakako.yamanashi.jp
 yamanashi.yamanashi.jp
 
-// ke : http://www.kenic.or.ke/index.php/en/policies-procedure/status-of-existing-second-level-domains
-// http://www.kenic.or.ke/index.php/en/ke-second-level-domain/second-level-domain
+// ke : http://www.kenic.or.ke/index.php/en/ke-domains/ke-domains
 ke
 ac.ke
 co.ke


### PR DESCRIPTION
kenic has started accepting registrations for second-level domains: http://www.kenic.or.ke/index.php/en/ke-second-level-domain/second-level-domain

Thus, in addition to the pre-existing second-level suffixes we need to add the TLD