### PR TITLE
Add cleverapps.io (Clever Cloud)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10889,6 +10889,10 @@ xenapponazure.com
 // Submitted by Leon Rowland <leon@clearvox.nl>
 virtueeldomein.nl
 
+// Clever Cloud : https://www.clever-cloud.com/
+// Submitted by Quentin Adam <noc@clever-cloud.com>
+cleverapps.io
+
 // Cloud66 : https://www.cloud66.com/
 // Submitted by Khash Sajadi <khash@cloud66.com>
 c66.me


### PR DESCRIPTION
`cleverapps.io` is a privately-owned domain.

* When a client deploys an app on Clever Cloud, it is assigned a domain like this: [random-UUID].cleverapps.io
* A client a also set a specific [myname].cleverapps.io.

All subdomains of cleverapps.io are considered mutually-untrusting parties/clients.
As such we request that it is added to the private section of the Public Suffix List.

Examples of apps deployed by clients:

* https://adminer.cleverapps.io/
* http://streamline-emojis.cleverapps.io
* https://json2caseclass.cleverapps.io/