### PR TITLE
Add Handshake zones

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11880,11 +11880,6 @@ publishproxy.com
 withgoogle.com
 withyoutube.com
 
-// Handshake : https://handshake.org
-// Submitted by Mike Damm <md@md.vc>
-hs.zone
-hs.run
-
 // Hakaran group: http://hakaran.cz
 // Submited by Arseniy Sokolov <security@hakaran.cz>
 fin.ci
@@ -11892,6 +11887,11 @@ free.hr
 caa.li
 ua.rs
 conf.se
+
+// Handshake : https://handshake.org
+// Submitted by Mike Damm <md@md.vc>
+hs.zone
+hs.run
 
 // Hashbang : https://hashbang.sh
 hashbang.sh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11824,6 +11824,11 @@ publishproxy.com
 withgoogle.com
 withyoutube.com
 
+// Handshake : https://handshake.org
+// Submitted by Mike Damm <md@md.vc>
+hs.zone
+hs.run
+
 // Hashbang : https://hashbang.sh
 hashbang.sh
 


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Organization Website: https://handshake.org/

Handshake is a decentralized, permissionless naming protocol compatible with DNS where every peer is validating and in charge of managing the root zone with the goal of creating an alternative to existing Certificate Authorities. Its purpose is not to replace the DNS protocol, but to replace the root zone file and the root servers with a public commons. The Handshake protocol maintains the root zone file in a decentralized manner, making the root zone uncensorable, permissionless, and free of gatekeepers.

I am a developer for this project.

Reason for PSL Inclusion
====

Names registered in Handshake are reflected in to the hs.zone and hs.run zones, allowing clients not running Handshake to look up these names. Because multiple parties can indirectly register names under these zones, cookie isolation is highly desirable.

DNS Verification via dig
=======

```
bash-3.2$ dig +short IN TXT _psl.hs.zone.
"https://github.com/publicsuffix/list/issues/796"
bash-3.2$ dig +short IN TXT _psl.hs.run.
"https://github.com/publicsuffix/list/issues/796"
```

make test
=========

Tested. https://pastebin.com/raw/iHMUfmMJ

```
============================================================================
Testsuite summary for libpsl 0.20.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================```
