### PR TITLE
Add wnext.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10969,6 +10969,10 @@ cloudaccess.net
 cloudcontrolled.com
 cloudcontrolapp.com
 
+// Clovyr : https://clovyr.io
+// Submitted by Patrick Nielsen <patrick@clovyr.io>
+wnext.app
+
 // co.ca : http://registry.co.ca/
 co.ca
 


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://clovyr.io

I'm co-founder and CTO of a company called Clovyr. We are working on making self-hosted applications easier to use, including without needing to register domains or know what A/CNAME records are.

Reason for PSL Inclusion
====

We would like to assign `foo-bar.wnext.app` and `baz-quux.wnext.app` to different people who we (Clovyr) don't particularly trust, and who don't trust each other, and so we would like to:

  - Avoid cookies being set on `wnext.app` under any circumstance
  - Allow users to provision LE certs, but still be subject to the LE rate limits for their "domain". (A single abusive user maxing out the limits for `wnext.app` would be very bad.)
  - Let the many tools that rely on PSL know to treat `wnext.app` as an extension

DNS Verification via dig
=======

```
dig +short TXT _psl.wnext.app
"https://github.com/publicsuffix/list/pull/785"
```

make test
=========

all tests passed (after running `apt-get install build-essential autoconf autopoint pkg-config libtool libicu-dev python` on a clean Debian box)  
