### PR TITLE
Add Balena domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10840,6 +10840,10 @@ myfritz.net
 // Submitted by Anthony Voutas <anthony@backplane.io>
 backplaneapp.io
 
+// Balena : https://www.balena.io
+// Submitted by Petros Angelatos <petrosagg@balena.io>
+balena-devices.com
+
 // Banzai Cloud
 // Submitted by Gabor Kozma <info@banzaicloud.com>
 app.banzaicloud.io


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Balena is a complete set of tools for building, deploying, and managing fleets of connected Linux devices. We provide infrastructure for fleet owners so they can focus on developing their applications and growing their fleets with as little friction as possible.

Organization Website: https://balena.io

Reason for PSL Inclusion
====

As part of our service we offer a unique URL per device that each user can use to host custom content like admin interfaces etc. We'd like to protect these domains by including their suffix in the public suffix list.

DNS Verification via dig
=======

```
dig +short TXT _psl.balena-devices.com
"https://github.com/publicsuffix/list/pull/814"
```

```
dig +short TXT _psl.balena-staging-devices.com
"https://github.com/publicsuffix/list/pull/814"
```

make test
=========

I ran the test, all good.
