### PR TITLE
Add 0e.vc to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11740,6 +11740,10 @@ firebaseapp.com
 flynnhub.com
 flynnhosting.net
 
+// Frederik Braun https://frederik-braun.com
+// Submitted by Frederik Braun <fb@frederik-braun.com>
+0e.vc
+
 // Freebox : http://www.freebox.fr
 // Submitted by Romain Fliedel <rfliedel@freebox.fr>
 freebox-os.com


### PR DESCRIPTION
We'd like to properly isolate each subdomain to prevent global cookie setting
on 0e.vc and highlight that each subdomain hosts a different site,
unrelated to the others.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)


Description of Organization
====
I'm representing myself, as an individual.
I will host content that would benefit from being isolated at the PSL level.

Organization Website: https://frederik-braun.com/



Reason for PSL Inclusion
====

Isolation of Cookies, mostly. (Plus some other minor oddities, that might prefer the PSL instead of a proper Same-Origin Policy Check)

DNS Verification via dig
=======
```
$ dig +short -t TXT _psl.0e.vc
"https://github.com/publicsuffix/list/pull/896"
```

make test
=========

All tests passed.
