### PR TITLE
Add pages.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12279,6 +12279,10 @@ pgfog.com
 // Submitted by Jason Kriss <jason@pagefronthq.com>
 pagefrontapp.com
 
+// Pages: https://pages.sh
+// Submitted by Will Huxtable <w@zif.io>
+pages.sh
+
 // .pl domains (grandfathered)
 art.pl
 gliwice.pl


### PR DESCRIPTION
Pages.sh is the domain used to provide GitLab pages access for members of the fork.sh community. As they each get a subdomain, I made this request - it is also recommended by the GitLab documentation.

(sorry for the second PR, managed to mess up the first one)