### PR TITLE
Update on-rancher.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12600,6 +12600,7 @@ rackmaze.net
 
 // Rancher Labs, Inc : https://rancher.com
 // Submitted by Vincent Fiduccia <domains@rancher.com>
+*.on-k3s.io
 *.on-rancher.cloud
 *.on-rio.io
 


### PR DESCRIPTION
 * [x] Description of Organization
 * [x] Reason for PSL Inclusion
 * [x] DNS verification via dig
 * [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://rancher.com

Rancher Labs develops an open-source Kubernetes distribution and management platform called Rancher.

I am [Vincent Fiduccia](https://github.com/vincent99), software architect at Rancher.

Reason for PSL Inclusion
====

This entry already exists (#779), but we would like to add another "*." onto it so that it can be split into multiple DNS zones to control the number of records that will live in each one.

(There are no records in on-rancher.cloud yet so there is no concern for current records becoming public.  on-rio.io is in use and is not changing.)

We are adding a feature to automatically provide each user cluster with a `<service name>.<random user-id>.<shard>.on-rancher.cloud` DNS entry, so each `user-id` is a mutually untrusting third-party that should not be able to set cookies readable by each other.  We also plan to provide Let's Encrypt wildcard certs for each `user-id`.

DNS Verification via dig
=======

```
dig +short TXT _psl.on-rancher.cloud
"https://github.com/publicsuffix/list/pull/879"
```

make test
=========

Says `12591: error: Illegal character: '*.*.on-rancher.cloud'`, but the [specification](https://publicsuffix.org/list/) specifically says this should be allowed?

`(I.e. *.*.foo is a valid rule: *bar.foo is not.)`