### PR TITLE
Add cloudycluster.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12227,6 +12227,10 @@ nom.vg
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
 
+// Omnibond Systems, LLC. : www.omnibond.com
+// Submitted by Cole Estep <cole@omnibond.com>
+cloudycluster.net
+
 // One Fold Media : http://www.onefoldmedia.com/
 // Submitted by Eddie Jones <eddie@onefoldmedia.com>
 nid.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12227,7 +12227,7 @@ nom.vg
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
 
-// Omnibond Systems, LLC. : www.omnibond.com
+// Omnibond Systems, LLC. : https://www.omnibond.com
 // Submitted by Cole Estep <cole@omnibond.com>
 cloudycluster.net
 


### PR DESCRIPTION
CloudyCluster is used to quickly spin up HPC Clusters and manage them from mobile or desktop devices.   We assign subdomains of cloudycluster.net to clusters that our customers start.  For security reasons, different clusters should not share cookies and other data.  We use cloudycluster.net only for our customers' subdomains.  