### PR TITLE
Add mo-siemens.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11717,6 +11717,10 @@ githubusercontent.com
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
 
+// Siemens Mobility GmbH
+// Submitted by Oliver Graebner <security@mo-siemens.io>
+mo-siemens.io
+
 // UKHomeOffice : https://www.gov.uk/government/organisations/home-office
 // Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
 homeoffice.gov.uk


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [x] DNS verification via dig
* [X] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://new.siemens.com/global/en/company/about/businesses/mobility.html

We are part of an innovation department for innovative mobility solutions based on cloud technologies and microservice architectures.

Reason for PSL Inclusion
====

mo-siemens.is is used for GitLab pages to allow arbitrary project groups to have subdomains.

DNS Verification via dig
=======

```
dig +short TXT _psl.mo-siemens.io
"https://github.com/publicsuffix/list/pull/762"
```



make test
=========
`make test` completed without errors
