### PR TITLE
Add new domain to Synology dynamic dns service.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12778,6 +12778,7 @@ i234.me
 myds.me
 synology.me
 vpnplus.to
+direct.quickconnect.to
 
 // TAIFUN Software AG : http://taifun-software.de
 // Submitted by Bjoern Henke <dev-server@taifun-software.de>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website:  https://www.synology.com 
Synology Inc. is a corporation that specializes in Network-attached storage (NAS) appliances.

Reason for PSL Inclusion
====
Hello, I'm engineer from synology.com and we would like to add a new domain for our public dynamic dns service. (refer to #62)

DNS Verification via dig
=======
```
dig +short TXT _psl.direct.quickconnect.to
"https://github.com/publicsuffix/list/pull/867"
```


make test
=========
Here are the validated make test
https://paste.yunohost.org/igonijahum.coffeescript
