### PR TITLE
Add GOV.UK PaaS client domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11717,6 +11717,11 @@ githubusercontent.com
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
 
+// GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
+// Submitted by Tom Whitwell <tom.whitwell@digital.cabinet-office.gov.uk>
+cloudapps.digital
+london.cloudapps.digital
+
 // UKHomeOffice : https://www.gov.uk/government/organisations/home-office
 // Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
 homeoffice.gov.uk


### PR DESCRIPTION

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [x] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

[GOV.UK Platform as a Service](https://www.cloud.service.gov.uk) is the UK Government's PaaS - these are the domains we use for client applications, ie. `appname.cloudapps.digital` / `appname.london.cloudapps.digital`.

Reason for PSL Inclusion
====

We need these domains to be in the public suffix list as each subdomain is specific to one client application: cookie isolation is required.

Additionally, one of our subdomains has been flagged as phishing, which has resulted in the whole *.london.cloudapps.digital being flagged as dangerous. We would like an explicit distinction between independent subdomains.

DNS Verification via dig
=======

```
dig +short TXT _psl.cloudapps.digital
"https://github.com/publicsuffix/list/pull/###"
```
```
dig +short TXT _psl.london.cloudapps.digital
"https://github.com/publicsuffix/list/pull/###"
```


make test
=========

Test run and passed.