### PR TITLE
Removed se.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10844,7 +10844,6 @@ no.com
 qc.com
 ru.com
 sa.com
-se.com
 se.net
 uk.com
 uk.net


### PR DESCRIPTION
The domain se.com is under new ownership and is no longer a public suffix. This will be reflected with the correct TXT DNS records shortly.

This is a correction for pull request 613.