### PR TITLE
Add web.app for Google

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11793,6 +11793,7 @@ goip.de
 // Submitted by Eduardo Vela <evn@google.com>
 run.app
 a.run.app
+web.app
 *.0emm.com
 appspot.com
 blogspot.ae
@@ -11876,7 +11877,6 @@ googleapis.com
 googlecode.com
 pagespeedmobilizer.com
 publishproxy.com
-web.app
 withgoogle.com
 withyoutube.com
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11876,6 +11876,7 @@ googleapis.com
 googlecode.com
 pagespeedmobilizer.com
 publishproxy.com
+web.app
 withgoogle.com
 withyoutube.com
 


### PR DESCRIPTION
Firebase Hosting (owned by Google) recently rolled out support for the web.app domain as a public suffix, this adds it to the list.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [ ] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://firebase.google.com/docs/hosting

Firebase Hosting is a web hosting provider owned by Google. It offers CDN-backed web hosting for static assets and dynamic content powered by Google Cloud Functions.

Reason for PSL Inclusion
====

Cookie security, Let's Encrypt issuance, and our existing shared domain `firebaseapp.com` is already on the PSL.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
