### PR TITLE
Add selfhost.de/at/eu/it/tv/es/se/info/biz/cc/ch/bz/pro/me/tk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7278,7 +7278,7 @@ auspost
 // author : 2014-12-18 Amazon Registry Services, Inc.
 author
 
-// auto : 2014-11-13 Cars Registry Limited
+// auto : 2014-11-13 Cars Registry Limited
 auto
 
 // autos : 2014-01-09 DERAutos, LLC
@@ -7560,7 +7560,7 @@ capital
 // capitalone : 2015-08-06 Capital One Financial Corporation
 capitalone
 
-// car : 2015-01-22 Cars Registry Limited
+// car : 2015-01-22 Cars Registry Limited
 car
 
 // caravan : 2013-12-12 Caravan International, Inc.
@@ -7578,7 +7578,7 @@ career
 // careers : 2013-10-02 Binky Moon, LLC
 careers
 
-// cars : 2014-11-13 Cars Registry Limited
+// cars : 2014-11-13 Cars Registry Limited
 cars
 
 // cartier : 2014-06-23 Richemont DNS Inc.
@@ -12691,5 +12691,23 @@ now.sh
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
+
+// selfhost.de : https://selfhost.de
+// Submitted by Johannes Scholz <johannes@selfhost.de>
+selfhost.de
+selfhost.at
+selfhost.eu
+selfhost.it
+selfhost.tv
+selfhost.es
+selfhost.se
+selfhost.info
+selfhost.biz
+selfhost.cc
+selfhost.ch
+selfhost.bz
+selfhost.pro
+selfhost.me
+selfhost.tk
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Description of Organization
====

We're a DynDNS provider from germany.
Organization Website: https://selfhost.de

Reason for PSL Inclusion
====

We want that our customers which are using free subdomains can use let's encrypt too. 
We want to prevents cross domain cookies & cross domain javascript. Every subdomain has his own owner with his own cookies.

DNS Verification via dig
=======

`dig +short TXT _psl.selfhost.de`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.at`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.eu`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.it`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.tv`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.es`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.se`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.info`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.biz`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.cc`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.ch`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.bz`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.pro`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.me`
`"https://github.com/publicsuffix/list/pull/735"`

`dig +short TXT _psl.selfhost.tk`
`"https://github.com/publicsuffix/list/pull/735"`

=========