### PR TITLE
add nic.za

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7024,6 +7024,7 @@ law.za
 mil.za
 net.za
 ngo.za
+nic.za
 nis.za
 nom.za
 org.za


### PR DESCRIPTION
Description of Organization
====

Organization Website: https://www.zadna.org.za/content/page/domain-information

NZDNA is the administrator of the .ZA top-level domain, the country-code top-level domain for South Africa. I am submitting this change on behalf of Mark Elkins <mje@posix.co.za> who asked for assistance with git-wrangling during the Africa DNS Forum being held this week in Gaborone, Botswana. My name is Joe Abley, and I like to be helpful.

Reason for PSL Inclusion
====

.ZA is already included on the PSL. This change is to add the second-level domain NIC.ZA alongside the other, existing second-level domains. NIC.ZA was added on 5 February 2018 but the PSL has not been updated since then to reflect that change. NIC.ZA should be listed in the PSL for the same reason as all the other second-level domains that are already listed.

The existence of the NIC.ZA second-level domain is documented at the URL already cited in the PSL, https://www.zadna.org.za/content/page/domain-information

DNS Verification via dig
=======

Not applicable. Change to be validated by policy published by the registry at https://www.zadna.org.za/content/page/domain-information

make test
=========

I ran the test and nothing broke.
