### PR TITLE
Add pub.cloud.scaleway.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12378,6 +12378,10 @@ sandcats.io
 logoip.de
 logoip.com
 
+// Scaleway : https://www.scaleway.com/
+// Submitted by Jeremy Therin <jtherin@scaleway.com>
+pub.cloud.scaleway.com
+
 // schokokeks.org GbR : https://schokokeks.org/
 // Submitted by Hanno Böck <hanno@schokokeks.org>
 schokokeks.net


### PR DESCRIPTION
Scaleway is a cloud provider, we assign a subdomain under pub.cloud.scaleway.com for each instance. For security reasons, different instances should not share cookies and other data.