### PR TITLE
Remove myfusion.cloud domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11566,10 +11566,6 @@ fbxos.fr
 freebox-os.fr
 freeboxos.fr
 
-// Fusion Intranet : https://www.fusion-intranet.com
-// Submitted by Matthias Burtscher <matthias.burtscher@fusonic.net>
-myfusion.cloud
-
 // Futureweb OG : http://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 *.futurecms.at


### PR DESCRIPTION
The domain should be removed from the list since it restricts us from using CloudFront system-wide.