### PR TITLE
Add *.webhare.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12913,6 +12913,10 @@ voorloper.cloud
 // Submitted by Masayuki Note <masa@blade.wafflecell.com>
 wafflecell.com
 
+// WebHare bv: https://www.webhare.com/
+// Submitted by Arnold Hendriks <info@webhare.com>
+*.webhare.dev
+
 // WeDeploy by Liferay, Inc. : https://www.wedeploy.com
 // Submitted by Henrique Vicente <security@wedeploy.com>
 wedeploy.io


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.webhare.com/

We are WebHare bv; we develop a CMS named WebHare which can be self-installed or is offered as a SaaS. We are a commercial organization but working on open-sourcing (parts of) our CMS - which will be done through https://www.webhare.dev/

The reason we're requesting the PSLs for webhare.dev and not webhare.com is that we're trying to separate the open source/product bits and the company bits.

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

We want to use subdomains under `test.webhare.dev` for continuous integration tests (we have a few automated tests that specifically test cross-domain logins, and require separate cookie jars) and for test and acceptance versions of websites for ourselves and our customers (which require logins to be separated for the sites).

We want to offer subdomains under `user.webhare.dev` to developers and partners who use our CMS to set up their own (possibly publicly accessible) test and development instances and to be able to set up DNS-validated (single or wildcard) SSL certificates for them. If we have a 'safe' subdomain to allocate to users, we can automate the entire provisioning process for them.

Adding `*.webhare.dev` allows both and keeps the PSL a slight bit smaller

DNS Verification via dig
=======

```
Arnolds-MBP:list arnold$ dig -t txt _psl.webhare.dev +short
"https://github.com/publicsuffix/list/pull/847"

```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
I ran the test - https://pastebin.com/zmQXR0vZ