### PR TITLE
add localzone.xyz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12121,6 +12121,10 @@ nodebalancer.linode.com
 // Submitted by Victor Velchev <admin@liquidnetlimited.com>
 we.bs
 
+// localzone.xyz
+// Submitted by Kenny Niehage <hello@yahe.sh>
+localzone.xyz
+
 // Log'in Line : https://www.loginline.com/
 // Submitted by Rémi Mach <remi.mach@loginline.com>
 loginline.app


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://yahe.sh

**localzone.xyz** is meant as a domain to be used in internal networks to circumvent the problems layed out [by the ICANN](https://www.icann.org/en/system/files/files/name-collision-mitigation-05dec13-en.pdf). To date there is only the **home.arpa** domain as specified in [RFC 8375](https://tools.ietf.org/html/rfc8375) but which is not widely used.

Reason for PSL Inclusion
====

The reason for inclusion is Cookie Security.

DNS Verification via dig
=======

```
yahe@YaheBookAir:~$ dig +short TXT _psl.localzone.xyz
"https://github.com/publicsuffix/list/pull/915"
```

make test
=========

Executed `make test` successfully:
https://gist.github.com/yahesh/cd9e116b2a7af577cf796fe4f7cc485c