### PR TITLE
Update to include all current 3LD/4LD edu.au suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -235,6 +235,8 @@ vic.au
 wa.au
 // 3LDs
 act.edu.au
+catholic.edu.au
+eq.edu.au
 nsw.edu.au
 nt.edu.au
 qld.edu.au
@@ -250,6 +252,9 @@ sa.gov.au
 tas.gov.au
 vic.gov.au
 wa.gov.au
+// 4LDs
+education.tas.edu.au
+schools.nsw.edu.au
 
 // aw : https://en.wikipedia.org/wiki/.aw
 aw


### PR DESCRIPTION
Description of Organization
====

Education Services Australia (ESA) is a national not-for-profit company owned by the state, territory and Australian Government education ministers. ESA is the sole organization authorised to deliver registrar services for edu.au and its child zones by .au Domain Administration Ltd (auDA), the policy authority and industry self-regulatory body for the .au domain space as endorsed by the Australian Government.

Organization Websites:
Primary - https://www.esa.edu.au
Registrar services - https://www.domainname.edu.au



Reason for PSL Inclusion
====

The PSL currently only includes the national level 2LD and the Australian state and territory level 3LDs for edu.au. The edu.au domain space has expanded in recent years to includes a number other 3LDs and also 4LDs for use by specific jurisdictions and sectors. This request is seeking to add these to the PSL so the institutions operating under these suffixes can gain access to services such as Let's Encrypt, and that other third party systems may better be able to identify the level at which the personal/private name has been registered.