### PR TITLE
Add nic.ro TLDs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5790,16 +5790,20 @@ asso.re
 com.re
 nom.re
 
-// ro : http://www.rotld.ro/
+// ro : http://www.rotld.ro/ and http://www.nic.ro/
 ro
 arts.ro
+co.ro
 com.ro
 firm.ro
 info.ro
 nom.ro
 nt.ro
+or.ro
 org.ro
 rec.ro
+sa.ro
+srl.ro
 store.ro
 tm.ro
 www.ro


### PR DESCRIPTION
> For example local or global Business with .CO.RO where 'co' is for co-mmercial.
> Or a srl Company "Societate cu răspundere limitată" with our .SRL.RO extension.
> Or a Corporation with .SA.RO ("Societate pe Actiuni").
> An or-ganisation with the .OR.RO suffix

Source: http://co.ro/ http://www.nic.ro/