### PR TITLE
Add ssl.fun

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12432,6 +12432,10 @@ bounty-full.com
 alpha.bounty-full.com
 beta.bounty-full.com
 
+// ssl.fun : https://ssl.fun
+// Submitted by Markus Hänel <ssl@ssl.fun>
+*.ssl.fun
+
 // staticland : https://static.land
 // Submitted by Seth Vincent <sethvincent@gmail.com>
 static.land


### PR DESCRIPTION
ssl.fun is a free service allowing users to register subdomains programmatically.

The wildcard is set in accordance with the allowed format:

```bash
# valid
example.com.ssl.fun
foobar.de.ssl.fun
baz.foobar.de.ssl.fun

# invalid
example.ssl.fun
com.ssl.fun
```

DNS ownership proof:
```bash
❯❯❯ dig TXT +short _psl.ssl.fun
"https://github.com/publicsuffix/list/pull/683"
```


