### PR TITLE
Syncloud dynamic dns service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12647,4 +12647,8 @@ now.sh
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+// Syncloud : https://syncloud.org
+// Submitted by Boris Rybalkin <syncloud@syncloud.it>
+syncloud.it
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
I would like to add syncloud.it as we are distributing devices with per user dns for example user1.syncloud.it.

dig TXT _psl.syncloud.it