### PR TITLE
Add readthedocs.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12370,6 +12370,10 @@ vaporcloud.io
 rackmaze.com
 rackmaze.net
 
+// Read The Docs, Inc : https://www.readthedocs.org
+// Submitted by Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+readthedocs.io
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12371,7 +12371,7 @@ rackmaze.com
 rackmaze.net
 
 // Read The Docs, Inc : https://www.readthedocs.org
-// Submitted by Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+// Submitted by David Fischer <team@readthedocs.org>
 readthedocs.io
 
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/


### PR DESCRIPTION
* [x] Description of Organization

[Read The Docs](https://readthedocs.org/) is an organization that hosts documentation for free software projects.

* [x] Reason for PSL Inclusion
$SUBDOMAIN.readthedocs.io is used to host documentation for projects using this service.

This inclusion in the PSL was [discussed and OK'ed with the upstream readthedocs folks](https://github.com/rtfd/readthedocs.org/issues/2233).

* [x] DNS verification via dig

This is now done:

~~~~
0 dkg@alice:~$ dig +short -t TXT _psl.readthedocs.io
"https://github.com/publicsuffix/list/pull/722"
0 dkg@alice:~$ 
~~~~

* [x] Run Syntax Checker (make test)
i have run the syntax checker with this patch included.
