### PR TITLE
Added KingHost domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12658,4 +12658,11 @@ now.sh
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+//KingHost : https://king.host
+// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
+kinghost.com.br
+kinghost.net
+king.host
+uni5.net
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11942,6 +11942,13 @@ js.org
 // Submitted by Martin Dannehl <postmaster@keymachine.de>
 keymachine.de
 
+//KingHost : https://king.host
+// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
+kinghost.com.br
+kinghost.net
+king.host
+uni5.net
+
 // KnightPoint Systems, LLC : http://www.knightpoint.com/
 // Submitted by Roy Keene <rkeene@knightpoint.com>
 knightpoint.systems
@@ -12764,12 +12771,5 @@ site.builder.nu
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
-
-//KingHost : https://king.host
-// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
-kinghost.com.br
-kinghost.net
-king.host
-uni5.net
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Our host company provides free subdomains for our customers:

>  kinghost.com.br
>  kinghost.net
>  king.host
>  uni5.net

This pull request add this subdomains