### PR TITLE
Added instantcloud.cn by Redstar Consultants

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12321,6 +12321,10 @@ protonet.io
 chirurgiens-dentistes-en-france.fr
 byen.site
 
+// Redstar Consultants : https://www.redstarconsultants.com/
+// Submitted by Jons Slemmer <jons@redstarconsultants.com>
+instantcloud.cn
+
 // Russian Academy of Sciences
 // Submitted by Tech Support <support@rasnet.ru>
 ras.ru


### PR DESCRIPTION
Redstar Consultants provides various services to companies starting in or expanding their business to China. Domains within this suffix are used to provide clients a method to internally validate their business project on Chinese cloud hosting services usually before being hosted on their own domain and/or being made publicly accessible.

Being added to the public suffix list is required to avoid lets encrypt limitations and to aim for a clear separation between multiple client projects.