### PR TITLE
Add Carrd suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10887,6 +10887,12 @@ vm.bytemark.co.uk
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu
 
+// Carrd : https://carrd.co
+// Submitted by AJ <aj@carrd.co>
+carrd.co
+crd.co
+uwu.ai
+
 // CentralNic : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com>
 ae.org


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Carrd is a free/paid platform for building responsive one-page sites.

Organization Website: https://carrd.co

Reason for PSL Inclusion
====

Carrd allows users to publish sites to multiple domain suffixes (including `carrd.co` itself, eg. `mysitename.carrd.co`) so we're requesting inclusion in the PSL primarily to ensure cookie isolation/security for sites hosted on the platform.

DNS Verification via dig
=======

```
$ dig +short TXT _psl.carrd.co
"https://github.com/publicsuffix/list/pull/816"
```

```
$ dig +short TXT _psl.crd.co
"https://github.com/publicsuffix/list/pull/816"
```

```
$ dig +short TXT _psl.uwu.ai
"https://github.com/publicsuffix/list/pull/816"
```

make test
=========

Ran and passed!