### PR TITLE
Remove go-vip.co, go-vip.net, and wpcomstaging.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10845,12 +10845,6 @@ sweetpepper.org
 // Submitted by Vincent Tseng <vincenttseng@asustor.com>
 myasustor.com
 
-// Automattic Inc. : https://automattic.com/
-// Submitted by Alex Concha <alex.concha@automattic.com>
-go-vip.co
-go-vip.net
-wpcomstaging.com
-
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Automattic (https://automattic.com/) is a company behind WordPress.com, where the users can create websites and blogs for free and enhance those sites with our premium services.

Reason for PSL ~Inclusion~ Exclusion
====

This PR seeks to undo changes made in #719 and #793 so that wildcard SSL certificates can be obtained.

DNS Verification via dig
=======

```
dig +short TXT _psl.go-vip.co
"https://github.com/publicsuffix/list/pull/XXXX"

dig +short TXT _psl.go-vip.net
"https://github.com/publicsuffix/list/pull/XXXX"

dig +short TXT _psl.wpcomstaging.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

make test
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
