### PR TITLE
Add AWS ElasticBeanstalk Ningxia, CN region

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10672,6 +10672,7 @@ us-east-1.amazonaws.com
 // Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
 cn-north-1.eb.amazonaws.com.cn
+cn-northwest-1.eb.amazonaws.com.cn
 elasticbeanstalk.com
 ap-northeast-1.elasticbeanstalk.com
 ap-northeast-2.elasticbeanstalk.com


### PR DESCRIPTION
This region was added back in early December, it appears that it was
missed from being added to the PSL. The public announcement can be found
here: https://aws.amazon.com/blogs/aws/now-open-aws-china-ningxia-region/