### PR TITLE
Submit bci.dnstrace.pro

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11327,6 +11327,10 @@ ddnss.org
 definima.net
 definima.io
 
+// dnstrace.pro : https://dnstrace.pro/
+// Submitted by Chris Partridge <chris@partridge.tech>
+bci.dnstrace.pro
+
 // Dynu.com : https://www.dynu.com/
 // Submitted by Sue Ye <sue@dynu.com>
 ddnsfree.com


### PR DESCRIPTION
dnstrace is a user-run domain intelligence data aggregator. We will be running untrusted nodes in subdomains under bci.dnstrace.pro, so cookie isolation is important to ensure no rogue node could steal information. Thus, the request.

TXT record is also in place:
`;QUESTION
_psl.bci.dnstrace.pro. IN TXT`
`;ANSWER
_psl.bci.dnstrace.pro. 299 IN TXT "https://github.com/publicsuffix/list/pull/630"`