### PR TITLE
remove wildcard from compute-1.amazonaws.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10644,7 +10644,9 @@ cloudfront.net
 // Amazon Elastic Compute Cloud : https://aws.amazon.com/ec2/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
 *.compute.amazonaws.com
-*.compute-1.amazonaws.com
+compute-1.amazonaws.com
+z-1.compute-1.amazonaws.com
+z-2.compute-1.amazonaws.com
 *.compute.amazonaws.com.cn
 us-east-1.amazonaws.com
 


### PR DESCRIPTION
z-{1,2}.compute-1.amazonaws.com was consolidated to *.compute-1.amazonaws.com but since new instances are being assigned names directly under compute-1.amazonaws.com, this is not exactly accurate.