### PR TITLE
Add Nabu Casa

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12076,6 +12076,10 @@ net.ru
 org.ru
 pp.ru
 
+// Nabu Casa : https://www.nabucasa.com
+// Submitted by Paulus Schoutsen <infra@nabucasa.com>
+ui.nabu.casa
+
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
 bitballoon.com


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.nabucasa.com

Nabu Casa offers Home Assistant Cloud, a cloud extension for the open source home automation platform [Home Assistant](https://www.home-assistant.io). With Home Assistant Cloud, local running Home Assistant instances can be accessed via the internet and integrate with cloud-only services like Alexa and Google Assistant.

I am Paulus Schoutsen, the founder of Nabu Casa and Home Assistant.

Reason for PSL Inclusion
====

To allow remote connection to Home Assistant instances, we're soon giving users the option to access their local running instance under the domain `https://<domain-id>.ui.nabu.casa`. These domains will be served by their local Home Assistant instances, not under our control. Home Assistant allows users to built extensions in both Python and JavaScript, which will allow the user to run any code under their domain. For security, cookies should not be allowed to be shared across subdomains.

DNS Verification via dig
=======

```
› dig +short TXT _psl.ui.nabu.casa
"https://github.com/publicsuffix/list/pull/781"
```

make test
=========

I was unable to get this fully running on my Mac. I used the Docker from #731 and got similar results:

Here is the output of `make test-syntax`, which runs fine:

```
> make test-syntax
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_NFKC: FAILED
--- test_NFKC.expected	2019-03-02 21:34:42.000000000 +0000
+++ log/test_NFKC.log	2019-03-03 01:31:01.000000000 +0000
@@ -1,2 +1,10 @@
-9: error: Rule must be NFKC: 'südtirol.it'
-11: warning: No PRIVATE section found
+Traceback (most recent call last):
+  File "./pslint.py", line 276, in <module>
+    sys.exit(main())
+  File "./pslint.py", line 270, in main
+    lint_psl(infile)
+  File "./pslint.py", line 174, in lint_psl
+    error('Rule must be NFKC')
+  File "./pslint.py", line 44, in error
+    print('%d: error: %s%s' % (nline, msg, ": \'" + orig_line + "\'" if orig_line else ""))
+UnicodeEncodeError: 'ascii' codec can't encode character '\u0308' in position 32: ordinal not in range(128)
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
```

Running `make test-rules` results in 

```
> make test-rules
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up-to-date.
aclocal: error: aclocal: file 'm4/lt~obsolete.m4' does not exist
autoreconf: aclocal failed with exit status: 1
Makefile:25: recipe for target 'libpsl-config' failed
make: *** [libpsl-config] Error 1
```




The [guidelines](https://github.com/publicsuffix/list/wiki/Guidelines#test-the-changes) include that Travis will test the changes too, however I have not seen the Travis check on my PR yet. 
