### PR TITLE
Add senseering.net domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12718,6 +12718,10 @@ my-firewall.org
 myfirewall.org
 spdns.org
 
+// Senseering GmbH : https://www.senseering.de
+// Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
+senseering.net
+
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.senseering.de

Senseering is developing a distributed network where every participant should be able to share and sell data to other participants. Anyone who wants to join the network should be able to get a valid https connection to the centralized marketplace.

Every participant has its own website were he can manage the software which is modular and not under our control. For cookie security reasons it would be useful that the websites hosted from them are separated from the main marketplace.

Reason for PSL Inclusion
====

The subdomains will be run by different organisations with the ability to manage the websites and set cookies. To add to this the certificates cant be created by a centralised authority, the participants themselves create them, which could lead to problems with lets encrypt over the entire network instead of for one user.

DNS Verification via dig
=======

```
dig +short TXT  _psl.senseering.net  
"https://github.com/publicsuffix/list/pull/946"
```

make test
=========

Here is the validated `make test`
https://pastebin.com/ycZYKeFG
