### PR TITLE
Add envoy.rocks domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11524,6 +11524,10 @@ staging.onred.one
 enonic.io
 customer.enonic.io
 
+// Envoy : https://www.envoy.rocks/
+// Submitted by Rijk van Wel <rijk@envoy.rocks>
+envoy.rocks
+
 // EU.org https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>
 eu.org


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.envoy.rocks

Envoy is an online feedback tool for creative agencies. It is a SaaS platform where each agency can set up a branded instance for their team under a subdomain.

I am the owner and developer of the platform.

Reason for PSL Inclusion
====

The different subdomains (agency1.envoy.rocks, agency2.envoy.rocks, etc) should not share cookies. Also, for people using the tool to give feedback it is important that the complete domain is highlighted in the address bar, as they will mainly recognise the name of the agency which is the subdomain.

DNS Verification via dig
=======

```
dig +short TXT _psl.envoy.rocks
"https://github.com/publicsuffix/list/issues/948"
```

make test
=========

Tests run.