### PR TITLE
Add go-vip.net.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10825,6 +10825,7 @@ myasustor.com
 // Automattic Inc. : https://automattic.com/
 // Submitted by Alex Concha <alex.concha@automattic.com>
 go-vip.co
+go-vip.net
 wpcomstaging.com
 
 // AVM : https://avm.de


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Automattic (https://automattic.com/) is a company behind WordPress.com, where the users can create websites and blogs for free and enhance those sites with our premium services.

This PR is identical to the information contained within https://github.com/publicsuffix/list/pull/719 but is only seeking to add an additional TLD.

Reason for PSL Inclusion
====

We provide subdomains in go-vip.net to our users (e.g. demo-site1-com.go-vip.net), allowing them to upload custom WordPress plugins or themes so they can test their site before they are migrated to a self-hosted environment.

As any subdomain can be operated by any user, we would like proper handling of the namespace by browsers (to ensure cookie isolation, highlighting the subdomain, SSL management). This will prevent super cookie violation on the main wpcomstaging.com and go-vip.net domain and isolate each subdomain from the others in the same namespace.

DNS Verification via dig
=======

```
dig +short TXT _psl.go-vip.net
"https://github.com/publicsuffix/list/pull/793"
```

make test
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public-builtin.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-all.o
  CC       test-is-public.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-all
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```
