### PR TITLE
Add wixsite.com and editorx.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13617,6 +13617,10 @@ meinforum.net
 wpenginepowered.com
 js.wpenginepowered.com
 
+// Wix.com, Inc. : https://www.wix.com
+// Submitted by Shahar Talmi <shahart@wix.com>
+wixsite.com
+
 // XenonCloud GbR: https://xenoncloud.net
 // Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>
 half.host

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13620,6 +13620,7 @@ js.wpenginepowered.com
 // Wix.com, Inc. : https://www.wix.com
 // Submitted by Shahar Talmi <shahart@wix.com>
 wixsite.com
+editorx.io
 
 // XenonCloud GbR: https://xenoncloud.net
 // Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.wix.com

Wix is a website building platform.

Registered users get their own subdomain (e.g. username.wixsite.com or username.editorx.io) on which their sites are hosted.

Reason for PSL Inclusion
====

We'd like to properly isolate each subdomain to prevent global cookie setting on wixsite.com/editorx.io and highlight that each subdomain hosts sites of a different user, unrelated to the others.

DNS Verification via dig
=======

```
dig +short TXT _psl.wixsite.com
"https://github.com/publicsuffix/list/pull/927"
```

```
dig +short TXT _psl.editorx.io
"https://github.com/publicsuffix/list/pull/927"
```

make test
=========

https://gist.github.com/shahata/d1c21c6a7fc30c3f0f2cc9e29fe89add