### PR TITLE
Remove unnecessary trailing whitespace for name.fj

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -991,7 +991,7 @@ com.fj
 gov.fj
 info.fj
 mil.fj
-name.fj 
+name.fj
 net.fj
 org.fj
 pro.fj


### PR DESCRIPTION
this is a simple change, just normalizing the text.