### PR TITLE
Add shopware.store domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12746,6 +12746,10 @@ myshopblocks.com
 // Submitted by Craig McMahon <craig@shopitcommerce.com>
 shopitsite.com
 
+// shopware AG : https://shopware.com
+// Submitted by Jens Küper <cloud@shopware.com>
+shopware.store
+
 // Siemens Mobility GmbH
 // Submitted by Oliver Graebner <security@mo-siemens.io>
 mo-siemens.io


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://shopware.store
I am an engineer at shopware working on our SaaS hosting for e-commerce shops which are based on Shopware 6 (https://github.com/shopware/platform).


Reason for PSL Inclusion
====

Cookie security between subdomains since the subdomains will be managed and run by different organizations with the ability to set cookies.

DNS Verification via dig
=======

```
dig +short TXT _psl.shopware.store
"https://github.com/publicsuffix/list/pull/958"
```

make test
=========

All passed