### PR TITLE
Add u.channelsdvr.net to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11685,6 +11685,7 @@ vologda.su
 // Fancy Bits, LLC : http://getchannels.com
 // Submitted by Aman Gupta <aman@getchannels.com>
 channelsdvr.net
+u.channelsdvr.net
 
 // Fastly Inc. : http://www.fastly.com/
 // Submitted by Fastly Security <security@fastly.com>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: getchannels.com

We are a SaaS company. I am the founder and CTO. We provide dynamic dns to users of our product and give them each a unique subdomain.

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

We previously added `channelsdvr.net` to the PSL in #495. Since then, due to limitations by our DNS provider, we have had to migrate new user DDNS entries to a separate `u.channelsdvr.net` domain.

We would like for cookies not to be shared across user subdomains like `xxx.u.channelsdvr.net`.

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

Tests pass:

```
# TOTAL: 5
# PASS:  5
```
