### PR TITLE
Add dyndns.dappnode.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11137,7 +11137,7 @@ reg.dk
 store.dk
 
 // dappnode.io : https://dappnode.io/
-// Submitted by Abel Boldu / DAppNode Team <info@dappnode.io>
+// Submitted by Abel Boldu / DAppNode Team <community@dappnode.io>
 dyndns.dappnode.io
 
 // dapps.earth : https://dapps.earth/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11136,6 +11136,10 @@ firm.dk
 reg.dk
 store.dk
 
+// dappnode.io : https://dappnode.io/
+// Submitted by Abel Boldu / DAppNode Team <info@dappnode.io>
+dyndns.dappnode.io
+
 // dapps.earth : https://dapps.earth/
 // Submitted by Daniil Burdakov <icqkill@gmail.com>
 *.dapps.earth


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://dappnode.io/

I'm a software and systems engineer working at DAppNode.
DAppNode is a solution to allow users to conveniently host P2P and distributed technologies on their own hardware, with focus on blockchain and cryptocurrency projects.

DAppNode software is an open-source platform developed by the non-profit association DAppNode association in Zug, Switzerland. DAppNode Association is driven and funded by the community, at the moment we have three grants from EF, Aragon, and ECF, but the association also has sustainability sources relying on projects that want their package uploaded to DAppNode and featured in the installer section, or the selling of hardware with DAppNode preinstalled which implies a donation to the association for every piece of hardware with DAppNode pre-installed sold, we are also backed by individual donors and supporters.

Reason for PSL Inclusion
====

We offer a dynamic DNS service to our users so they can easily access their hardware running at home. Hosted services and APIs can be reachable through a VPN, but we also want to expose them using domains with the form <userid>.dyndns.dappnode.io so users can host their own services. Those can be full nodes, hosted cloud storage, dsitributed apps (DApps), IPFS gateways, etc.
We want to improve cookie security of such services, and identify them as part of their own dynamic domain recognized as a public suffix. We also want to add SSL security to them and this inclusion would make it easier to generate Let's Encrypt certificates in case it's needed.

DNS Verification via dig
=======

    dig +short TXT _psl.dyndns.dappnode.io
    "https://github.com/publicsuffix/list/pull/912"


make test
=========

The test passed successfully