### PR TITLE
Update source of reserved .it geo-names

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1368,7 +1368,7 @@ it
 gov.it
 edu.it
 // Reserved geo-names (regions and provinces):
-// http://www.nic.it/sites/default/files/docs/Regulation_assignation_v7.1.pdf
+// https://www.nic.it/sites/default/files/archivio/docs/Regulation_assignation_v7.1.pdf
 // Regions
 abr.it
 abruzzo.it


### PR DESCRIPTION
http://www.nic.it/sites/default/files/docs/Regulation_assignation_v7.1.pdf is no more available.

The new URL of that PDF is https://www.nic.it/sites/default/files/archivio/docs/Regulation_assignation_v7.1.pdf - see [this page](https://www.nic.it/en/doc/2015/assignment-and-management-domain-names-cctdlit-regulations-version-71).
