### PR TITLE
Add blmgroep.nl as Private Domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10871,6 +10871,10 @@ bnr.la
 // Submitted by Paul Crowder <paul.crowder@blackbaud.com>
 blackbaudcdn.net
 
+// BLMGroep
+// Submitted by Bob van den Heuvel <publicsuffixlist@blmgroep.nl>
+blmgroep.nl
+
 // Boomla : https://boomla.com
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: no website

This domain is used for private and personal(/student) development. 

Reason for PSL Inclusion
====

As a private teacher I provide free subdomains to my students. This PR will help them with cookie domain scoping.

DNS Verification via dig
=======

```
dig +short TXT _psl.blmgroep.nl
"https://github.com/publicsuffix/list/pull/876"
```


make test
=========

Ran the test, all passed.
