### PR TITLE
Adds hasura.app to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11794,6 +11794,7 @@ hashbang.sh
 
 // Hasura : https://hasura.io
 // Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura.app
 hasura-app.io
 
 // Hepforge : https://www.hepforge.org


### PR DESCRIPTION
Similar to `hasura-app.io`, with the introduction of new `app` TLD, Hasura allocates sub-domains on `hasura.app` for the clusters users create on it's platform. A user should not be able to set cookies across these subdomains, apart from their own.