### PR TITLE
Add dyn53.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12694,6 +12694,10 @@ lib.de.us
 // Submitted by Danko Aleksejevs <danko@very.lv>
 2038.io
 
+// Port53 : https://port53.io/
+// Submitted by Maximilian Schieder <maxi@zeug.co>
+dyn53.io
+
 // Viprinet Europe GmbH : http://www.viprinet.com
 // Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12379,6 +12379,10 @@ on-web.fr
 *.platform.sh
 *.platformsh.site
 
+// Port53 : https://port53.io/
+// Submitted by Maximilian Schieder <maxi@zeug.co>
+dyn53.io
+
 // prgmr.com : https://prgmr.com/
 // Submitted by Sarah Newman <owner@prgmr.com>
 xen.prgmr.com
@@ -12693,10 +12697,6 @@ lib.de.us
 // VeryPositive SIA : http://very.lv
 // Submitted by Danko Aleksejevs <danko@very.lv>
 2038.io
-
-// Port53 : https://port53.io/
-// Submitted by Maximilian Schieder <maxi@zeug.co>
-dyn53.io
 
 // Viprinet Europe GmbH : http://www.viprinet.com
 // Submitted by Simon Kissel <hostmaster@viprinet.com>


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [ ] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://port53.io

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->
I'm the owner of port53, which will run a Anycast DNS Network.

Reason for PSL Inclusion
====

Because user.dyn53.io is used for customers, Cookie Security would be crucial.

DNS Verification via dig
=======

```
dig +short TXT _psl.dyn53.io
"https://github.com/publicsuffix/list/pull/820"
```

make test
=========

I could not getting make test work. It throws errors (make not list errors)