### PR TITLE
Syncloud dynamic dns service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12752,4 +12752,8 @@ site.builder.nu
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+// Syncloud : https://syncloud.org
+// Submitted by Boris Rybalkin <syncloud@syncloud.it>
+syncloud.it
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12547,6 +12547,10 @@ temp-dns.com
 applicationcloud.io
 scapp.io
 
+// Syncloud : https://syncloud.org
+// Submitted by Boris Rybalkin <syncloud@syncloud.it>
+syncloud.it
+
 // Synology, Inc. : https://www.synology.com/
 // Submitted by Rony Weng <ronyweng@synology.com>
 diskstation.me
@@ -12751,9 +12755,5 @@ site.builder.nu
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
-
-// Syncloud : https://syncloud.org
-// Submitted by Boris Rybalkin <syncloud@syncloud.it>
-syncloud.it
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [x] DNS verification via dig
* [X] Run Syntax Checker (make test)
 
Description of Organization
====

Organization Website: https://syncloud.it

Syncloud allows to run popular cloud services (mail, files, messaging ...) on personal devices

Reason for PSL Inclusion
====

Syncloud DDNS server (syncloud.it) hosts user's DNS records and also has its own site at syncloud.it.
So In practice allthesebelong todifferent people:
user1.syncloud.it
user2.syncloud.it
www.syncloud.it

Also any incorrectly set cookie sharing across all three is not safe as different users can run anything under *.[user].syncloud.it

DNS Verification via dig
=======

```
dig +short TXT _psl.syncloud.it
"https://github.com/publicsuffix/list/pull/727"
```

make test
=========

OK