### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12657,3 +12657,13 @@ now.sh
 zone.id
 
 // ===END PRIVATE DOMAINS===
+
+// Lifetime Hosting : https://Lifetime.Hosting/
+// Submitted by Mike Fillator <support@lifetime.hosting>
+co.business
+co.education
+co.events
+co.financial
+co.network
+co.place
+co.technology


### PR DESCRIPTION
I am the general manager for a hosting company (https://lifetime.hosting) and we provide subdomains (SLDs) to our customers. For cookie isolation, SSL management, Direct URL translation, and the inevitable developments in security, it would be great to get added to the public suffix list.

[~]# dig +short TXT _psl.co.business
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.education
"h ttps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.technology
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.events
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.financial
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.network
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.place
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.technology
"ht tps://github.com/publicsuffix/list/pull/598"

Spaces added to disable Markdown Auto linking (I am certain that there is a better more sophisticated way to fix that, but I am neither patient nor smart enough to research it).