### PR TITLE
Add *.r.appspot.com to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11816,6 +11816,8 @@ a.run.app
 web.app
 *.0emm.com
 appspot.com
+r.appspot.com
+*.r.appspot.com
 blogspot.ae
 blogspot.al
 blogspot.am


### PR DESCRIPTION
* [x] Description of Organization

The organization is Google. We are adding a new URL format for App Engine. Similar to the existing appspot.com (already on PSL), subdomains under *.r.appspot.com (e.g. foo.xyz.r.appspot.com) will each serve different customer apps.

* [x] Reason for PSL Inclusion

Same as existing appspot.com.

* [x] DNS verification via dig

Working on this. Needed to submit PR first to get a number to add to DNS.

Once it's ready, will be available at `dig +short TXT _psl.r.appspot.com`.

* [x] Run Syntax Checker (make test)

Passes.