### PR TITLE
Added bh.je and bhcod.es

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10840,6 +10840,11 @@ myfritz.net
 // Submitted by Anthony Voutas <anthony@backplane.io>
 backplaneapp.io
 
+// Benjamin Howe : https://www.bh96.uk/
+// Submitted by Benjamin Howe <ben@bh96.uk>
+bh.je
+bhcod.es
+
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>
 betainabox.com


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [x] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

I'm an individual who makes various things on the internet. My website is https://www.bh96.uk/.

Reason for PSL Inclusion
====

For some side projects, I may not have complete (or in some cases, any) control over the source code. If If not using their own domain name, these projects are typically subdomains of bh.je or bhcod.es. I would like browsers to treat these appropriately with respect to cookies.

DNS Verification via dig
=======

```
ben@ben-laptop:~$ dig +short TXT _psl.bh.je
"https://github.com/publicsuffix/list/pull/775"
ben@ben-laptop:~$ dig +short TXT _psl.bhcod.es
"https://github.com/publicsuffix/list/pull/775"
```
`make test`
=========

I have run `make test`: https://pastebin.com/U7td9ajQ
