### PR TITLE
Add edgestack.me private domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11126,6 +11126,10 @@ store.dk
 *.dapps.earth
 *.bzz.dapps.earth
 
+// Datawire, Inc : https://www.datawire.io
+// Submitted by Richard Li <secalert@datawire.io>
+edgestack.me
+
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.datawire.io

We build software for organizations deploying applications to Kubernetes.

Reason for PSL Inclusion
====

To simplify the onboarding experience, we want to give users the ability to dynamically register a DNS name that points to their Ambassador instance.

DNS Verification via dig
=======

```
:~> dig +short txt _ps1.edgestack.me
"https://github.com/publicsuffix/list/pull/925"
```
make test
=========


```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
