### PR TITLE
Add "urown.cloud" and "dnsupdate.info"

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12882,6 +12882,10 @@ inc.hk
 virtualuser.de
 virtual-user.de
 
+// urown.net : https://urown.net
+// Submitted by Hostmaster <hostmaster@urown.net>
+urown.cloud
+
 // .US
 // Submitted by Ed Moore <Ed.Moore@lib.de.us>
 lib.de.us

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12885,6 +12885,7 @@ virtual-user.de
 // urown.net : https://urown.net
 // Submitted by Hostmaster <hostmaster@urown.net>
 urown.cloud
+dnsupdate.info
 
 // .US
 // Submitted by Ed Moore <Ed.Moore@lib.de.us>


### PR DESCRIPTION
- [x] Description of Organization
- [x] Reason for PSL Inclusion
- [x] DNS verification via dig
- [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://urown.net

The domains "dnsupdate.info" and "urown.cloud" are privately owned and made available for free use by the public with the dynamic DNS service https://nsupdate.info/.

Reason for PSL Inclusion
====

nsupdate.info strongly advises to add public domains to the public suffix list.


DNS Verification via dig
=======

```
dig +short TXT _psl.urown.cloud
"https://github.com/publicsuffix/list/pull/880"
dig +short TXT _psl.dnsupdate.info
"https://github.com/publicsuffix/list/pull/880"
```

make test
=========

https://travis-ci.org/publicsuffix/list/builds/616010823
