### PR TITLE
Add mozilla-iot.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11834,6 +11834,10 @@ azurewebsites.net
 azure-mobile.net
 cloudapp.net
 
+// Mozilla Corporation : https://mozilla.com
+// Submitted by Ben Francis <bfrancis@mozilla.com>
+mozilla-iot.org
+
 // Mozilla Foundation : https://mozilla.org/
 // Submitted by glob <glob@mozilla.com>
 bmoattachments.org


### PR DESCRIPTION
Mozilla offers free subdomains for Web of Things gateways in people's homes as part of an experimental "Project Things". See https://iot.mozilla.org

Each subdomain points at a different web server under a different user's control so cookies should not be shared across subdomains.

Please use email authentication if possible.

Thanks!