### PR TITLE
Add *.owo.codes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12535,6 +12535,10 @@ outsystemscloud.com
 ownprovider.com
 own.pm
 
+// OwO : https://whats-th.is/
+// Submitted by Dean Sheather <dean@deansheather.com>
+*.owo.codes
+
 // OX : http://www.ox.rs
 // Submitted by Adam Grand <webmaster@mail.ox.rs>
 ox.rs


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://whats-th.is

OwO provides free file and source code hosting for its members. It is run independently by @deansheather and @aurieh using donations.

Reason for PSL Inclusion
====

Cookie security. `*.owo.codes` hosts individual GitLab pages sites created by users. A wildcard is used as cookies are used on the root.

DNS Verification via dig
=======

```
dig +short TXT _psl.owo.codes
"https://github.com/publicsuffix/list/pull/973"
```