### PR TITLE
Add g.vbrplsbx.io domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12660,6 +12660,10 @@ vaporcloud.io
 rackmaze.com
 rackmaze.net
 
+// Rakuten Games, Inc : https://dev.viberplay.io
+// Submitted by Joshua Zhang <public-suffix@rgames.jp>
+g.vbrplsbx.io
+
 // Rancher Labs, Inc : https://rancher.com
 // Submitted by Vincent Fiduccia <domains@rancher.com>
 *.on-k3s.io


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: <https://dev.viberplay.io>

Viber Play is a game platform running in the messenger platform Viber <https://chats.viber.com/rakutengames>. It helps game developers to develop and publish HTML5 game content inside Viber.

Viber Play is developed and operated by Rakuten Games, Inc. <http://corp.rakuten-games.com/>

Reason for PSL Inclusion
====

Subdomains under g.vbrplsbx.io are assigned to different game developers for hosting their HTML5 game contents.

We want to protect users from being tracked across games via cross-subdomains cookie/state sharing.

DNS Verification via dig
=======

```
dig +short TXT _psl.vbrplsbx.io
"https://github.com/publicsuffix/list/pull/994"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
