### PR TITLE
Add regnumneapolitanum.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11114,6 +11114,12 @@ cupcake.is
 cyon.link
 cyon.site
 
+// Daftano: https://www.daftano.com
+// Submitted by Davide Fiorentino lo Regio <public-suffix@daftano.com>
+*.regnumneapolitanum.com
+!www.regnumneapolitanum.com
+!api.regnumneapolitanum.com
+
 // Daplie, Inc : https://daplie.com
 // Submitted by AJ ONeal <aj@daplie.com>
 daplie.me


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://daftano.com

I am the founder.
The domain will provide hosting and domain names to business and individuals related to the Neapolitan culture.

Reason for PSL Inclusion
====

**_Cookie Security_**
The main purpose is to allow each assignee to set its cookies securely and keep them separate from those of the main server (www|api)

The * is required because each assignee will belong to specific geographical regions, e.g.:

**Cookies may not be set for:**
- ac.regnumneapolitanum.com
- asia.regnumneapolitanum.com
- north.regnumneapolitanum.com

**Cookies may be set for:**
- regnumneapolitanum.com
- api.regnumneapolitanum.com
- www.regnumneapolitanum.com
- www.south.regnumneapolitanum.com
- business.ad.regnumneapolitanum.com managed by Alice
- business.xyz.regnumneapolitanum.com managed by Bob


DNS Verification via dig
=======

```
dig +short TXT _psl.regnumneapolitanum.com
"https://github.com/publicsuffix/list/pull/913"
```
make test
=========

All passed:

```
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```