### PR TITLE
Removed k12.wa.us

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6506,7 +6506,7 @@ k12.ut.us
 k12.vi.us
 k12.vt.us
 k12.va.us
-k12.wa.us
+// k12.wa.us - Removed at the request of Dan Heisel <dan.heisel@watech.wa.gov>
 k12.wi.us
 // k12.wv.us  Bug 947705 - Removed at request of Verne Britton <verne@wvnet.edu>
 k12.wy.us


### PR DESCRIPTION
Hi. So this is certainly a new one for me. My team launched a new site for k12.wa.us and our host is unable to apply an automated public cert for the site. They pointed us here and asked that we remove k12.wa.us from the list so the cert can apply. I've made the change and hope that nothing is out of order. Please be kind if this little change is not correct. Thanks!
