### PR TITLE
Add on-rio.io and on-rancher.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12405,6 +12405,11 @@ vaporcloud.io
 rackmaze.com
 rackmaze.net
 
+// Rancher Labs, Inc : https://rancher.com
+// Submitted by Vincent Fiduccia <domains@rancher.com>
+*.on-rancher.cloud
+*.on-rio.io
+
 // Read The Docs, Inc : https://www.readthedocs.org
 // Submitted by David Fischer <team@readthedocs.org>
 readthedocs.io


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://rancher.com

Rancher Labs develops an open-source Kubernetes distribution and management platform called Rancher and similar container product called Rio.

I am [Vincent Fiduccia](https://github.com/vincent99), software architect at Rancher.

Reason for PSL Inclusion
====

We are adding a feature to automatically provide each user cluster with a `<service name>.<random user-id>.on-rancher.cloud` (and `on-rio.io`) DNS entry, so each `user-id` is a mutually untrusting third-party that should not be able to set cookies readable by each other.  We also plan to provide Let's Encrypt wildcard certs for each `user-id`.

DNS Verification via dig
=======

```
dig +short TXT _psl.on-rancher.cloud
"https://github.com/publicsuffix/list/pull/779"
```

```
dig +short TXT _psl.on-rio.io
"https://github.com/publicsuffix/list/pull/779"
```
make test
=========

Ran and passed..

<details>
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_NFKC: FAILED
--- test_NFKC.expected	2019-03-01 18:29:20.000000000 +0000
+++ log/test_NFKC.log	2019-03-01 18:59:38.000000000 +0000
@@ -1,2 +1,10 @@
-9: error: Rule must be NFKC: 'südtirol.it'
-11: warning: No PRIVATE section found
+Traceback (most recent call last):
+  File "./pslint.py", line 276, in <module>
+    sys.exit(main())
+  File "./pslint.py", line 270, in main
+    lint_psl(infile)
+  File "./pslint.py", line 174, in lint_psl
+    error('Rule must be NFKC')
+  File "./pslint.py", line 44, in error
+    print('%d: error: %s%s' % (nline, msg, ": \'" + orig_line + "\'" if orig_line else ""))
+UnicodeEncodeError: 'ascii' codec can't encode character '\u0308' in position 32: ordinal not in range(128)
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up-to-date.
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:36: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:36: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:36: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
configure.ac:11: installing 'build-aux/compile'
configure.ac:5: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/list/public_suffix_list.dat --with-psl-testfile=/list/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
ar: `u' modifier ignored since `D' is the default (see `U')
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
</details>