### PR TITLE
Remove non-public museum domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4339,8 +4339,6 @@ niepce.museum
 norfolk.museum
 north.museum
 nrw.museum
-nuernberg.museum
-nuremberg.museum
 nyc.museum
 nyny.museum
 oceanographic.museum


### PR DESCRIPTION
As technical contact of the current domain owner, I request removal of his domains from the list.

Subdomains are no longer available/for sale/active, this project has been abandoned by the previous owner long ago.

I will add dns records for authentication ASAP:
```
dig +short TXT _psl.nuernberg.museum
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.nuremberg.museum
"https://github.com/publicsuffix/list/pull/XXXX"
```
