### PR TITLE
Proposal to remove bv.nl

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4659,9 +4659,6 @@ web.ni
 //      ccTLD for the Netherlands
 nl
 
-// BV.nl will be a registry for dutch BV's (besloten vennootschap)
-bv.nl
-
 // no : http://www.norid.no/regelverk/index.en.html
 // The Norwegian registry has declined to notify us of updates. The web pages
 // referenced below are the official source of the data. There is also an


### PR DESCRIPTION
I represent the registry for the .nl ccTLD (SIDN) and would like to draw your attention to bv.nl.
To the best of our knowledge that private domain has never properly qualified for the public suffix list, even though there might have been good intentions when the initial request was made. We are not the owner of the private domain bv.nl. We did try to contact the current owner and discuss the matter, but we received no response. Since we are not sure what the correct procedures are in this case, I'd like to ask for extra attention (and help) from the maintainers of this list.
