### PR TITLE
Add s5y.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12074,6 +12074,7 @@ spdns.org
 
 // SensioLabs, SAS : https://sensiolabs.com/
 // Submitted by Fabien Potencier <fabien.potencier@sensiolabs.com>
+*.s5y.io
 *.sensiosite.cloud
 
 // Service Online LLC : http://drs.ua/


### PR DESCRIPTION
This adds a new domain for SensioCloud (https://sensio.cloud/).

This new entry covers all the regional deployments of the SensioCloud product (eu.s5y.io, us.s5y.io, etc.). The customer subdomains running arbitrary code are subdomains of these regional deployment domains, as in myapp.us.s5y.io.

The new domain will gradually replace the existing one.

DNS update coming just after the PR number has been attributed.
