### PR TITLE
Update ye suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7010,7 +7010,12 @@ yt
 xxx
 
 // ye : http://www.y.net.ye/services/domain_name.htm
-*.ye
+ye
+com.ye
+me.ye
+net.ye
+org.ye
+gov.ye
 
 // za : http://www.zadna.org.za/content/page/domain-information
 ac.za


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig (see below)
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: http://www.y.net.ye/services/domain_name.htm (.ye registrar) https://aws.amazon.com (my organization)

I am an engineer at Amazon Web Services working on a product that consumes this list. 

This TLD is the ccTLD for Yemen. 

Reason for PSL Inclusion
====

We have observed a number of registered domains from the .ye name server which do not conform to the `*.ye` rule contained in this list (ex: post.ye, yemennet.ye). This pull request updates the list to allow .ye as a valid suffix on its own and include those second level suffixes I could find that the name server will resolve. 


DNS Verification via dig
=======

I do not own this name server and am unable to provide DNS verification. However, I can provide an example of the name server resolving a domain that does not conform to the current rule:

```
dig +short post.ye
82.114.179.226
```

make test
=========

Tests passed: https://pastebin.com/j2NLbXcV