### PR TITLE
Add certdns.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10953,6 +10953,10 @@ co.com
 // c.la : http://www.c.la/
 c.la
 
+// CertDNS : https://www.certdns.com/
+// Submitted by Andrew Kesper <publicsuffixlist@certdns.com>
+certdns.com
+
 // certmgr.org : https://certmgr.org
 // Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.certdns.com/

CertDNS provides web developers and power users with everything they need to serve HTTPS from their local machine: a certdns.com subdomain, private keys, certificates, dynamic DNS, and easy-to-follow instructions.

CertDNS is particularly useful for people having trouble setting up HTTPS from inside their home network or corporate intranet.

Reason for PSL Inclusion
====

Customers can use their own domain or create a subdomain under certdns.com. Inclusion to the PSL would: 1) isolate cookies on certdns.com subdomains; and 2) allow customers to use Let’s Encrypt on a certdns.com subdomain without hitting the “Certificates per Registered Domain” rate limit.

DNS Verification via dig
=======

```
dig +short TXT _psl.certdns.com
"https://github.com/publicsuffix/list/pull/753"
```

make test
=========

`make test` completed successfully and all tests passed.

Output: https://www.certdns.com/publicsuffixlist-make-test.txt
