### PR TITLE
Add dnsbird.org suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10923,6 +10923,44 @@ debian.net
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
+// dnsbird.org : https://dnsbird.org/
+// Submitted by Mia Rehlinger <mia@rehlinger.net>
+es.ax
+ftp.bz
+az.ci
+file.ci
+files.ci
+gb.ci
+nl.ci
+nz.ci
+ws.ci
+mau.lt
+ssh.lu
+toip.me
+es.mk
+gameip.org
+clan.re
+pgp.re
+pics.re
+jp.rs
+ddns.sh
+home.tf
+any.tg
+dev.tg
+exe.tg
+git.tg
+now.tg
+porn.tg
+root.tg
+site.tg
+blog.vu
+cu.vu
+is.vu
+it.vu
+me.vu
+ddns.ws
+meow.ws
+
 // DNShome : https://www.dnshome.de/
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de


### PR DESCRIPTION
These domains are part of dnsbird.org (not public yet), a DNS service which also offers free subdomains / 3rd level domains. I'd like to add these domains to the public suffix list before the service goes public.