### PR TITLE
Add YunoHost DynDns domains: nohost.me & noho.st

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12384,6 +12384,11 @@ ybo.review
 ybo.science
 ybo.trade
 
+// Yunohost : https://yunohost.org
+// Submitted by Valentin Grimaud <security@yunohost.org>
+nohost.me
+noho.st
+
 // ZaNiC : http://www.za.net/
 // Submitted by registry <hostmaster@nic.za.net>
 za.net


### PR DESCRIPTION
# Reason of this Pull Request
YunoHost is a server operating system aiming to make self-hosting accessible to everyone.
We provide dyndns subdomain  `noho.st` and `nohost.me` to our users, allowing them to self-host some services without the need of buying a personnal domain and with the advantage to bypass some ISPs dynamic IP and to configure DNS entries automatically.

It could be very usefull, if browser could correctly manage those subdomains (cookies, highlighting the subdomain, sorting by subdomain and not all the domain ). We want these services to be recognized as a known public suffix and dyndns services too.

# Dig request output

```
dig +short TXT _psl.noho.st
"https://github.com/publicsuffix/list/pull/615"
```
and
```
dig +short TXT _psl.nohost.me
"https://github.com/publicsuffix/list/pull/615"
```

# Make test
Here are the validated `make test`
https://paste.yunohost.org/mixofawodi.swift

# Extra info
There was an old PR ( #250 ) done by an old contributor (opi) to the yunohost project, the issue was the lack of a contact clearly identify by his firstname/lastname. The PR has been closed, I was not able to reopen it.

I am a member of the yunohost council (the decision-making body of the Yunohost project). I have been mandated by the YunoHost Council the 27th february 2018 during a meeting to open this PR with the "submitted by Valentin GRIMAUD" instead of "submitted by YunoHost" as you requested it. I have put the security [at] yunohost.org mailing list as email contact (more appropriate) but if you want insist I can edit this PR with the personnal valentin.grimaud [at] yunohost.org instead.

I am also known as ljf inside the YunoHost community. I have made the PR directly from a fork hosted on our official organization on github.
