### PR TITLE
Add bbs.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12647,4 +12647,7 @@ now.sh
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+// bbs.io - https://www.bbs.io/
+// Submitted by Michael J. Ryan <tracker1@gmail.com>
+bbs.io
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
bbs.io was registered to offer a good dyndns option for bulletin board systems.