### PR TITLE
Remove 1password domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10640,12 +10640,6 @@ cc.ua
 inf.ua
 ltd.ua
 
-// AgileBits Inc : https://agilebits.com
-// Submitted by Roustem Karimov <roustem@agilebits.com>
-1password.ca
-1password.com
-1password.eu
-
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl


### PR DESCRIPTION
We had a few issues and for now it would be easier if we do not have 1password domains listed in PSL.