### PR TITLE
Superseded by 726

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12498,6 +12498,9 @@ sopot.pl
 // Telebit : https://telebit.cloud
 // Submitted by AJ ONeal <coolaj86@gmail.com>
 telebit.cloud
+telebit.io
+telebit.xyz
+telebit.fun
 
 // The Gwiddle Foundation : https://gwiddlefoundation.org.uk
 // Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12495,6 +12495,10 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// Telebit : https://telebit.cloud
+// Submitted by AJ ONeal <coolaj86@gmail.com>
+telebit.cloud
+
 // The Gwiddle Foundation : https://gwiddlefoundation.org.uk
 // Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
 gwiddle.co.uk


### PR DESCRIPTION
Superseded by #726 (waiting to close this until the new one is reviews so that the email about this being closed won't be confused with the new issue being closed)

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Telebit
====

Organization Website: <https://ppl.family>
Product Website: <https://telebit.cloud>

I'm the owner and operator of <https://ppl.family>, which offers a number a products and services related to home servers, self-hosting, and social file and document sharing.

We're getting ready to launch https://telebit.cloud, which is an authenticated relay service to allow developers to connect a testable public domain to private devices and services - such as apps running in development on localhost and IoT devices and Raspberry Pis behind school firewalls.

![terminal-example-1](https://user-images.githubusercontent.com/122831/43668582-f3e4f5a2-973a-11e8-81ff-ecc1a4e3c48b.png)

Reason for adding Telebit domains
====

Essentially it's an open source alternative to services like ngrok and localtunnel.me

Each device gets a semi-random subdomain on one of our domains (such as lucky-duck-42.telebit.cloud) with unlimited subdomains (i.e. office.lucky-duck-42.telebit.cloud).

We want to remove the rate-limit restrictions of Let's Encrypt as well has have separate cookies for each of the sites.

DNS Verification
=====

```
dig TXT +short _psl.telebit.cloud
"https://github.com/publicsuffix/list/pull/672"
```

```
dig TXT +short _psl.telebit.io
"https://github.com/publicsuffix/list/pull/672"
```

```
dig TXT +short _psl.telebit.xyz
"https://github.com/publicsuffix/list/pull/672"
```

```
dig TXT +short _psl.telebit.fun
"https://github.com/publicsuffix/list/pull/672"
```

make test
=======

Syntax is correct.