### PR TITLE
These domains are used to host member subdomains.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11826,8 +11826,8 @@ barsy.support
 
 // May First - People Link : https://mayfirst.org/
 // Submitted by Jamie McClelland <info@mayfirst.org>
-mayfirst.org
 mayfirst.info
+mayfirst.org
 
 // Mail.Ru Group : https://hb.cldmail.ru
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11824,6 +11824,11 @@ barsy.support
 // Submitted by Damien Tournoud <dtournoud@magento.cloud>
 *.magentosite.cloud
 
+// May First - People Link : https://mayfirst.org/
+// Submitted by Jamie McClelland <info@mayfirst.org>
+mayfirst.org
+mayfirst.info
+
 // Mail.Ru Group : https://hb.cldmail.ru
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru


### PR DESCRIPTION
Members can create their own subdomains using either
[member].mayfirst.org or [member].mayfirst.info.