### PR TITLE
add domains of Individual Network Berlin e.V.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11836,6 +11836,19 @@ moonscale.net
 // Submitted by Hannu Aronsson <haa@iki.fi>
 iki.fi
 
+// Individual Network Berlin e.V. : https://www.in-berlin.de/
+// Submitted by Christian Seitz <chris@in-berlin.de>
+in-berlin.de
+in-brb.de
+in-dsl.de
+in-dsl.net
+in-dsl.org
+in-vpn.de
+in-vpn.net
+in-vpn.org
+in-butter.de
+dyn-berlin.de
+
 // info.at : http://www.info.at/
 biz.at
 info.at


### PR DESCRIPTION
Description of Organization
====

IN-Berlin e.V. ( https://www.in-berlin.de/ ) is a non-profit organisation that provides internet services since the beginning of the 90s. All work is done by volunteers. I am the chairman of the board. We give subdomains to our users. The subdomains are being used for webhosting, virtual servers, dedicated servers, DSL, VPN and DynDNS.

Reason for PSL Inclusion
====

As every subdomain is operated by another user we think that adding cookie security is very important. Also our users can request Let's Encrypt certificates for their subdomains. Therefore we often hit the limits at Let's Encrypt and sometimes cannot request a certificate for our own infrastructure because there have been too many certificates requested by users.

DNS Verification via dig
=======

The TXT record"_psl " has been added to all subdomains and points to this pull request.

make test
=========

The tests have been successful.