### PR TITLE
Update subdomains of .ls

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3791,9 +3791,17 @@ org.lr
 net.lr
 
 // ls : https://en.wikipedia.org/wiki/.ls
+// see also: http://www.nic.ls/
 ls
+ac.ls
+biz.ls
 co.ls
+edu.ls
+gov.ls
+info.ls
 org.ls
+net.ls
+sc.ls
 
 // lt : https://en.wikipedia.org/wiki/.lt
 lt

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3791,6 +3791,7 @@ org.lr
 net.lr
 
 // ls : http://www.nic.ls/
+// Confirmed by registry <lsadmin@nic.ls>
 ls
 ac.ls
 biz.ls
@@ -3798,8 +3799,8 @@ co.ls
 edu.ls
 gov.ls
 info.ls
-org.ls
 net.ls
+org.ls
 sc.ls
 
 // lt : https://en.wikipedia.org/wiki/.lt

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3790,8 +3790,7 @@ gov.lr
 org.lr
 net.lr
 
-// ls : https://en.wikipedia.org/wiki/.ls
-// see also: http://www.nic.ls/
+// ls : http://www.nic.ls/
 ls
 ac.ls
 biz.ls


### PR DESCRIPTION

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====
I am the former technical contact for .LS, dating back to when the registry was operated by Rhodes University - my previous employer. I left Rhodes in 2016, and technical operations of .LS were passed from Rhodes University to LsNIC, the Lesotho Network Information Centre, in April 2018.

Whilst I was the registry operator, I maintained the referenced Wikipedia page (cf https://en.wikipedia.org/w/index.php?title=.ls&action=history).

Post the transfer to LsNIC, the new registry operator has set up a dedicated web page at http://www.nic.ls/. Whilst there is (unfortunately) not a complete list of second level domains there, it can be derived from a combination of the information on Wikipedia, the policy published on LsNIC's page, and some other bits of LsNIC's page.

Reason for PSL Inclusion
====

LS only allows registration at the third level (see http://www.nic.ls/policies.html) and the list of second level domains was incomplete.

make test
=========
```============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```