### PR TITLE
Add domains for FASTVPS EESTI OU

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11653,6 +11653,10 @@ global.ssl.fastly.net
 // Submitted by Likhachev Vasiliy <lihachev@fastvps.ru>
 fastpanel.direct
 fastvps-server.com
+myfast.space
+myfast.host
+fastvps.site
+fastvps.host
 
 // Featherhead : https://featherhead.xyz/
 // Submitted by Simon Menke <simon@featherhead.xyz>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://fastvps.ru/

FASTVPS EESTI OU is hosting provider. I am the one of engineers working with infrastructure.

Reason for PSL Inclusion
====
We provide technical domains for our customers so they can test their sites without the need of assigning their production domain to the server. We now have 4 technical domains:
myfast.space
myfast.host
fastvps.site
fastvps.host

3-rd level domains based on these are not related with each other and should not trust each other.
Every domain is used by different website and typically by different customer.
Also it is good to have ability to issue Let's Encrypt for such domains.


DNS Verification via dig
=======

Work in progress - we need to create PR first. I'll update it when records are added.

make test
=========
**make test** finished OK
http://ghostbin.fv.ee/paste/ayewa/raw