### PR TITLE
Add Bytemark Hosting domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10819,6 +10819,12 @@ square7.net
 // Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
 browsersafetymark.io
 
+// Bytemark Hosting : https://www.bytemark.co.uk
+// Submitted by Paul Cammish <paul.cammish@bytemark.co.uk>
+uk0.bigv.io
+dh.bytemark.co.uk
+vm.bytemark.co.uk
+
 // callidomus : https://www.callidomus.com/
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu


### PR DESCRIPTION
Specifically `uk0.bigv.io`, `dh.bytemark.co.uk`, and `vm.bytemark.co.uk`.

Bytemark Hosting provides both dedicated and virtual servers on the above domains, with customer host  provided subdomains (and sub-sub domains) of the above.

Relevant TXT records should be along soon.