### PR TITLE
Add b-data.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10854,7 +10854,7 @@ myfritz.net
 *.awdev.ca
 *.advisor.ws
 
-// b-data GmbH
+// b-data GmbH : https://www.b-data.io
 // Submitted by Olivier Benz <olivier.benz@b-data.ch>
 b-data.io
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10854,6 +10854,10 @@ myfritz.net
 *.awdev.ca
 *.advisor.ws
 
+// b-data GmbH
+// Submitted by Olivier Benz <olivier.benz@b-data.ch>
+b-data.io
+
 // backplane : https://www.backplane.io
 // Submitted by Anthony Voutas <anthony@backplane.io>
 backplaneapp.io


### PR DESCRIPTION
 - [x] Description of Organization
 - [x] Reason for PSL Inclusion
 - [x] DNS verification via dig
 - [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.b-data.io

I'm a Data Scientist at b-data using GitLab (https://gitlab.b-data.ch) to serve repositories to my customers.

Reason for PSL Inclusion
====

b-data.io is used for GitLab pages to allow arbitrary users to have subdomains.
