### PR TITLE
Add 2038.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12234,6 +12234,10 @@ inc.hk
 // Submitted by Ed Moore <Ed.Moore@lib.de.us>
 lib.de.us
 
+// VeryPositive SIA : http://very.lv
+// Submitted by Danko Aleksejevs <danko@very.lv>
+2038.io
+
 // Viprinet Europe GmbH : http://www.viprinet.com
 // Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management


### PR DESCRIPTION
Hi. 2038.io is a domain for users of 2038.host, a hosting service. Users can host any web content on their corresponding subdomain, so we need this to avoid cookies leaking.