### PR TITLE
Add Fermax and mydobiss.com domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11650,6 +11650,10 @@ cloud.fedoraproject.org
 app.os.fedoraproject.org
 app.os.stg.fedoraproject.org
 
+// Fermax : https://fermax.com/
+// submitted by Koen Van Isterdael <k.vanisterdael@fermax.be>
+mydobiss.com
+
 // Filegear Inc. : https://www.filegear.com
 // Submitted by Jason Zhu <jason@owtware.com>
 filegear.me


### PR DESCRIPTION
Dobiss is a home automation system produced by Fermax. Individual users
can get cloud access to their home system through an automatically
registered <user>.mydobiss.com domain. User foo.mydobiss.com should not
share cookies or other data by bar.mydobiss.com.

In principle a user should not get direct access to his own
<user>.mydobiss.com domain, but as a defense-in-depth measure it is
better not to propagate this trust.