### PR TITLE
Add kyma.ondemand.com domain and subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12701,6 +12701,12 @@ wellbeingzone.co.uk
 // Submitted by Jennifer Herting <jchits@rit.edu>
 git-pages.rit.edu
 
+// SAP SE : https://www.sap.com/
+// Submitted by Zsolt Kis <zsolt.kis@sap.com>
+kyma.ondemand.com
+dev.kyma.ondemand.com
+stage.kyma.ondemand.com
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====
SAP SE is a European multinational software corporation that makes enterprise software to manage  
business operations and customer relations.  
Organization Website: https://www.sap.com/  
For more details: https://en.wikipedia.org/wiki/SAP_SE  

Reason for PSL Inclusion
====

The domain "ondemand.com" hosts various SAP services for it's customers.  
The requested kyma subdomain is a for the kyma project (https://kyma-project.io/), where we would like to use individual Let's Encrypt SSL certificates for the various subdomains as a separate authority from ondemand.com 

DNS Verification via dig
=======
```
dig +short TXT _psl.kyma.ondemand.com
"https://github.com/publicsuffix/list/pull/969"
```

```
dig +short TXT _psl.dev.kyma.ondemand.com
"https://github.com/publicsuffix/list/pull/969"
```

```
dig +short TXT _psl.stage.kyma.ondemand.com
"https://github.com/publicsuffix/list/pull/969"
```

make test
=========
Passed