### PR TITLE
Add gov.scot to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12668,6 +12668,10 @@ logoip.com
 // Submitted by Hanno Böck <hanno@schokokeks.org>
 schokokeks.net
 
+// Scottish Government: https://www.gov.scot
+// Submitted by Martin Ellis <martin.ellis@gov.scot>
+gov.scot
+
 // Scry Security : http://www.scrysec.com
 // Submitted by Shante Adam <shante@skyhat.io>
 scrysec.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.gov.scot

The Scottish Government is the devolved government for Scotland. There is no ccTLD for Scotland, but there is a geographic gTLD: `.scot`. The gov.scot domain is used by the Scottish Government and other public sector organisations in Scotland.

The lack of ccTLD for Scotland means that this proposed entry appears in an unusual place in the list for a government domain. From the commit message:

> This entry for gov.scot appears in the private domains section of the list.  This is in contrast to most `gov.*` domains in the list, which appear in the ICANN section of the list, near or alongside the relevant country code.  This is because the .scot domain is a (geographic) gTLD and the gTLD section of the list is auto-generated, so the entry for `gov.scot` cannot be added alongside the entry for `.scot`. Use of the private domains section is consistent with, for example, `service.gov.uk`.

Please see Section 4 of this "Gov.scot domains" publication for information about which organisations are eligible to register gov.scot domains:
https://www.gov.scot/publications/govscot-domains/

Registration of gov.scot domains is handled by JISC:

* Instructions:
https://community.jisc.ac.uk/library/network-and-technology-service-documentation/register-govscot
* Form: https://www.jisc.ac.uk/forms/govscot-domain-registration-form

My role is as a software engineer in the Digital directorate at the Scottish Government (possibly devops or infrastructure engineer, depending on who you ask). My responsibilities include the hosting of gov.scot and www.gov.scot web sites (the former redirecting to the latter), and coordinating DNS changes for both www.gov.scot and the gov.scot apex domain with JISC.

This change follows consultation with:

* the Technical Director in the Digital Directorate;
* the Information Security Officer in the Digital Directorate;
* Digital Communications in the Scottish Government;
* JISC; and
* Demys (who provide DNS hosting for many (all?) gov.scot domains).

Reason for PSL Inclusion
====

*Cookies*: We'd like to avoid super-cookies being set on the gov.scot domain. Subdomains of gov.scot are owned by other organisations and we have concerns about the security of subdomains sharing the same cookie namespace. In particular, because some public sector services will be handling sensitive user information. Our team is responsible for web hosting of the gov.scot apex domain, so I'm also keen that we don't inadvertently set any cookies that could cause issues with the behaviour of other sites.

*Consistency*: The PSL currently includes many entries of the form `gov.tld`, such as `gov.uk`. This change ensures that the gov.scot domain is handled by browsers in a way that is consistent with domains used by other governments. This helps us be more confident about security on the domain, and I understand may also have benefits browser UIs.

*Let's Encrypt*: We're aware that PSL maintainers are concerned about use of the PSL to circumvent rate limits for this service. We do use Let's Encrypt at the Scottish Government, but our usage is not such that we need increased rate limits. However, we are concerned that if another public sector organisation in Scotland had a bug in their Let's Encrypt automation, then it could cause problems for us as we currently share the same usage limits with that organisation. We believe this change ensures that Let's Encrypt service limits are applied as intended, rather than something that circumvents PSL policy.
 
DNS Verification via dig
=======

```
dig +short TXT _psl.gov.scot
"https://github.com/publicsuffix/list/pull/904"
```

make test
=========

```
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

👍

