### PR TITLE
Add panel.gg and daemon.panel.gg

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13014,6 +13014,11 @@ remotewd.com
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
 
+// WISP : https://wisp.gg
+// Submitted by Stepan Fedotov <stepan@wisp.gg>
+panel.gg
+daemon.panel.gg
+
 // WoltLab GmbH : https://www.woltlab.com
 // Submitted by Tim Düsterhus <security@woltlab.cloud>
 myforum.community


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://wisp.gg

I'm a Software Engineer for WISP, a Game Panel SaaS. We host the web interface while allowing you to use your own nodes for deploying game servers. Each client gets their own {id}.panel.gg subdomain, and each client's node gets {id}.daemon.panel.gg subdomain to not require the user to have their own domain.

Reason for PSL Inclusion
====
As we have no control over what the user serves on these subdomains, we're looking to get them added to the PSL, improving the cookie security and browser's behavior.

DNS Verification via dig
=======
```
dig +short TXT _psl.panel.gg
"https://github.com/publicsuffix/list/pull/978"
```
```
dig +short TXT _psl.daemon.panel.gg
"https://github.com/publicsuffix/list/pull/978"
```

make test
=========
Tests passed, [command output](https://hastebin.com/xoserixatu.bash).
