### PR TITLE
htts://www.transip.nl => https://www.transip.nl

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12527,7 +12527,7 @@ lima-city.rocks
 webspace.rocks
 lima.zone
 
-// TransIP : htts://www.transip.nl
+// TransIP : https://www.transip.nl
 // Submitted by Rory Breuk <rbreuk@transip.nl>
 *.transurl.be
 *.transurl.eu


### PR DESCRIPTION
`s` suggests that `https` was meant and not `http`