### PR TITLE
Add altervista.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10688,6 +10688,10 @@ barsy.ca
 *.compute.estate
 *.alces.network
 
+// Altervista: https://www.altervista.org
+// Submitted by Carlo Cannas <tech_staff@altervista.it>
+altervista.org
+
 // alwaysdata : https://www.alwaysdata.com
 // Submitted by Cyril <admin@alwaysdata.com>
 alwaysdata.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.altervista.org

Altervista is a free web hosting service.

Each registered user gets its own subdomain (e.g. username.altervista.org) on which PHP scripts can be uploaded and executed.

Reason for PSL Inclusion
====

We'd like to properly isolate each subdomain to prevent global cookie setting on altervista.org and highlight that each subdomain hosts a different site, unrelated to the others.

DNS Verification via dig
=======

```
$ dig +short TXT _psl.altervista.org
"https://github.com/publicsuffix/list/pull/883"
```

make test
=========

https://gist.github.com/CarloCannas/ed43e1ddf23541659c6e296c1cfc5ed3
https://travis-ci.org/publicsuffix/list/builds/586473517
