### PR TITLE
Update Hostbip Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11934,6 +11934,7 @@ col.ng
 firm.ng
 gen.ng
 ltd.ng
+ngo.ng
 ng.school
 sch.so
 


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====
Organization Website: https://hostbip.com

'HostBip' is a 'PDNR' (Private Domain Name Registry), allowing 3rd parties to register domain names in a variety of domain name extensions / suffixes.


Reason for PSL Inclusion
====
'HostBip' has an existing section in the 'Public Suffix List', and is updating it's section to include additional domain extensions / suffixes in it's portfolio.

This request is seeking to add these to the PSL so the individuals / institutions operating under these suffixes can gain access to services such as Let's Encrypt, Cloudflare and that other third party systems may better be able to identify the level at which the personal/private name has been registered.


DNS Verification via dig
=======

```
dig +short TXT _psl.ngo.ng
"https://github.com/publicsuffix/list/pull/871"
```


make test
=========

I ran the test with make test.

```
===========================================
Testsuite summary for libpsl 0.21.0
===========================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
===========================================

```