### PR TITLE
Add EduGit pages under edugit.org.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12529,6 +12529,10 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// Teckids e.V. : https://www.teckids.org
+// Submitted by Dominik George <dominik.george@teckids.org>
+edugit.org
+
 // The Gwiddle Foundation : https://gwiddlefoundation.org.uk
 // Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
 gwiddle.co.uk


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.teckids.org

Teckids e.V. is a (probably the) free software youth organisation, that aims at both getting free software in use by young people and in schools, and at getting young people involved in free software contribution. We are a non-profit organisation based in Germany.

Reason for PSL Inclusion
====

EduGit.org is a Git hosting service using GitLab and for use in schools, for educational software, etc., with terms of use tailored to the legal needs when working with minors and in classrooms. It provides GitLab pages, where projects can public static web content under a subdomain named after their self-chosen namespace. PSL inclusion is thus important for cookie security and security-related browser UI improvement.

DNS Verification via dig
=======

```
dig +short TXT _psl.edugit.org
"https://github.com/publicsuffix/list/pull/736"
```

make test
=========

All tests passed while running `make test` ☺.