### PR TITLE
Add lodz.pl domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5680,6 +5680,7 @@ lebork.pl
 legnica.pl
 lezajsk.pl
 limanowa.pl
+lodz.pl
 lomza.pl
 lowicz.pl
 lubin.pl


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.man.lodz.pl/man/

Reason for PSL Inclusion
====

Domain `lodz.pl` exists on https://en.wikipedia.org/wiki/.pl#Regional_domains list, but it is not on public suffix list like another Polish regional domain.
Can't add domain to Cloudflare. They are not recognized as domain.

DNS Verification via dig
=======

```
dig +short TXT katedra.lodz.pl
"https://github.com/publicsuffix/list/pull/842"
```

```
dig +short ns lodz.pl
"https://github.com/publicsuffix/list/pull/842"
```

make test
====
```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```