### PR TITLE
Add lifetime.hosting domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11920,6 +11920,16 @@ git-repos.de
 lcube-server.de
 svn-repos.de
 
+// Lifetime Hosting : https://Lifetime.Hosting/
+// Submitted by Mike Fillator <support@lifetime.hosting>
+co.business
+co.education
+co.events
+co.financial
+co.network
+co.place
+co.technology
+
 // Lightmaker Property Manager, Inc. : https://app.lmpm.com/
 // Submitted by Greg Holland <greg.holland@lmpm.com>
 app.lmpm.com


### PR DESCRIPTION
I am the general manager for a hosting company (https://lifetime.hosting) and we provide subdomains (SLDs) to our customers. For cookie isolation, SSL management, Direct URL translation, and the inevitable developments in security, it would be great to get added to the public suffix list.

[~]# dig +short TXT _psl.co.business
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.education
"h ttps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.technology
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.events
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.financial
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.network
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.place
"ht tps://github.com/publicsuffix/list/pull/598"

[~]# dig +short TXT _psl.co.technology
"ht tps://github.com/publicsuffix/list/pull/598"

Spaces added to disable Markdown Auto linking (I am certain that there is a better more sophisticated way to fix that, but I am neither patient nor smart enough to research it).

I think I have finally got it right this time