### PR TITLE
Add public suffix entries for dapps.earth

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11084,6 +11084,11 @@ firm.dk
 reg.dk
 store.dk
 
+// dapps.earth : https://dapps.earth/
+// Submitted by Daniil Burdakov <icqkill@gmail.com>
+*.dapps.earth
+*.bzz.dapps.earth
+
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net


### PR DESCRIPTION
# Reason of this pull request

[dapps.earth](https://dapps.earth/) is an HTTP gateway into IPFS/Swarm.

Anyone can effectively create websites at the following subdomains (by uploading content into IPFS or Swarm/ENS):
1) `*.ipfs.dapps.earth` (example: `bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dapps.earth`)
2) `*.bzz-immutable.dapps.earth` (example: `h4cpab3mz443iehtiipfi5vj46pnytrspvm5peu2u2wz7rz7m4vq.bzz-immutable.dapps.earth`)
3) `*.*.bzz.dapps.earth` (example: `theswarm.eth.dapps.earth`)

Therefore, to isolate cookies of all hosted websites, I suggest adding the following public suffix records:
1) `*.dapps.earth`
2) `*.bzz.dapps.earth`

Similarly for `staging.dapps.earth`, which runs testing version of the same website.

# DNS verification

```
dig +short TXT _psl.dapps.earth
"https://github.com/publicsuffix/list/pull/708"
dig +short TXT _psl.bzz.dapps.earth
"https://github.com/publicsuffix/list/pull/708"
dig +short TXT _psl.staging.dapps.earth
"https://github.com/publicsuffix/list/pull/708"
dig +short TXT _psl.bzz.staging.dapps.earth
"https://github.com/publicsuffix/list/pull/708"
```

make test
=========
Passed: http://termbin.com/ym4m