### PR TITLE
Add platter.dev user app domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12563,6 +12563,12 @@ on-web.fr
 *.platform.sh
 *.platformsh.site
 
+// Platter: https://platter.dev
+// Submitted by Patrick Flor <patrick@platter.dev>
+platter-app.com
+platter-app.dev
+platterp.us
+
 // Port53 : https://port53.io/
 // Submitted by Maximilian Schieder <maxi@zeug.co>
 dyn53.io


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://platter.dev

Platter (Boilerplatter, Inc.) is a product development platform for developers. We create, host, and continuously deploy sites for our users on subdomains of platter-app.com, platter-app.dev, and platterp.us.


Reason for PSL Inclusion
====

We want to be able to do the following for our users on these subdomains:

- protect against cross-subdomain cookie/state sharing via the higher level domain suffixes
- use subdomains as Google OAuth Authorized Domains to prevent over-authorizing origins
- experiment with some origin trials on individual sites we run on subdomains

DNS Verification via dig
=======

```
$ dig txt _psl.platter-app.com
_psl.platter-app.com.	600	IN	TXT	"https://github.com/publicsuffix/list/pull/935"

```

```
$ dig txt _psl.platter-app.dev
_psl.platter-app.dev.	3600	IN	TXT	"https://github.com/publicsuffix/list/pull/935"
```

```
$ dig txt _psl.platterp.us
_psl.platterp.us.	600	IN	TXT	"https://github.com/publicsuffix/list/pull/935"
```

make test
=========

PASS: https://travis-ci.org/publicsuffix/list/builds/624960797
