### PR TITLE
Add edu.mu and biz.mu, sort .mu suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3953,13 +3953,15 @@ org.mt
 
 // mu : https://en.wikipedia.org/wiki/.mu
 mu
-com.mu
-net.mu
-org.mu
-gov.mu
 ac.mu
+biz.mu
 co.mu
+com.mu
+edu.mu
+gov.mu
+net.mu
 or.mu
+org.mu
 
 // museum : http://about.museum/naming/
 // http://index.museum/


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
.mu ccTLD administered by MUNIC: [http://nic.mu](http://nic.mu)
Wikipedia: [https://en.wikipedia.org/wiki/.mu](https://en.wikipedia.org/wiki/.mu)

Reason for PSL Inclusion
====
.edu.mu and .biz.mu subdomains recently made available under .mu ccTLD. Adjust existing subdomains to sort alphabetically.

DNS Verification via dig
=======
N/A

make test
=========
Ran and passed.
