### PR TITLE
Add Google Compute Engine VP automatic domains to PSL

### DIFF
--- a/linter/pslint.py
+++ b/linter/pslint.py
@@ -180,7 +180,7 @@ def lint_psl(infile):
 		# strip leading wildcards
 		flags = section
 		# while line[0:2] == '*.':
-		if line[0:2] == '*.':
+		while line[0:2] == '*.':
 			flags |= PSL_FLAG_WILDCARD
 			line = line[2:]
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11728,6 +11728,7 @@ run.app
 a.run.app
 *.0emm.com
 appspot.com
+*.*.*.bc.googleusercontent.com
 blogspot.ae
 blogspot.al
 blogspot.am


### PR DESCRIPTION
* [x] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Google Cloud Platform is a cloud platform provider.

Organization Website: https://cloud.google.com/

I am an engineer working on Google Cloud Platform, working with Google's DNS and networking teams.


Reason for PSL Inclusion
====

The `$REVERSE_IP.bc.googleusercontent.com` IP addresses are assigned to customer VMs in [Google Compute Engine](https://cloud.google.com/compute/) and other Google products, primarily to satisfy SSH forward and backwards PTR checks.

We want to add these IPs to the PSL to enforce cookie security on the upper levels of the `bc.googleusercontent.com` space (e.g. `34.bc.googleusercontent.com`).

This is similar to the existing entry on 10707 for `*.compute.amazonaws.com`.

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc).
-->

DNS Verification via dig
=======

```shell
dig +short TXT _psl.bc.googleusercontent.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

TODO: fill in pull request number once created.

make test
=========

Tests pass as of this PR.

A few notes on the test process (I can open a separate documentation PR):
* The test seems to expect/require a linux or at least unix machine.
* The test assumes the following software packages installed (at least):
  - python
  - autoconf
  - libicu-dev

**NOTE** The linter was broken in comparison with the rules at https://publicsuffix.org/list/#list-format -- it only accepted a single level of wildcard. I fixed that as part of this PR.

It's not clear that test suites cover multi-level wildcards, despite being specified as supported.
