### PR TITLE
add bitbridge.net to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11185,6 +11185,9 @@ drud.us
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org
 
+// bitbridge.net : Submitted by Craig Welch, abeliidev@gmail.com
+bitbridge.net
+
 // dy.fi : http://dy.fi/
 // Submitted by Heikki Hannikainen <hessu@hes.iki.fi>
 dy.fi


### PR DESCRIPTION
// bitbridge.net : Submitted by Craig Welch, abeliidev@gmail.com

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.softlatch.net https://gitlab.com/cwsyncdev/SoftLatch/-/wikis/home

SoftLatch provides a way to self-host home automation and productivity apps - a simple way to install domoticz (https://www.domoticz.com/), a motion detecting webcam application, and a note taking application, with more planned.  

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

I'm the founder of the project and owner of the domain names, Craig Welch.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc).
-->

The desire to be added to this list is to enable https://letsencrypt.org/ certificates to be vended for the self-hosted bridge applications for which dynamic dns services are offered on bitbridge.net (e.g. after signup for an account on softlatch.net, during installation of the bridge on macos, windows, or linux (raspberry pi included), the bridge can be linked to the site to easily give it a dns name, and it will also create a let's encrypt certificate.  This entry will allow multiple bridges to register and receive let's encrypt certificates (otherwise there is a limit at let's encrypt which will block users over a certain volume each week from successfully completing the challenge).


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

```
$ dig +short -t txt _psl.bitbridge.net
"https://github.com/publicsuffix/list/pull/1000"
```

make test
=========

Looks to pass...
```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

```
<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
