### PR TITLE
Add *.otap.co

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10924,6 +10924,10 @@ cloudcontrolapp.com
 // co.ca : http://registry.co.ca/
 co.ca
 
+// Co & Co : https://co-co.nl/
+// Submitted by Govert Versluis <govert@co-co.nl>
+*.otap.co
+
 // i-registry s.r.o. : http://www.i-registry.cz/
 // Submitted by Martin Semrad <semrad@i-registry.cz>
 co.cz


### PR DESCRIPTION
Co & Co is a bespoke software developer for a wide variety of clients.
We use otap.co as a domain for test environments, acceptance environments and on the fly hosting of short and long lived experiments. We would like to add stronger (cookie) isolation between these domains, as well as benefit from any additional effects the PSL might bring us in terms of browser UI, etc.

Domain names on otap.co always have four labels total in the form of {project}.{client}.otap.co, hence the wildcard.

Examples:
a.x.otap.co should be isolated from b.x.otap.co. Both should also be isolated from c.y.otap.co.
inner1.a.x.otap.co is not isolated from a.x.otap.co.