### PR TITLE
Adding `app.lmpm.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11796,6 +11796,10 @@ linkyard-cloud.ch
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>
 we.bs
 
+// Lightmaker Property Manager, Inc. : https://app.lmpm.com/
+// Submitted by Greg Holland <greg.holland@lmpm.com>
+app.lmpm.com
+
 // Lukanet Ltd : https://lukanet.com
 // Submitted by Anton Avramov <register@lukanet.com>
 barsy.bg


### PR DESCRIPTION
We provide subdomains for our clients which should not share cookies, saved passwords, etc

**Example**
customer1.app.lmpm.com
customer2.app.lmpm.com

The above two domains should be treated separately. 