### PR TITLE
Add dattoweb.com, dattorelay.com, dattolocal.net, dattolocal.com, mydatto.net and mydatto.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10984,12 +10984,12 @@ localhost.daplie.me
 
 // Datto, Inc. : https://www.datto.com/
 // Submitted by Philipp Heckel <ph@datto.com>
-dattoweb.com
-dattorelay.com
-dattolocal.net
 dattolocal.com
-mydatto.net
+dattorelay.com
+dattoweb.com
 mydatto.com
+dattolocal.net
+mydatto.net
 
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10982,6 +10982,15 @@ cyon.site
 daplie.me
 localhost.daplie.me
 
+// Datto, Inc. : https://www.datto.com/
+// Submitted by Philipp Heckel <ph@datto.com>
+dattoweb.com
+dattorelay.com
+dattolocal.net
+dattolocal.com
+mydatto.net
+mydatto.com
+
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>
 biz.dk


### PR DESCRIPTION
[Datto](https://www.datto.com/) is a backup and disaster recovery company. We sell backup appliances and we'd like to add Let's Encrypt based HTTPS support with custom domains to them.  

```
$ dig TXT _psl.dattolocal.net +short
"https://github.com/publicsuffix/list/pull/624"

$ dig TXT _psl.mydatto.net +short   
"https://github.com/publicsuffix/list/pull/624"

$ dig TXT _psl.dattoweb.com +short   
"https://github.com/publicsuffix/list/pull/624"

$ dig TXT _psl.dattolocal.com +short
"https://github.com/publicsuffix/list/pull/624"

$ dig TXT _psl.dattorelay.com +short
"https://github.com/publicsuffix/list/pull/624"

$ dig TXT _psl.mydatto.com +short 
"https://github.com/publicsuffix/list/pull/624"
```

Edit: All domain TXT records have now been propagated. 