### PR TITLE
Add additional Handshake resolver (hsd.zone)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11891,6 +11891,8 @@ conf.se
 // Submitted by Mike Damm <md@md.vc>
 hs.zone
 hs.run
+// Submitted by Jacob H. Haven <jacob@jhaven.me>
+hsd.zone
 
 // Hashbang : https://hashbang.sh
 hashbang.sh


### PR DESCRIPTION
* [x]  Description of Organization
* [x]  Reason for PSL Inclusion
* [x]  DNS verification via dig
* [x]  Run Syntax Checker (make test)

Organization Website: https://handshake.org/

Handshake is a decentralized, permissionless naming protocol compatible with DNS where every peer is validating and in charge of managing the root zone with the goal of creating an alternative to existing Certificate Authorities. Its purpose is not to replace the DNS protocol, but to replace the root zone file and the root servers with a public commons. The Handshake protocol maintains the root zone file in a decentralized manner, making the root zone uncensorable, permissionless, and free of gatekeepers.

I am a developer for this project.

# Reason for PSL Inclusion
Names registered in Handshake can be resolved as a prefix of the hsd.zone, allowing clients not running Handshake to look up these names. Because multiple parties can indirectly register names under these zones, cookie isolation is highly desirable.

hsd.zone is being added in addition to hs.zone / hs.run added in #796 for independent testing of different resolver configurations.

# DNS Verification via dig
```
$ dig +short IN TXT _psl.hsd.zone.
"https://github.com/publicsuffix/list/issues/884"

```

# make test
Tested. https://pastebin.com/raw/dmyjDjLv

```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```