### PR TITLE
Add myqnapcloud.cn

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12100,6 +12100,11 @@ qa2.com
 
 // QNAP System Inc : https://www.qnap.com
 // Submitted by Nick Chang <nickchang@qnap.com>
+dev.myqnapcloud.cn
+qa-nr.myqnapcloud.cn
+qa-bf.myqnapcloud.cn
+alpha.myqnapcloud.cn
+myqnapcloud.cn
 dev-myqnapcloud.com
 alpha-myqnapcloud.com
 myqnapcloud.com


### PR DESCRIPTION
My Service https://www.myqnapcloud.cn is a cloud service provider for QNAP User in China, which let QNAP customer to register a subdomain and mapping to their QNAP NAS.
So, the primary domain (myqnapcloud.cn) and the subdomain (dev.myqnapcloud.cn/qa-nr.myqnapcloud.cn/qa-bf.myqnapcloud.cn/alpha.myqnapcloud.cn) is different Site.

Please help me.