### PR TITLE
Add oh.name

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11093,6 +11093,10 @@ store.dk
 *.dapps.earth
 *.bzz.dapps.earth
 
+// Darren Oh : https://darren.oh.name/
+// Submitted by Darren Oh <darren@oh.name>
+oh.name
+
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net


### PR DESCRIPTION
Needed to allow domains in this namespace to use Cloudflare. Domains in this namespace belong to individuals who have the surname _Oh_. The first domain registered in this namespace is darren.oh.name.

DNS verification via dig is not possible (Verisign does not allow two-letter second-level .name domains to be registered, and only provides MX records for them). Please use the email address darren@oh.name to verify the oh.name TLD.

Description of Organization
====

Organization Website: https://darren.oh.name/

My name is Darren Oh. I registered darren.oh.name, the first oh.name domain. .name domains allow individuals to register their own names as their Internet identities. When a third-level .name domain is registered, the second-level domain becomes a TLD. Verisign provides a second-level email address to everyone who registers a third-level .name domain. darren.oh.name has a corresponding darren@oh.name address.

Reason for PSL Inclusion
====

I have not been able to add my domain to Cloudflare because Verisign does not provide a list of second-level .name TLDs. I inquired about the possibility of registering oh.name as a second-level domain instead, but Verisign informed me that all two-letter second-level .name domains are reserved and cannot be registered. On behalf of myself and anyone else who shares Oh as a last name, I am requesting that oh.name be included as a private domain.

DNS Verification via email
=======

As oh.name cannot be registered, DNS verification via dig is not possible. However, the second-level email address Verisign provides to everyone who registers a third-level .name domain can be used to verify the oh.name TLD. My second-level domain email is darren@oh.name.

make test
=========

All tests passed.