### PR TITLE
Added gentlentapis.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11797,7 +11797,7 @@ usercontent.jp
 // Gentlent, Inc. : https://www.gentlent.com
 // Submitted by Tom Klein <tom@gentlent.com>
 gentapps.com
-lab.ms
+gentlentapis.com
 
 // GitHub, Inc.
 // Submitted by Patrick Toomey <security@github.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11798,6 +11798,7 @@ usercontent.jp
 // Submitted by Tom Klein <tom@gentlent.com>
 gentapps.com
 gentlentapis.com
+lab.ms
 
 // GitHub, Inc.
 // Submitted by Patrick Toomey <security@github.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11770,8 +11770,9 @@ service.gov.uk
 gehirn.ne.jp
 usercontent.jp
 
-// Gentlent, Limited : https://www.gentlent.com
-// Submitted by Tom Klein <tklein@gentlent.com>
+// Gentlent, Inc. : https://www.gentlent.com
+// Submitted by Tom Klein <tom@gentlent.com>
+gentapps.com
 lab.ms
 
 // GitHub, Inc.


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.gentlent.com

I am CEO/CTO at Gentlent, which is a software development and consulting company.

Reason for PSL Inclusion
====

gentlentapis.com will be used to host multiple (incl. third-party) APIs on different subdomains which should not be able to set cookies to other subdomains for security reasons. User content may be allowed. Browsers should, therefore, recognize gentlentapis.com as a suffix.

DNS Verification via dig
=======

```
dig +short TXT _psl.gentlentapis.com
"https://github.com/publicsuffix/list/pull/984"
```

make test
=========

"make test" ran successfully: https://gist.github.com/tomkln/e6d5f0a747a3b2433ab2db2b0abe7428
