### PR TITLE
Adding customer.speedpartner.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12184,6 +12184,10 @@ apps.lair.io
 // Submitted by Reza Akhavan <spacekit.io@gmail.com>
 spacekit.io
 
+// SpeedPartner GmbH: https://www.speedpartner.de/
+// Submitted by Stefan Neufeind <info@speedpartner.de>
+customer.speedpartner.de
+
 // Stackspace : https://www.stackspace.io/
 // Submitted by Lina He <info@stackspace.io>
 stackspace.space


### PR DESCRIPTION
Subdomains of this are assigned to customers and their servers. Things like cookies set for one of the subdomains must not be set across subdomains.