### PR TITLE
Add cloudera.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10979,6 +10979,10 @@ cloudaccess.net
 cloudcontrolled.com
 cloudcontrolapp.com
 
+// Cloudera, Inc. : https://www.cloudera.com/
+// Submitted by Philip Langdale <security@cloudera.com>
+cloudera.site
+
 // Cloudflare, Inc. : https://www.cloudflare.com/
 // Submitted by Jake Riesterer <publicsuffixlist@cloudflare.com>
 workers.dev


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

https://www.cloudera.com

I am an engineer at Cloudera, Inc. We sell enterprise software in both shrink-wrapped and cloud service forms.

Reason for PSL Inclusion
====

As part of Cloudera's cloud service offering, we are adding a feature
to provide customer's access to their resources under a
<customer>.cloudera.site domain.

As we need to provide strong boundaries between customers, we should
add cloudera.site to the public suffix list to ensure that
* Cookies cannot be set to apply across customers
* Certificate generation activity of one customer doesn't affect others

DNS Verification via dig
=======

```
dig +short TXT _psl.cloudera.site
"https://github.com/publicsuffix/list/pull/829"
```

make test
=========

Ran the tests and they passed.