### PR TITLE
cloud.muni.cz cloud subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11824,6 +11824,11 @@ hb.cldmail.ru
 cloud.metacentrum.cz
 custom.metacentrum.cz
 
+// MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
+// Submitted by Radim Janča <janca@cesnet.cz>
+flt.cloud.muni.cz
+usr.cloud.muni.cz
+
 // Meteor Development Group : https://www.meteor.com/hosting
 // Submitted by Pierre Carrier <pierre@meteor.com>
 meteorapp.com


### PR DESCRIPTION
Arranging for appropriate TXT records now.

This is a public IaaS cloud service for academic use, provided by cooperation of https://www.metacentrum.cz/en, http://www.ics.muni.cz/ and https://www.cerit-sc.cz/.

The DNS structure is flat. Domain names used for virtual machines provisioned in the cloud are for instance:

snowflake252.flt.cloud.muni.cz
snowflake215.flt.cloud.muni.cz

We will also deploy a Dynamic DNS service, where users will be able to set up DNS names for their virtual machines. These names will go to the usr zone, i.e., the names will be:

foo.usr.cloud.muni.cz
bar.usr.cloud.muni.cz