### PR TITLE
Add prvcy.page

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12385,6 +12385,10 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
+// PrivacyTools.io Git Pages : https://git.privacytools.io/
+// Submitted by Jonah Aragon <jonah@privacytools.io>
+prvcy.page
+
 // Protonet GmbH : http://protonet.io
 // Submitted by Martin Meier <admin@protonet.io>
 protonet.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12385,7 +12385,7 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
-// PrivacyTools.io Git Pages : https://git.privacytools.io/
+// privacytools.io : https://www.privacytools.io/
 // Submitted by Jonah Aragon <jonah@privacytools.io>
 prvcy.page
 


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.privacytools.io (https://git.privacytools.io)

@privacytoolsIO is a socially motivated organization providing resources and services to promote privacy online. We are currently operating a [public GitLab instance](https://git.privacytools.io) for our users and our team's use, and will be offering free subdomains with GitLab Pages.

Reason for PSL Inclusion
====

We will be implementing GitLab Pages on the `prvcy.page` domain, allowing any user to publish their own static site hosted on our GitLab instance to a subdomain of their choosing. Being added to the PSL is a [recommended task](https://docs.gitlab.com/ee/administration/pages/#add-the-domain-to-the-public-suffix-list) for GitLab Pages administrators to prevent browsers accepting supercookies for the domain.

DNS Verification via dig
=======

```
dig +short TXT _psl.prvcy.page
"https://github.com/publicsuffix/list/pull/803"
```

make test
=========

Passed.