### PR TITLE
Add AWS ElasticBeanstalk Osaka, JP region

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10676,6 +10676,7 @@ cn-north-1.eb.amazonaws.com.cn
 elasticbeanstalk.com
 ap-northeast-1.elasticbeanstalk.com
 ap-northeast-2.elasticbeanstalk.com
+ap-northeast-3.elasticbeanstalk.com
 ap-south-1.elasticbeanstalk.com
 ap-southeast-1.elasticbeanstalk.com
 ap-southeast-2.elasticbeanstalk.com


### PR DESCRIPTION
The new region was announced in February here: https://aws.amazon.com/jp/blogs/news/osaka-local-region-launch-2018feb/