### PR TITLE
Add linkyard.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11721,6 +11721,7 @@ svn-repos.de
 // linkyard ldt: https://www.linkyard.ch/
 // Submitted by Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
 linkyard.cloud
+linkyard-cloud.ch
 
 // LiquidNet Ltd : http://www.liquidnetlimited.com/
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11718,6 +11718,10 @@ git-repos.de
 lcube-server.de
 svn-repos.de
 
+// linkyard ldt: https://www.linkyard.ch/
+// Submitted by Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
+linkyard.cloud
+
 // LiquidNet Ltd : http://www.liquidnetlimited.com/
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>
 we.bs


### PR DESCRIPTION
We are hosting Atlassian products -as-a-Service under the linkyard.cloud domain.
Since each customer is run on his own instances I'd be great to have cookie isolation. The customer sites are run as xyz.linkyard.cloud.