### PR TITLE
Add cnpy.gdn as private domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10940,6 +10940,10 @@ cloudns.us
 // Submitted by Stefan Dimitrov <contact@cloudeity.com>
 cloudeity.net
 
+// CNPY : https://cnpy.gdn
+// Submitted by Angelo Gladding <angelo@lahacker.net>
+cnpy.gdn
+
 // CoDNS B.V.
 co.nl
 co.no


### PR DESCRIPTION
`cnpy.gdn` will serve as a namespace for customers' personal websites.

    alice.cnpy.gdn
    bob.cnpy.gdn
    carol.cnpy.gdn

Each site should stand independent. Cookies should not be shared across subdomains.