### PR TITLE
Remove outdated asterisk for Yemeni suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -7026,7 +7026,15 @@ yt
 xxx
 
 // ye : http://www.y.net.ye/services/domain_name.htm
-*.ye
+ye
+com.ye
+co.ye
+ltd.ye
+me.ye
+net.ye
+org.ye
+plc.ye
+gov.ye
 
 // za : https://www.zadna.org.za/content/page/domain-information/
 ac.za


### PR DESCRIPTION
The use of an asterisk before *.ye suggests that this suffix does
does not allow domain names to be registered directly under the suffix,
but instead must be registered as a third level name.

There is ample empirical evidence that this is outdated;  the
page http://althawrah.ye/archives/597366 is 200-OK as of
Thu Oct 17 11:31:44 EDT 2019, and althawrah is the actual domain,
not second-level domain or part of the suffix.

Related discussion:

> https://stackoverflow.com/q/58434990/7954504
