### PR TITLE
Add Mineduc private subregistry for public schools: aprendemas.cl

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -725,11 +725,7 @@ cl
 // Chilean Ministry of Education : https://www.mineduc.cl/
 // Submitted by .CL registry <hsalgado@nic.cl> on behalf of Mineduc
 aprendemas.cl
-// Entel Chile S.A., private subregistry
-// Confirmed by registry <hsalgado@nic.cl>
 co.cl
-// Chilean government subregistries
-// Confirmed by registry <hsalgado@nic.cl>
 mil.cl
 gob.cl
 gov.cl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -719,15 +719,20 @@ gouv.ci
 *.ck
 !www.ck
 
-// cl : https://en.wikipedia.org/wiki/.cl
+// cl : https://www.nic.cl
+// Confirmed by .CL registry <hsalgado@nic.cl>
 cl
 // Chilean Ministry of Education : https://www.mineduc.cl/
 // Submitted by .CL registry <hsalgado@nic.cl> on behalf of Mineduc
 aprendemas.cl
-gov.cl
-gob.cl
+// Entel Chile S.A., private subregistry
+// Confirmed by registry <hsalgado@nic.cl>
 co.cl
+// Chilean government subregistries
+// Confirmed by registry <hsalgado@nic.cl>
 mil.cl
+gob.cl
+gov.cl
 
 // cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
 cm

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -721,6 +721,9 @@ gouv.ci
 
 // cl : https://en.wikipedia.org/wiki/.cl
 cl
+// Chilean Ministry of Education : https://www.mineduc.cl/
+// Submitted by .CL registry <hsalgado@nic.cl> on behalf of Mineduc
+aprendemas.cl
 gov.cl
 gob.cl
 co.cl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -722,8 +722,6 @@ gouv.ci
 // cl : https://www.nic.cl
 // Confirmed by .CL registry <hsalgado@nic.cl>
 cl
-// Chilean Ministry of Education : https://www.mineduc.cl/
-// Submitted by .CL registry <hsalgado@nic.cl> on behalf of Mineduc
 aprendemas.cl
 co.cl
 mil.cl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -724,9 +724,9 @@ gouv.ci
 cl
 aprendemas.cl
 co.cl
-mil.cl
 gob.cl
 gov.cl
+mil.cl
 
 // cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
 cm


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Mineduc is the Ministry of Education of the Chilean Government, responsible for promoting development at all levels of education at both public and private institutions.

Organization Website: https://www.mineduc.cl/

I work for NIC Chile (Hugo Salgado <hsalgado@nic.cl>), the .CL registry, submitting this PR on behalf of Mineduc. We're coordinated to validate the change. .CL whois doesn't list contact emails, but I can provide you with any proof at your request.

Reason for PSL Inclusion
====

Mineduc will use this private sub-registry to give each public school in Chile a website for e-learning infrastructure. Each site will be fully managed by school administrators, so they need independence for certificate issuing, cookie management, etc.


DNS Verification via dig
=======

Done:

```
$ dig _psl.aprendemas.cl txt +short 
"'https://github.com/publicsuffix/list/pull/1001'"

```

make test
=========

Tests were successfully run. No skips, fail or error.
