### PR TITLE
Add utwente.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12227,6 +12227,10 @@ stackspace.space
 // Submitted by Philip Hutchins <hostmaster@storj.io>
 storj.farm
 
+// Studenten Net Twente : http://www.snt.utwente.nl/
+// Submitted by Silke Hofstra <syscom@snt.utwente.nl>
+utwente.io
+
 // Sub 6 Limited: http://www.sub6.com
 // Submitted by Dan Miller <dm@sub6.com>
 temp-dns.com


### PR DESCRIPTION
utwente.io is used for GitLab Pages and thus allows arbitrary users to host websites on arbitrary subdomains.

Update - TXT record is in place:
```
$ dig txt _psl.utwente.io +short
"https://github.com/publicsuffix/list/pull/626"
```