### PR TITLE
Add cianfriglia.name

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10961,6 +10961,10 @@ c.la
 // Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org
 
+// Cianfriglia.name
+// Submitted by Simone Cianfriglia <simone@simone.cianfriglia.name>
+cianfriglia.name
+
 // Citrix : https://citrix.com
 // Submitted by Alex Stoddard <alex.stoddard@citrix.com>
 xenapponazure.com


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: N/A

The list says: `name : has 2nd-level tlds, but there's no list of them`.

cianfriglia.name is one of those 2nd-level domains and is actually reserved by Verisign, as can be verified from whois (see below).

I'm Simone Cianfriglia, owner of simone.cianfriglia.name 3rd-level domain and I'm asking for an allowance as discussed in issue #275.

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

Subdomains of cianfriglia.name are controller by different customers, they should be treated as separate domains for cookie purposes.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

`cianfriglia.name` domain is actually managed directly by Verisign, thus making impossible to add TXT records.

The WHOIS Result for `cianfriglia.name` DOMAIN follows:

```
The WHOIS Result for your query is below, under your certification of this information's use. Use .NAME Whois responsibly.

Disclaimer: VeriSign, Inc. makes every effort to maintain the
completeness and accuracy of the Whois data, but cannot guarantee
that the results are error-free. Therefore, any data provided
through the Whois service are on an as is basis without any
warranties.
BY USING THE WHOIS SERVICE AND THE DATA CONTAINED
HEREIN OR IN ANY REPORT GENERATED WITH RESPECT THERETO, IT IS
ACCEPTED THAT VERISIGN, INC. IS NOT LIABLE FOR
ANY DAMAGES OF ANY KIND ARISING OUT OF, OR IN CONNECTION WITH, THE
REPORT OR THE INFORMATION PROVIDED BY THE WHOIS SERVICE, NOR
OMISSIONS OR MISSING INFORMATION. THE RESULTS OF ANY WHOIS REPORT OR
INFORMATION PROVIDED BY THE WHOIS SERVICE CANNOT BE RELIED UPON IN
CONTEMPLATION OF LEGAL PROCEEDINGS WITHOUT FURTHER VERIFICATION, NOR
DO SUCH RESULTS CONSTITUTE A LEGAL OPINION. Acceptance of the
results of the Whois constitutes acceptance of these terms,
conditions and limitations. Whois data may be requested only for
lawful purposes, in particular, to protect legal rights and
obligations. Illegitimate uses of Whois data include, but are not
limited to, unsolicited email, data mining, direct marketing or any
other improper purpose. Any request made for Whois data will be
documented by VeriSign, Inc. but will not be used for any commercial purpose whatsoever.

 ****

Not available for registration.
Second level domain name is reserved.
To request access to data listed as “Redacted” or “Redacted for Privacy” in the
above WHOIS result, please contact Customer Service at info@verisign-grs.com 
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

`make test` ran successfully.
