### PR TITLE
Add private dynamic DNS solution for barsy.ca

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10707,6 +10707,10 @@ ltd.ua
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl
 
+// alboto.ca : http://alboto.ca
+// Submitted by Anton Avramov <avramov@alboto.ca>
+barsy.ca
+
 // Alces Software Ltd : http://alces-software.com
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====
Organization Website: http://alboto.ca (in development)
Alboto Inc is a new Canadian corporation that specializes in software, network and marketing solutions for bars and restaurants. It is the official distributor of Barsy software www.barsy.bg for Canada

Reason for PSL Inclusion
====
Barsy software solution integrates dynamic DNS solution for each individual client that has the software installed on premises. The main goal is for the client to be able to access his installation easily remotely. Since it deals with sensitive financial and personal clients information security is a major concern and Cookies should be not cross between individual subdomains. The company developed the software has the same solution for its Europe clients and it has proven to work very well.

DNS Verification via dig
=======
```
$ dig +short TXT _psl.barsy.ca
"https://github.com/publicsuffix/list/pull/732"
```

make test
=========

Prior to submitting we have run make test to make sure our patch is complient
