### PR TITLE
Add azimuth.network and arvo.network

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10806,6 +10806,10 @@ apigee.io
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
+// Arvo : https://arvo.network
+// Submitted by Mark Staarink <mark@tlon.io>
+arvo.network
+
 // Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
 // Submitted by Hector Martin <marcan@euskalencounter.org>
 user.party.eus

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10806,10 +10806,6 @@ apigee.io
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
-// Arvo : https://arvo.network
-// Submitted by Mark Staarink <mark@tlon.io>
-arvo.network
-
 // Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
 // Submitted by Hector Martin <marcan@euskalencounter.org>
 user.party.eus
@@ -10839,10 +10835,6 @@ myfritz.net
 // Submitted by James Kennedy <domains@advisorwebsites.com>
 *.awdev.ca
 *.advisor.ws
-
-// Azimuth : https://azimuth.network
-// Submitted by Mark Staarink <mark@tlon.io>
-azimuth.network
 
 // backplane : https://www.backplane.io
 // Submitted by Anthony Voutas <anthony@backplane.io>
@@ -12622,6 +12614,11 @@ cust.dev.thingdust.io
 cust.disrec.thingdust.io
 cust.prod.thingdust.io
 cust.testing.thingdust.io
+
+// Tlon.io : https://tlon.io
+// Submitted by Mark Staarink <mark@tlon.io>
+arvo.network
+azimuth.network
 
 // TownNews.com : http://www.townnews.com
 // Submitted by Dustin Ward <dward@townnews.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10836,6 +10836,10 @@ myfritz.net
 *.awdev.ca
 *.advisor.ws
 
+// Azimuth : https://azimuth.network
+// Submitted by Mark Staarink <mark@tlon.io>
+azimuth.network
+
 // backplane : https://www.backplane.io
 // Submitted by Anthony Voutas <anthony@backplane.io>
 backplaneapp.io


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://urbit.org

I am Mark Staarink, engineer at [Tlon](https://tlon.io), the company working on Urbit. It comprises several separate components, which include Azimuth (decentralized identity) and Arvo (personal server).

Reason for PSL Inclusion
====

Azimuth and Arvo will provide identity owners with their own subdomain under `azimuth.network` and `arvo.network` respectively. For example, `palfun-foslup.arvo.network`.

In the case of Azimuth, the identity subdomain will serve as a unique log-on point for that specific identity.  
In the case of Arvo, the identity subdomain will point to the owner's personal server, which can serve arbitrary content.

DNS Verification via dig
=======

```
> dig +short TXT _psl.azimuth.network
"https://github.com/publicsuffix/list/pull/812"

> dig +short TXT _psl.arvo.network
"https://github.com/publicsuffix/list/pull/812"
```

make test
=========

`make test` sees all tests pass.
