### PR TITLE
Add builtwithdark.com to the public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11133,6 +11133,10 @@ store.dk
 *.dapps.earth
 *.bzz.dapps.earth
 
+// Dark, Inc. : https://darklang.com
+// Submitted by Paul Biggar <ops@darklang.com>
+builtwithdark.com
+
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Hi!

Description of Organization
====

Organization Website: https://darklang.com

Our website says:

> Dark is a holistic programming language, structured editor, and infrastructure, for building backend web services. It's for frontend, backend, and mobile engineers.

I'm a co-founder of Dark.

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

Dark allows users to write code that is hosted on subdomains of `builtwithdark.com`. These mutually-untrusted users can currently write code to set cookies for other subdomains; we believe that adding `builtwithdark.com` to the public suffix list is the best way to fix this.

DNS Verification via dig
=======

```
$ dig +short TXT _psl.builtwithdark.com
"https://github.com/publicsuffix/list/pull/857"
```
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

We ran it:

https://gist.github.com/startling/0714e92d58dff744fe9db742636504cf