### PR TITLE
Added gentapps.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11770,8 +11770,9 @@ service.gov.uk
 gehirn.ne.jp
 usercontent.jp
 
-// Gentlent, Limited : https://www.gentlent.com
-// Submitted by Tom Klein <tklein@gentlent.com>
+// Gentlent, Inc. : https://www.gentlent.com
+// Submitted by Tom Klein <tom@gentlent.com>
+gentapps.com
 lab.ms
 
 // GitHub, Inc.


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: [https://www.gentlent.com](https://www.gentlent.com)

I am a director and engineer at Gentlent, which is a software development and consulting company.

Reason for PSL Inclusion
====

We are going to use gentapps.com for user-specific spaces and projects for our upcoming SaaS products. DynDNS may be included later too. As our users may upload custom content to these domains, they should not set cookies on the root domain. Browsers should therefore recognize gentapps.com as a suffix.

DNS Verification via dig
=======

```
dig +short TXT _psl.gentapps.com
"https://github.com/publicsuffix/list/pull/916"
```

make test
=========

I ran "make test" with all tests passing. See [https://gist.github.com/tomkln/f291349514901d3a6b3c5384e8e2efd3](https://gist.github.com/tomkln/f291349514901d3a6b3c5384e8e2efd3)
