### PR TITLE
Add Cynthia.re IPv4 Hex resolver

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12712,7 +12712,7 @@ now.sh
 zone.id
 
 // IPv4 Hex Resolver @ Cynthia.re : https://cynthia.re
-// Submitted by Cynthia Revstrom <me@cynthia.re> 
+// Submitted by Cynthia Revstrom <me@cynthia.re>
 *.ipv4.cynthia.re
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12711,4 +12711,8 @@ now.sh
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
 
+// IPv4 Hex Resolver @ Cynthia.re : https://cynthia.re
+// Submitted by Cynthia Revstrom <me@cynthia.re> 
+*.ipv4.cynthia.re
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
### Reason for this PR
ipv4.cynthia.re is a little project that is a hex IPv4 resolver such as `ff00ff00.ipv4.cynthia.re` is an A record of `255.0.255.0` and due to this, every single IPv4 address has a subdomain.

This is to help with browser cookies, etc. I would like this domain to be recognized as a known public suffix.

### Dig request output
`TODO`

### Make test
The make test output is located at this url:
[https://cdn.cynthia.re/upload/psl.txt](https://cdn.cynthia.re/upload/psl.txt)

### Extra info
My name is Cynthia Revström but I put Revstrom in the submitted by comment due to ASCII compatibility.