### PR TITLE
Add pages.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11661,6 +11661,10 @@ firebaseapp.com
 flynnhub.com
 flynnhosting.net
 
+// Pages: https://pages.sh
+// Submitted by Will Huxtable <w@zif.io>
+pages.sh
+
 // Freebox : http://www.freebox.fr
 // Submitted by Romain Fliedel <rfliedel@freebox.fr>
 freebox-os.com


### PR DESCRIPTION
Pages.sh is the domain used to provide GitLab pages access for members of the fork.sh community. As they each get a subdomain, I made this request - it is also recommended by the GitLab documentation.