### PR TITLE
Add Zitcom domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12769,10 +12769,10 @@ bss.design
 
 // Zitcom A/S : https://www.zitcom.dk
 // Submitted by Emil Stahl <esp@zitcom.dk>
-site.builder.nu
 basicserver.io
-enterprisecloud.nu
 virtualserver.io
+site.builder.nu
+enterprisecloud.nu
 
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12770,6 +12770,9 @@ bss.design
 // Zitcom A/S : https://www.zitcom.dk
 // Submitted by Emil Stahl <esp@zitcom.dk>
 site.builder.nu
+basicserver.io
+enterprisecloud.nu
+virtualserver.io
 
 // Zone.id : https://zone.id/
 // Submitted by Su Hendro <admin@zone.id>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====
Zitcom A/S is a hosting and cloud provider.
Organization Website: https://www.zitcom.dk/

Reason for PSL Inclusion
====
The three domains is used for hostnames and reverse DNS for customer servers.  And for that reason the domains should be added to the list, so that cookies is not shared and to get better/more correct Let's Encrypt limits etc.

DNS Verification via dig
=======
```
dig +short TXT _psl.basicserver.io
"https://github.com/publicsuffix/list/pull/817"
```

```
dig +short TXT _psl.enterprisecloud.nu
"https://github.com/publicsuffix/list/pull/817"
```

```
dig +short TXT _psl.virtualserver.io
"https://github.com/publicsuffix/list/pull/817"
```

make test
=========
Ran – no problems.