### PR TITLE
Add azurecontainer.io regional domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12000,6 +12000,26 @@ co.pl
 // Microsoft Corporation : http://microsoft.com
 // Submitted by Justin Luk <juluk@microsoft.com>
 azurecontainer.io
+australiaeast.azurecontainer.io
+brazilsouth.azurecontainer.io
+canadacentral.azurecontainer.io
+canadaeast.azurecontainer.io
+centralindia.azurecontainer.io
+centralus.azurecontainer.io
+eastasia.azurecontainer.io
+eastus.azurecontainer.io
+eastus2.azurecontainer.io
+japaneast.azurecontainer.io
+koreacentral.azurecontainer.io
+northcentralus.azurecontainer.io
+northeurope.azurecontainer.io
+southcentralus.azurecontainer.io
+southeastasia.azurecontainer.io
+southindia.azurecontainer.io
+uksouth.azurecontainer.io
+westeurope.azurecontainer.io
+westus.azurecontainer.io
+westus2.azurecontainer.io
 azurewebsites.net
 azure-mobile.net
 cloudapp.net


### PR DESCRIPTION
sorted by TLD as requested in contributor guide

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://azure.com

Azure is a cloud-provider, Container Instances is a hosted-container solution on Azure enabling customers to utilize DNS names for each container group they deploy.

Reason for PSL Inclusion
====

We would like all of our domain names to be compliant, including cookie handling, DNS sorting, and Let's Encrypt cert issuance.

DNS Verification via dig
=======

Referencing previous PR for merging azurecontainer.io. Uncertain if we need to redo the DNS verification for each regional domain name of azurecontainer.io.

```
dig +short TXT _psl.azurecontainer.io
"https://github.com/publicsuffix/list/pull/637"
```

make test
=========

Test successfully ran.

Extra Info
=========
I made a successful PR last time (#637) for the azurecontainer.io domain. We need to update this to capture each region for the domain name, hence this PR. If there is a better path to do this let me know. Thanks!