### PR TITLE
Added adobeaemcloud domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10657,6 +10657,12 @@ cc.ua
 inf.ua
 ltd.ua
 
+// Adobe : https://www.adobe.com/
+// Submitted by Ian Boston <boston@adobe.com>
+adobeaemcloud.com
+adobeaemcloud.net
+*.dev.adobeaemcloud.com
+
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://www.adobe.com

I am an Engineer working at Adobe in the Adobe Experience Manager organisation working on SaaS hosting.

Reason for PSL Inclusion
====
Cookie Security between subdomains since the subdomains will be managed and run by different organisations with the ability to set cookies.


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

Done
$ dig +short TXT _psl.adobeaemcloud.com
"https://github.com/publicsuffix/list/pull/931"
$ dig +short TXT _psl.adobeaemcloud.net
"https://github.com/publicsuffix/list/pull/931"
$ dig +short TXT _psl.dev.adobeaemcloud.com
"https://github.com/publicsuffix/list/pull/931"


make test
=========

make test and other validations have been run.

```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```



No breakages or syntax rule failures.

