### PR TITLE
Add sorrell.us to list of private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12768,6 +12768,10 @@ static.land
 dev.static.land
 sites.static.land
 
+// Sorrell Solutions, L.L.C. : https://sorrell.us (no current website)
+// Submitted by Sven Aelterman <security@sorrell.us>
+sorrell.us
+
 // SourceLair PC : https://www.sourcelair.com
 // Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
 apps.lair.io


### PR DESCRIPTION
* [X] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [ ] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://sorrell.us. We currently do not have a public-facing website.

Sorrell Solutions, L.L.C. is a business service firm. 

I am the Cloud Software Architect for the projects, and secretary of the LLC.

Reason for PSL Inclusion
====

We create subdomains for different customer projects. Cookies from different projects should not leak up to the parent domain or other child domains.

DNS Verification via dig
=======

Pending PR #

make test
=========

Haven't been able to complete yet.
