### PR TITLE
Add api.stdlib.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12502,6 +12502,10 @@ spacekit.io
 // Submitted by Stefan Neufeind <info@speedpartner.de>
 customer.speedpartner.de
 
+// Standard Library : https://stdlib.com
+// Submitted by Jacob Lee <jacob@stdlib.com>
+api.stdlib.com
+
 // Storj Labs Inc. : https://storj.io/
 // Submitted by Philip Hutchins <hostmaster@storj.io>
 storj.farm


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://stdlib.com

My name is Jacob Lee, and I'm the co-founder of Standard Library and am in charge of platform development and architecture. The CEO of the company, Keith Horwood (@keithwhor), is the original owner of the domain and he will also comment here.

Standard Library is an API development, management, and hosting platform. We support tens of thousands of developers and work closely with Slack and Stripe. Both organizations are active investors in the company and users of the product.

Reason for PSL Inclusion
====

Each user on our platform receives a unique hostname with the base domain where we host their deployed APIs. Though many APIs on the platform act as either JSON responses or webhook endpoints, a significant number of developers on the platform utilize our hosting capabilities to host static content (APIs can return `Content-Type: text/html` no problem). We currently run our gateway on the `lib.id` domain.

We intend to migrate all APIs to `api.stdlib.com` shortly. We would like cookie isolation at the subdomain level (`user.api.stdlib.com`). Inclusion of `api.stdlib.com` in the PSL would mitigate the risk of users setting and accessing cross site cookies that apply to other users' subdomains via the base `api.stdlib.com` domain.

As an example (and to verify success), I've created a page that attempts set a cookie named "xdomaincookie" for the base domain `api.stdlib.com`, and checks to see if the cookie was successfully set. It will return a success message once `api.stdlib.com` has been added to the Public Suffix List.
https://jacoblee.api.stdlib.com/psltest@dev/

DNS Verification via dig
=======

```
$ dig +short TXT _psl.api.stdlib.com
"https://github.com/publicsuffix/list/pull/751"
```

make test
=========

I have successfully run `make test` with the patch. 