### PR TITLE
Add Balena.io device domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12352,7 +12352,7 @@ rhcloud.com
 resindevice.io
 devices.resinstaging.io
 
-// Balena : https://balena-devices.com
+// Balena : https://www.balena.io
 // Submitted by Jack Brown <jack@balena.io>
 balena-devices.com
 balena-staging-devices.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12352,6 +12352,11 @@ rhcloud.com
 resindevice.io
 devices.resinstaging.io
 
+// Balena : https://balena-devices.com
+// Submitted by Jack Brown <jack@balena.io>
+balena-devices.com
+balena-staging-devices.com
+
 // RethinkDB : https://www.rethinkdb.com/
 // Submitted by Chris Kastorff <info@rethinkdb.com>
 hzc.io


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Make test

Description of Organization
====

Organization Website: https://www.balena.io

Balena is a fleet-management product for IoT devices. 

Reason for PSL Inclusion
====

We have a cloud platform that has the capability of exposing ports on devices via a proxy managed by us, hosted on the domains below. We'd like to ensure isolation for security purposes.

DNS Verification via dig
=======

```
dig +short TXT _psl.balena-devices.com
"https://github.com/publicsuffix/list/pull/717"
```

```
dig +short TXT _psl.balena-staging-devices.com
"https://github.com/publicsuffix/list/pull/717"
```
