### PR TITLE
Add find.jobs property to .jobs TLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1735,7 +1735,11 @@ mil.jo
 name.jo
 
 // jobs : https://en.wikipedia.org/wiki/.jobs
+// Company : Employ Media, LLC.
+// Submitted by John Winkler <jwinkler@find.jobs>
 jobs
+// Main jobs property
+find.jobs
 
 // jp : https://en.wikipedia.org/wiki/.jp
 // http://jprs.co.jp/en/jpdomain.html


### PR DESCRIPTION
I am an employee of Employ Media and find.jobs, a web property under the .jobs TLD.
Employ Media, LLC. is listed as the registry on the [wiki](https://en.wikipedia.org/wiki/.jobs)

You can contact myself at jwinkler@find.jobs or Ray Fassett at ray@goto.jobs for more information.