### PR TITLE
Add wien.funkfeuer.at

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11664,6 +11664,10 @@ freeboxos.fr
 // Submitted by Daniel Stone <daniel@fooishbar.org>
 freedesktop.org
 
+// FunkFeuer - Verein zur Förderung freier Netze : http://www.funkfeuer.at
+// Submitted by Wolfgang Nagele <mail@wnagele.com>
+wien.funkfeuer.at
+
 // Futureweb OG : http://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 *.futurecms.at


### PR DESCRIPTION
FunkFeuer is an association with various initiatives throughout Austria. These initiatives all have their own sub-domain within the funkfeuer.at namespace. These sub-domains are fully delegated out to the initiatives and allocate their member domains underneath as they see fit. This adds the community sub-domain for Vienna.