### PR TITLE
Add freedesktop.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11571,6 +11571,10 @@ fbxos.fr
 freebox-os.fr
 freeboxos.fr
 
+// freedesktop.org : https://www.freedesktop.org
+// Submitted by Daniel Stone <daniel@fooishbar.org>
+freedesktop.org
+
 // Futureweb OG : http://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 *.futurecms.at


### PR DESCRIPTION
freedesktop.org is a site hosting a number of diverse open-source communities.