### PR TITLE
Add the new TLD .ss

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6047,6 +6047,18 @@ org.so
 // sr : https://en.wikipedia.org/wiki/.sr
 sr
 
+// ss : https://registry.nic.ss/
+// IANA https://www.iana.org/domains/root/db/ss.html
+// Enquiries <technical@nic.ss>
+// Please note that the 2nd level(.ss) is only used by the registry (e.g nic.ss) not open to the public
+ss
+biz.ss
+com.ss
+edu.ss
+gov.ss
+net.ss
+org.ss
+
 // st : http://www.nic.st/html/policyrules/
 st
 co.st
@@ -7058,18 +7070,6 @@ co.zw
 gov.zw
 mil.zw
 org.zw
-
-// ss : https://registry.nic.ss/
-// IANA https://www.iana.org/domains/root/db/ss.html
-// Enquiries <technical@nic.ss>
-// Please note that the 2nd level(.ss) is only used by the registry (e.g nic.ss) not open to the public
-ss
-edu.ss
-com.ss
-net.ss
-biz.ss
-gov.ss
-org.ss
 
 // newGTLDs
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7069,6 +7069,7 @@ gov.zw
 mil.zw
 org.zw
 
+
 // newGTLDs
 
 // List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2019-09-10T15:21:14Z

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6048,9 +6048,7 @@ org.so
 sr
 
 // ss : https://registry.nic.ss/
-// IANA https://www.iana.org/domains/root/db/ss.html
-// Enquiries <technical@nic.ss>
-// Please note that the 2nd level(.ss) is only used by the registry (e.g nic.ss) not open to the public
+// Submitted by registry <technical@nic.ss>
 ss
 biz.ss
 com.ss

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7059,6 +7059,17 @@ gov.zw
 mil.zw
 org.zw
 
+// ss : https://registry.nic.ss/
+// IANA https://www.iana.org/domains/root/db/ss.html
+// Enquiries <technical@nic.ss>
+// Please note that the 2nd level(.ss) is only used by the registry (e.g nic.ss) not open to the public
+ss
+edu.ss
+com.ss
+net.ss
+biz.ss
+gov.ss
+org.ss
 
 // newGTLDs
 


### PR DESCRIPTION
Description of Organization
<hr>
<a href="https://www.iana.org/domains/root/db/ss.html">.ss </a>is the designated country code top-level domain (ccTLD) for South Sudan as approved by the ICANN board on 27 January 2019 and added to the DNS root zone on 2 February 2019.

Reason for PSL Inclusion
<hr>
To have the .ss ccTLD to be included in the public list for any applications referencing the list.