### PR TITLE
Add wpcomstaging.com and go-vip.co to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10838,6 +10838,7 @@ myasustor.com
 // Automattic Inc. : https://automattic.com/
 // Submitted by Alex Concha <alex.concha@automattic.com>
 wpcomstaging.com
+go-vip.co
 
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10835,6 +10835,10 @@ sweetpepper.org
 // Submitted by Vincent Tseng <vincenttseng@asustor.com>
 myasustor.com
 
+// Automattic Inc. : https://automattic.com/
+// Submitted by Alex Concha <alex.concha@automattic.com>
+wpcomstaging.com
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10837,8 +10837,8 @@ myasustor.com
 
 // Automattic Inc. : https://automattic.com/
 // Submitted by Alex Concha <alex.concha@automattic.com>
-wpcomstaging.com
 go-vip.co
+wpcomstaging.com
 
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>


### PR DESCRIPTION
 * [x]  Description of Organization
 * [x]  Reason for PSL Inclusion
 * [x]  DNS verification via dig
 * [x]  Run Syntax Checker (make test)

### Description of Organization

Automattic (https://automattic.com/) is a company behind WordPress.com, where the users can create websites and blogs for free and enhance those sites with our premium services.

### Reason for PSL Inclusion

We provide subdomains in wpcomstaging.com and go-vip.co to our users (e.g. site100.wpcomstaging.com, site20.wpcomstaging.com, demo-site1-com.go-vip.co), allowing them to upload custom WordPress plugins or themes so they can test their site before they are migrated to a self-hosted environment.

As any subdomain can be operated by any user, we would like proper handling of the namespace by browsers (to ensure cookie isolation, highlighting the subdomain, SSL management). This will prevent super cookie violation on the main wpcomstaging.com and go-vip.co domain and isolate each subdomain from the others in the same namespace.


### Dig request output
```
$ dig +short txt _psl.wpcomstaging.com
"https://github.com/publicsuffix/list/pull/719"
$ dig +short txt _psl.go-vip.co
"https://github.com/publicsuffix/list/pull/719"
```
### Make test

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-is-public-all.o
  CC       test-is-public.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```