### PR TITLE
Add lublin.pl and some other regional domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11925,6 +11925,15 @@ linkyard-cloud.ch
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>
 we.bs
 
+// LubMAN UMCS Sp. z o.o : https://lubman.pl/
+// Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
+krasnik.pl
+leczna.pl 
+lubartow.pl
+lublin.pl
+poniatowa.pl
+swidnik.pl
+
 // Lug.org.uk : https://lug.org.uk
 // Submitted by Jon Spriggs <admin@lug.org.uk>
 uklugs.org


### PR DESCRIPTION
LubMAN UMCS sp. z o.o. is a hosting provider that provides to our customers website services, DNS and SSL certificates with LetsEncrypt within following domains: krasnik.pl, leczna.pl, lubartow.pl, lublin.pl, poniatowa.pl and swidnik.pl.
All these are regional domains in which local companies register their individual private subdomains.
For cookie isolation, SSL management, Direct URL translation, and the inevitable developments in security, it would be great to get added to the public suffix list.