### PR TITLE
Update contact for SymfonyCloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12672,8 +12672,8 @@ my-firewall.org
 myfirewall.org
 spdns.org
 
-// SensioLabs, SAS : https://sensiolabs.com/
-// Submitted by Fabien Potencier <fabien.potencier@sensiolabs.com>
+// Symfony, SAS : https://symfony.com/
+// Submitted by Fabien Potencier <fabien@symfony.com>
 *.s5y.io
 *.sensiosite.cloud
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12672,11 +12672,6 @@ my-firewall.org
 myfirewall.org
 spdns.org
 
-// Symfony, SAS : https://symfony.com/
-// Submitted by Fabien Potencier <fabien@symfony.com>
-*.s5y.io
-*.sensiosite.cloud
-
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua
@@ -12765,6 +12760,11 @@ temp-dns.com
 // Submitted by Matthias.Winzeler <matthias.winzeler@swisscom.com>
 applicationcloud.io
 scapp.io
+
+// Symfony, SAS : https://symfony.com/
+// Submitted by Fabien Potencier <fabien@symfony.com>
+*.s5y.io
+*.sensiosite.cloud
 
 // Syncloud : https://syncloud.org
 // Submitted by Boris Rybalkin <syncloud@syncloud.it>


### PR DESCRIPTION
This updates contact for SymfonyCloud domains.

Symfony SAS became independent in 2018: https://symfony.com/blog/a-business-model-for-symfony
SymfonyCloud, the product using those domains is operated by Symfony SAS: https://symfony.com/blog/meet-the-newest-member-of-the-symfony-family-symfonycloud

DNS update coming after the PR number has been attributed.