### PR TITLE
added thingdustdata.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12590,6 +12590,7 @@ gwiddle.co.uk
 
 // Thingdust AG : https://thingdust.com/
 // Submitted by Adrian Imboden <adi@thingdust.com>
+thingdustdata.com
 cust.dev.thingdust.io
 cust.disrec.thingdust.io
 cust.prod.thingdust.io


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
Organization Website: https://thingdust.com

We are a small startup that provides a solution for measuring the occupancy of workplace environments (primarily shared desk and meeting rooms). Every customer gets his own instance with his own subdomain provided by us.

Reason for PSL Inclusion
====
We currently have prod.cust.thingdust.io (and the same pattern for out testing systems) registered, to provide each customer his own subdomain which must not interfere with the other customers instances.
The inclusion in this list gives each customer his own cookie scope.

We now want to change the prod url gradually from *.prod.cust.thingdust.io to *.thingdustdata.com


DNS Verification via dig
=======
```
dig +short TXT _psl.thingdustdata.com
"https://github.com/publicsuffix/list/pull/767"
```

make test
=========
Did run successfully