### PR TITLE
Add bss.design

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12654,6 +12654,10 @@ za.org
 // Submitted by Olli Vanhoja <olli@zeit.co>
 now.sh
 
+// Zine EOOD : https://zine.bg/
+// Submitted by Martin Angelov <martin@zine.bg>
+bss.design
+
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>
 zone.id


### PR DESCRIPTION
One of the products our company develops allows users to publish websites as subdomains under the `bss.design` domain name. Examples:

```
https://example.bss.design
https://foobar.bss.design
```

This pull request adds `bss.design` to the list.