### PR TITLE
Add zone.id and *.zone.id

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1197,6 +1197,11 @@ or.id
 sch.id
 web.id
 
+// zone.id : https://zone.id
+// Submitted by Su Hendro <admin@zone.id>
+zone.id
+*.zone.id
+
 // ie : https://en.wikipedia.org/wiki/.ie
 ie
 gov.ie


### PR DESCRIPTION
My website https://zone.id is a subdomain provider, which let someone to register a subdomain and park it to their website / blog.
So, the primary domain (zone.id) and the subdomain (*.zone.id) is different website.
then i want Alexa to rank separately between zone.id and its subdomain. But alexa team said: i should submit my domain to publicsuffix.
Please help me.