### PR TITLE
add *.uberspace.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12321,6 +12321,7 @@ synology-ds.de
 // Uberspace : https://uberspace.de
 // Submitted by Moritz Werner <mwerner@jonaspasche.com>
 uber.space
+*.uberspace.de
 
 // UDR Limited : http://www.udr.hk.com
 // Submitted by registry <hostmaster@udr.hk.com>


### PR DESCRIPTION
We're a hosting company and we're using *.uberspace.de for our customers content. Every account gets its own mydomain.*.uberspace.de domain. For cookie isolation it would be great to get included in the public suffix list.