### PR TITLE
Add playstation-cloud.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12788,6 +12788,10 @@ static.land
 dev.static.land
 sites.static.land
 
+// Sony Interactive Entertainment LLC : https://sie.com/
+// Submitted by David Coles <david.coles@sony.com>
+playstation-cloud.com
+
 // SourceLair PC : https://www.sourcelair.com
 // Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
 apps.lair.io


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.sie.com/en/

Sony Interactive Entertainment LLC (SIE) a US-based company that develops and distributes PlayStation® brand hardware, software, content and network services. Within SIE, Cloud Gaming Engineering & Infrastructure (CGEI) operates a number of cloud-gaming services including [PlayStation™Now](https://www.playstation.com/en-us/explore/playstation-now/).

CGEI operates a global network of datacenters and associated network infrastructure to support these services under the umbrella of [AS33353 (SIE-CGEI-ASN-1)](https://whois.arin.net/rest/asn/AS33353).

Communication regarding this network can be sent to sie-cgei-net-arin-contact@sony.com.

Reason for PSL Inclusion
====

This domain will be used to serve a variety of publicly accessable content and services as subdomains (e.g. `service.playstation-cloud.com`). The content will come from a variety of sources (including user-generated), thus each subdomain should be treated as an independent entity with no ability to influence another (e.g. by setting or accessing cookies of the top-level domain or another subdomain).

DNS Verification via dig
=======

```
$ dig +short TXT _psl.playstation-cloud.com
"https://github.com/publicsuffix/list/pull/1006"
```

make test
=========

Test suite passed with no failures.