### PR TITLE
Remove site.builder.nu

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12991,7 +12991,6 @@ bss.design
 // Submitted by Emil Stahl <esp@zitcom.dk>
 basicserver.io
 virtualserver.io
-site.builder.nu
 enterprisecloud.nu
 
 // Zone.id : https://zone.id/


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====


Organization Website: https://www.zitcom.dk

Zitcom A/S is a hosting and cloud provider.

Reason for PSL removal
====

site.builder.nu is used for our site builder product. Each customer is assigned a subdomain on *.site.builder.nu -like [randomstring].site.builder.nu.

However as we use a *.site.builder.nu wildcard, the inclusion means that we need to get an exception from the CA, when the cert needs to be renewed, and that is not feasible. And as we has full control over the entire *.site.builder.nu space, we wish site.builder.nu to be **removed** from the PSL.

DNS Verification via dig
=======

```
dig +short TXT _psl.site.builder.nu
"https://github.com/publicsuffix/list/pull/866"
```

make test
=========

Ran the test, nothing broke
<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->