### PR TITLE
Reserved domains off

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6935,7 +6935,8 @@ yt
 ак.срб
 
 // xn--p1ai ("rf", Russian-Cyrillic) : RU
-// http://www.cctld.ru/en/docs/rulesrf.php
+// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
 рф
 
 // xn--wgbl6a ("Qatar", Arabic) : QA

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5882,7 +5882,7 @@ gov.rs
 in.rs
 org.rs
 
-// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
 // Submitted by George Georgievsky <gug@cctld.ru>
 ru
 
@@ -6934,7 +6934,7 @@ yt
 упр.срб
 ак.срб
 
-// xn--p1ai ("rf", Russian-Cyrillic) : RU
+// Coordination Center for TLD RU and XN--P1AI ("rf", Russian-Cyrillic) : RU
 // ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
 // Submitted by George Georgievsky <gug@cctld.ru>
 рф
@@ -12770,5 +12770,14 @@ site.builder.nu
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
+
+// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
+// Submitted by George Georgievsky <gug@cctld.ru>
+ac.ru
+edu.ru
+gov.ru
+int.ru
+mil.ru
+test.ru
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5882,14 +5882,9 @@ gov.rs
 in.rs
 org.rs
 
-// ru : https://cctld.ru/en/domains/domens_ru/reserved/
+// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
 ru
-ac.ru
-edu.ru
-gov.ru
-int.ru
-mil.ru
-test.ru
 
 // rw : http://www.nic.rw/cgi-bin/policy.pl
 rw

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6934,8 +6934,8 @@ yt
 упр.срб
 ак.срб
 
-// Coordination Center for TLD RU and XN--P1AI ("rf", Russian-Cyrillic) : RU
-// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// xn--p1ai ("rf", Russian-Cyrillic) : RU
+// https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
 // Submitted by George Georgievsky <gug@cctld.ru>
 рф
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5882,7 +5882,7 @@ gov.rs
 in.rs
 org.rs
 
-// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
 // Submitted by George Georgievsky <gug@cctld.ru>
 ru
 
@@ -11028,6 +11028,15 @@ co.no
 webhosting.be
 hosting-cluster.nl
 
+// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
+// Submitted by George Georgievsky <gug@cctld.ru>
+ac.ru
+edu.ru
+gov.ru
+int.ru
+mil.ru
+test.ru
+
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
 dyn.cosidns.de
@@ -12770,14 +12779,5 @@ site.builder.nu
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>
 zone.id
-
-// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
-// Submitted by George Georgievsky <gug@cctld.ru>
-ac.ru
-edu.ru
-gov.ru
-int.ru
-mil.ru
-test.ru
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Description of Organization
====
Coordination Center for TLD RU (CC for TLD RU) is administrator of national top level domains .RU and .РФ (national registry).
Organization Website: https://cctld.ru

Reason of this Pull Request
====

1) CC for TLD RU changed the rules and there are no Reserved domain names at Top level domain .RU at this time. 

Domains 

ac.ru
edu.ru
gov.ru
int.ru
mil.ru
test.ru

is the regular domain names now.

2) New URL for Term and Conditions in section xn--p1ai

