### PR TITLE
remove wildcard from *.compute-1.amazonaws.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10644,7 +10644,7 @@ cloudfront.net
 // Amazon Elastic Compute Cloud : https://aws.amazon.com/ec2/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
 *.compute.amazonaws.com
-*.compute-1.amazonaws.com
+compute-1.amazonaws.com
 *.compute.amazonaws.com.cn
 us-east-1.amazonaws.com
 


### PR DESCRIPTION
@lawells Remove wildcard prefix from compute-1.amazonaws.com.  It appears this entry was added to consolidate {z-1,z-2}.compute-1.amazonaws.com.  These z-1 and z-2 subdomains appears to be deprecated as all DNS entries regularly observed are ec2-XX-XX-XX-XX.compute-1.amazonaws.com