### PR TITLE
Add trycloudflare.com to Cloudflare's suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11008,6 +11008,8 @@ cloudera.site
 // Cloudflare, Inc. : https://www.cloudflare.com/
 // Submitted by Jake Riesterer <publicsuffixlist@cloudflare.com>
 workers.dev
+// Submitted by Adam Chalmers <publicsuffixlist@cloudflare.com>
+trycloudflare.com
 
 // Clovyr : https://clovyr.io
 // Submitted by Patrick Nielsen <patrick@clovyr.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11007,9 +11007,8 @@ cloudera.site
 
 // Cloudflare, Inc. : https://www.cloudflare.com/
 // Submitted by Jake Riesterer <publicsuffixlist@cloudflare.com>
-workers.dev
-// Submitted by Adam Chalmers <publicsuffixlist@cloudflare.com>
 trycloudflare.com
+workers.dev
 
 // Clovyr : https://clovyr.io
 // Submitted by Patrick Nielsen <patrick@clovyr.io>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [ ] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.cloudflare.com

Cloudflare is a cloud computing company and edge provider. We have a product, [Argo Tunnel](https://www.cloudflare.com/products/argo-tunnel/) that lets users set up a reverse proxy on their origins to safely expose local servers to internet traffic via a hostname they configure with Cloudflare. Recently, we [announced a free tier](https://blog.cloudflare.com/a-free-argo-tunnel-for-your-next-project/) for this project. Users can now expose their local servers to the internet on a subdomain of TryCloudflare.com by running `cloudflared tunnel`. This sets up a randomly-chosen subdomain like `a-big-cool-dog.cloudflare.com` for the user's server. As such, each subdomain should be treated as its own host for cookie purposes, etc.

I am an engineer at Cloudflare and the primary developer of the free Argo Tunnel project, aka TryCloudflare.com. I am responsible for most of the commits to support the free tunnels project, e.g. [1](https://github.com/cloudflare/cloudflared/commit/0e6492342b7f91fc27d2a2157a8293d95d6d6c22) and [2](https://github.com/cloudflare/cloudflared/commit/8560436487686452aa54a43d55b26549cf262e21). 

Reason for PSL Inclusion
====

Cloudflare customers will given a subdomain of trycloudflare.com to route traffic to their local servers. Because subdomains are each controlled by different customers, they should be treated as separate domains for cookie purposes.

DNS Verification via dig
=======

```
dig +short TXT _psl.trycloudflare.com
"https://github.com/publicsuffix/list/pull/835"
```

make test
=========

I'm still trying to figure out what I need installed for the tests. I installed `automake` from `brew`, but I get the following output:

```
cd linter;                                \
          ./pslint_selftest.sh;                     \
          ./pslint.py ../public_suffix_list.dat;
-n test_NFKC: 
OK
-n test_allowedchars: 
OK
-n test_dots: 
OK
-n test_duplicate: 
OK
-n test_exception: 
OK
-n test_punycode: 
OK
-n test_section1: 
OK
-n test_section2: 
OK
-n test_section3: 
OK
-n test_section4: 
OK
-n test_spaces: 
OK
-n test_wildcard: 
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
          cd libpsl;                                                                    \
          git pull;                                                                     \
          echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
          echo "CLEANFILES =" >> gtk-doc.make;                                          \
          autoreconf --install --force --symlink;
Already up to date.
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:65: error: possibly undefined macro: AC_MSG_ERROR
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:82: error: possibly undefined macro: AC_LINK_IFELSE
configure.ac:83: error: possibly undefined macro: AC_LANG_PROGRAM
configure.ac:188: error: possibly undefined macro: AC_SEARCH_LIBS
configure.ac:221: error: possibly undefined macro: AC_MSG_CHECKING
configure.ac:226: error: possibly undefined macro: AC_MSG_RESULT
autoreconf: /usr/local/Cellar/autoconf/2.69/bin/autoconf failed with exit status: 1
make: *** [libpsl-config] Error 1
```