### PR TITLE
Add gittub.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11698,6 +11698,10 @@ githubusercontent.com
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
 
+// GitTub : https://gittub.io
+// Submitted by Kullawat Chaowanawatee <e29qwg@gmail.com>
+gittub.io
+
 // UKHomeOffice : https://www.gov.uk/government/organisations/home-office
 // Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
 homeoffice.gov.uk


### PR DESCRIPTION
gittub.io hosted GitLab and provides subdomains for GitLab Pages to users.