### PR TITLE
Add toolforge.org and wmcloud.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13006,8 +13006,10 @@ wedeploy.sh
 remotewd.com
 
 // Wikimedia Labs : https://wikitech.wikimedia.org
-// Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
+// Submitted by Arturo Borrero Gonzalez <aborrero@wikimedia.org>
 wmflabs.org
+toolforge.org
+wmcloud.org
 
 // WoltLab GmbH : https://www.woltlab.com
 // Submitted by Tim Düsterhus <security@woltlab.cloud>


### PR DESCRIPTION
Add a couple of private domains:
 * toolforge.org
 * wmcloud.org

Both domains belong to the Wikimedia Foundation and are used specifically by
the Wikimedia Cloud Services team to provide services such as Toolforge and
CloudVPS. Information about both can be found on Wikitech:

 https://wikitech.wikimedia.org

In both domains, we allow arbitrary subdomains to be created by users of our
services. Any subdomain of a given subdomain is under control of the same user.
Detailed information about the domain names used by Wikimedia Cloud Services
and how do we handle them can be found at Wikitech as well:

 https://wikitech.wikimedia.org/wiki/Portal:Cloud_VPS/Admin/DNS

For the record, this update is tracked in Wikimedia's ticketing system:

 https://phabricator.wikimedia.org/T168677

While at it, update submitter email address. Yuvi is no longer part of the
organization.

Signed-off-by: Arturo Borrero Gonzalez <aborrero@wikimedia.org>