### PR TITLE
tools: update newgtlds.go to filter removed gTLDs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7062,7 +7062,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2019-08-02T16:08:27Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2019-08-06T14:14:47-04:00
 // This list is auto-generated, don't edit it manually.
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
@@ -7426,9 +7426,6 @@ bms
 
 // bmw : 2014-01-09 Bayerische Motoren Werke Aktiengesellschaft
 bmw
-
-// bnl : 2014-07-24 Banca Nazionale del Lavoro
-bnl
 
 // bnpparibas : 2014-05-29 BNP Paribas
 bnpparibas
@@ -8483,9 +8480,6 @@ homesense
 // honda : 2014-12-18 Honda Motor Co., Ltd.
 honda
 
-// honeywell : 2015-07-23 Honeywell GTLD LLC
-honeywell
-
 // horse : 2013-11-21 Minds + Machines Group Limited
 horse
 
@@ -8602,9 +8596,6 @@ ipiranga
 
 // irish : 2014-08-07 Binky Moon, LLC
 irish
-
-// iselect : 2015-02-11 iSelect Ltd
-iselect
 
 // ismaili : 2015-08-06 Fondation Aga Khan (Aga Khan Foundation)
 ismaili
@@ -9865,9 +9856,6 @@ staples
 
 // star : 2015-01-08 Star India Private Limited
 star
-
-// starhub : 2015-02-05 StarHub Ltd
-starhub
 
 // statebank : 2015-03-12 STATE BANK OF INDIA
 statebank

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -85,6 +85,9 @@ type pslEntry struct {
 	// ICANN. When rendered by the pslTemplate only entries with
 	// ContractTerminated = false are included.
 	ContractTerminated bool
+	// RemovalDate indicates the date the gTLD delegation was removed from the
+	// root zones.
+	RemovalDate string
 }
 
 // normalize will normalize a pslEntry by mutating it in place to trim the
@@ -152,7 +155,7 @@ func getData(url string) ([]byte, error) {
 }
 
 // filterGTLDs removes entries that are present in the legacyGTLDs map or have
-// ContractTerminated equal to true.
+// ContractTerminated equal to true, or a non-empty RemovalDate.
 func filterGTLDs(entries []*pslEntry) []*pslEntry {
 	var filtered []*pslEntry
 	for _, entry := range entries {
@@ -160,6 +163,9 @@ func filterGTLDs(entries []*pslEntry) []*pslEntry {
 			continue
 		}
 		if entry.ContractTerminated {
+			continue
+		}
+		if entry.RemovalDate != "" {
 			continue
 		}
 		filtered = append(filtered, entry)

--- a/tools/newgtlds_test.go
+++ b/tools/newgtlds_test.go
@@ -273,6 +273,12 @@ func TestGetPSLEntriesEmptyFilteredResults(t *testing.T) {
 				// NOTE: Setting ContractTerminated to ensure filtering.
 				ContractTerminated: true,
 			},
+			{
+				ALabel:                  "removed",
+				DateOfContractSignature: "1999-10-31",
+				RegistryOperator:        "Department of Historical Baggage and Technical Debt",
+				RemovalDate:             "2019-08-06",
+			},
 		},
 	}
 


### PR DESCRIPTION
The tooling added in https://github.com/publicsuffix/list/pull/834 had support for removing gTLDs previously added to the `public_suffix_list.dat` file when the registry contract was terminated: https://github.com/publicsuffix/list/blob/38eb4c45a1e47cb7daa8eee202e3993e4ffcade5/tools/newgtlds.go#L162-L164

In practice I see gTLDs that are removed from the root zones but do not have a terminated contract. E.g. consider `.bnl`, which was marked removed on `2019-07-30` but has `"contractTerminated": false`:
```
$ curl https://www.icann.org/resources/registries/gtlds/v2/gtlds.json 2>/dev/null |  jq '.gTLDs | .[] | select(.gTLD=="bnl")'
{
  "applicationId": "1-1257-44806",
  "contractTerminated": false,
  "dateOfContractSignature": "2014-07-24",
  "delegationDate": "2015-06-26",
  "gTLD": "bnl",
  "registryClassDomainNameList": null,
  "registryOperator": "Banca Nazionale del Lavoro",
  "registryOperatorCountryCode": null,
  "removalDate": "2019-07-30",
  "specification13": null,
  "thirdOrLowerLevelRegistration": false,
  "uLabel": null
}
```

It seems like removing gTLDs with a non-empty removal date would be helpful for the PSL tooling to keep the gTLD section up to date and tidy. 

This branch implements the change to the tooling in ae01d35 The corresponding updates to the `public_suffix_list.dat` file are implemented in 7063200, removing four gTLDs that have been marked removed in the ICANN v2 gTLD json:

* `.bnl`       -> removed 2019-07-30
* `.honeywell` -> removed 2019-06-06
* `.iselect`   -> removed 2019-08-05
* `.starhub`   -> removed 2019-08-02

Once this PR is merged the @tld-update-bot will handle this class of removals automatically going forward.
