### PR TITLE
Add WoltLab Cloud domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12988,6 +12988,14 @@ remotewd.com
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
 
+// WoltLab GmbH : https://www.woltlab.com
+// Submitted by Tim Düsterhus <security@woltlab.cloud>
+myforum.community
+community-pro.de
+diskussionsbereich.de
+community-pro.net
+meinforum.net
+
 // XenonCloud GbR: https://xenoncloud.net
 // Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>
 half.host


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.woltlab.com/

I'm an Engineer at WoltLab GmbH. WoltLab GmbH is the developer of WoltLab Suite, a web application suite to build online communities. So far our web application suite was only offered as a downloadable package for customers to host themselves. We plan to provide a fully managed SaaS solution starting in the first quarter of 2020: https://community.woltlab.com/thread/279987-managed-hosting-introducing-the-woltlab-cloud/

Reason for PSL Inclusion
====

Within the SaaS solution we will offer a number of domains for customers to choose a subdomain from if they do not want to bring their own domain.

Customers are able to customize the look and feel of their community, including the generated HTML and to a certain extent the server side application code. By doing so they would technically be able to read cookies belonging to the communities of other customers, including `HttpOnly` cookies. For obvious security reasons we would like to prevent that by submitting the domains to public suffix list.

DNS Verification via dig
=======

```
+ dig +short TXT _psl.community-pro.de
"https://github.com/publicsuffix/list/pull/947"
+ dig +short TXT _psl.community-pro.net
"https://github.com/publicsuffix/list/pull/947"
+ dig +short TXT _psl.diskussionsbereich.de
"https://github.com/publicsuffix/list/pull/947"
+ dig +short TXT _psl.meinforum.net
"https://github.com/publicsuffix/list/pull/947"
+ dig +short TXT _psl.myforum.community
"https://github.com/publicsuffix/list/pull/947"
```

make test
=========

I ran `make test` after making the change. All tests passed.