### PR TITLE
Add Swisscom Application Cloud domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12466,6 +12466,11 @@ utwente.io
 // Submitted by Dan Miller <dm@sub6.com>
 temp-dns.com
 
+// Swisscom Application Cloud: https://developer.swisscom.com
+// Submitted by Matthias.Winzeler <matthias.winzeler@swisscom.com>
+applicationcloud.io
+scapp.io
+
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>
 diskstation.me


### PR DESCRIPTION
We at Swisscom offer a CloudFoundry based PaaS called Application cloud (https://developer.swisscom.com) where end users can host their apps under `<app-a>.scapp.io` or `<app-a>.applicationcloud.io`.

Therefore, each subdomain of scapp.io and applicationcloud.io should be treated as a distinct domain.

I'll add DNS verification ASAP.