### PR TITLE
Add telebit.io .app .xyz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12524,6 +12524,12 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// Telebit : https://telebit.cloud
+// Submitted by AJ ONeal <aj@telebit.cloud>
+telebit.app
+telebit.io
+*.telebit.xyz
+
 // The Gwiddle Foundation : https://gwiddlefoundation.org.uk
 // Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
 gwiddle.co.uk


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Supersedes #672 in order to
* to be free of merge conflicts
* to use only our best branded domains
  * telebit.io
  * telebit.app
  * *.telebit.xyz (for unlimited subdomains for users)

Description of Telebit
====

Organization Website: <https://rootprojects.org>
Product Website: <https://telebit.cloud>

I'm the owner and operator of <https://rootprojects.org>, which offers a number a products and services related to home servers, self-hosting, and social file and document sharing.

We're getting ready to launch https://telebit.cloud, which is an authenticated relay service to allow developers to connect a testable public domain to private devices and services - such as apps running in development on localhost and IoT devices and Raspberry Pis behind school firewalls.

![terminal-example-1](https://user-images.githubusercontent.com/122831/43668582-f3e4f5a2-973a-11e8-81ff-ecc1a4e3c48b.png)

Reason for adding Telebit domains
====

Telebit is similar to services like ngrok, serveo, and localtunnel.me, but we're focused on home and education, and committed to open standards (no vendor lock-in).

Each device gets a semi-random subdomain on one of our domains (such as lucky-duck-42.telebit.io) with unlimited subdomains (i.e. home.lucky-duck-42.telebit.xyz).

We want to remove the rate-limit restrictions of Let's Encrypt as well has have separate cookies for each of the sites.

DNS Verification
=====

```
dig TXT +short _psl.telebit.app
"https://github.com/publicsuffix/list/pull/726"
```

```
dig TXT +short _psl.telebit.io
"https://github.com/publicsuffix/list/pull/726"
```

```
dig TXT +short _psl.telebit.xyz
"https://github.com/publicsuffix/list/pull/726"
```
make test
=======

None of the failing entries are related to this change.