### PR TITLE
Add glitch.me to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11724,6 +11724,10 @@ githubusercontent.com
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
 
+// Glitch, Inc : https://glitch.com
+// Submitted by Mads Hartmann <mads@glitch.com>
+glitch.me
+
 // UKHomeOffice : https://www.gov.uk/government/organisations/home-office
 // Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
 homeoffice.gov.uk


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://glitch.com

Glitch is the friendly community where everyone can discover and create the best stuff on the web. For more information about Glitch head over to https://glitch.com/about/

Reason for PSL Inclusion
====

Everyone can go to https://glitch.com and create an app. We provide every app on Glitch with its own `glitch.me` subdomain.

We'd like to be included in the list to improve our cookie security. 

DNS Verification via dig
=======

```
dig +short TXT _psl.glitch.me
"https://github.com/publicsuffix/list/pull/769"
```

make test
=========

I ran the tests and they pass 👍 
