### PR TITLE
Added antiquariatssoftware.com for our customers pages

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12658,4 +12658,8 @@ now.sh
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+// Guthschrift-Systems : http://guthschrift-systems.com
+// Submitted by Pasqual Brettner <p.brettner@bee.de>
+antiquariatssoftware.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Hello,
we host a software (online-shop) for our customers and they get a subdomain (e.g paket1.antiquariatssoftware.com) for their shop hosted by us. We ran into problems with the letsencrypt rate-limit for subdomains so that some of our customers can't secure their pages with SSL now. Please consider adding antiquariatssoftware.com to the list.

Kind regards
Pasqual B.