### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5765,6 +5765,7 @@ eng.pro
 jur.pro
 law.pro
 med.pro
+nitr.pro 
 recht.pro
 
 // ps : https://en.wikipedia.org/wiki/.ps


### PR DESCRIPTION
Add nitr.pro on ICANN List Suffix of PSL

/ RegistryPRO Northern Ireland and Tyrone: http://www.registry.nitr.pro
+// Submitted by Saymon Rhuano saymonrhuano@gmail.com
+nitr.pro