### PR TITLE
Add *.on-k3s.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12600,6 +12600,7 @@ rackmaze.net
 
 // Rancher Labs, Inc : https://rancher.com
 // Submitted by Vincent Fiduccia <domains@rancher.com>
+*.on-k3s.io
 *.on-rancher.cloud
 *.on-rio.io
 


### PR DESCRIPTION
 * [x] Description of Organization
 * [x] Reason for PSL Inclusion
 * [x] DNS verification via dig
 * [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://rancher.com

Rancher Labs develops an open-source Kubernetes distribution called K3s

I am [Vincent Fiduccia](https://github.com/vincent99), software architect at Rancher.

Reason for PSL Inclusion
====

We are adding a feature to automatically provide each user cluster with a `<random user-id>.on-k3s.io` DNS entry that can be used to reach published Kubernetes services (largely HTTP servers). Each `user-id` is a mutually untrusting third-party that should not be able to set cookies readable by each other.  We also plan to provide Let's Encrypt wildcard certs for each `user-id`.

DNS Verification via dig
=======

```
dig +short TXT _psl.on-k3s.io
"https://github.com/publicsuffix/list/pull/922"
```

make test
=========

Passes