### PR TITLE
Added git-pages.rit.edu

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12369,6 +12369,10 @@ wellbeingzone.eu
 ptplus.fit
 wellbeingzone.co.uk
 
+// Rochester Institute of Technology : http://www.rit.edu/
+// Submitted by Jennifer Herting <jchits@rit.edu>
+git-pages.rit.edu
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io


### PR DESCRIPTION
# Purpose of the site referenced

A GitLab pages hosting instance for the Rochester Institute of Technology community. 

# Reason for site to be added

* Proper handling of the namespace by browsers.
* Prevention of cookie based attacks among others. Sites hosted under this namespace will be controlled by any number of students, staff, faculty, etc.

# Authentication

```
dig TXT _psl.git-pages.rit.edu +short
"https://github.com/publicsuffix/list/pull/690"
```

# About the organization 

Rochester Institute of Technology is a university in Rochester, New York. More information can be found at [our website](https://www.rit.edu/overview/rit-in-brief).

# About me

I am a full time staff member in the Information Technology Services organization, primarily working with Research Computing but assist with other areas as well.