### PR TITLE
Add discourse.team

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10954,8 +10954,9 @@ certmgr.org
 xenapponazure.com
 
 // Civilized Discourse Construction Kit, Inc. : https://www.discourse.org/
-// Submitted by Rishabh Nambiar <rishabh.nambiar@discourse.org>
+// Submitted by Rishabh Nambiar & Michael Brown <team@discourse.org>
 discourse.group
+discourse.team
 
 // ClearVox : http://www.clearvox.nl/
 // Submitted by Leon Rowland <leon@clearvox.nl>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.discourse.org/

I am on the Infrastructure team at Civilized Discourse Construction Kit, Inc. and we build an open source community platform for civilized discussion on the web at https://github.com/discourse/discourse/.

We will be hosting a new product on discourse.team in the same manner that we do for discourse.group as previously added in #768 

Reason for PSL Inclusion
====

As we will host multiple forums under the discourse.team domain we'd like to add it to the PSL to:

Ensure that each subdomain of discourse.team is treated as a distinct domain.
Adding cookie security.

DNS Verification via dig
=======

```
○ → dig +short TXT _psl.discourse.team.
"https://github.com/publicsuffix/list/pull/949"
```

make test
=========

I ran the test and everything was OK.