### PR TITLE
Added MythCoders, LLC

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12025,6 +12025,10 @@ net.ru
 org.ru
 pp.ru
 
+// MythCoders, LLC : https://www.mythcoders.com
+// Submitted by Justin Adkins <justin.adkins@mythcoders.com>
+mythcoders.net
+
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
 bitballoon.com


### PR DESCRIPTION
Domain is used for [GitLab Pages](https://docs.gitlab.com/ee/administration/pages/#add-the-domain-to-the-public-suffix-list), a tool that allows groups to host static websites.