### PR TITLE
Add memset.net and miniserver.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11819,6 +11819,11 @@ barsy.support
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru
 
+// Memset hosting : https://www.memset.com
+// Submitted by Tom Whitwell <domains@memset.com>
+miniserver.com
+memset.net
+
 // MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
 // Submitted by Zdeněk Šustr <zdenek.sustr@cesnet.cz>
 cloud.metacentrum.cz


### PR DESCRIPTION
[Memset Hosting](https://www.memset.com) is a dedicated and VPS hosting provider. These are domains we use for customer hosted dedicated servers and VPS's (ie. `customer.memset.net`)

## Reasons for listing

We need these domains to be in the public suffix list as each subdomain is specific to one customer server: cookie isolation is required.

Additionally, we have recently had memset.net blacklisted by Google - one of our customers was hosting malware, and the whole *.memset.net domain was blacklisted. We have been advised by StopBadware to request addition to the Public Suffix list:

> Google assumes by default that a domain is used entirely by one entity. If instead you are using this domain as a TLD, you should have the owner of the domain request its addition to the Public Suffix List: https://publicsuffix.org/.

## Proof

```
dig +short TXT _psl.memset.net
"https://github.com/publicsuffix/list/pull/625"
dig +short TXT _psl.miniserver.com
"https://github.com/publicsuffix/list/pull/625"
```