### PR TITLE
Add domain to existing Netlify entry: netlify.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12297,6 +12297,7 @@ nctu.me
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
 bitballoon.com
+netlify.app
 netlify.com
 
 // Neustar Inc.


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.netlify.com/

I'm Jessica Parsons, staff technical writer at Netlify. Netlify is a platform people use to build, deploy, and serve websites.

Reason for PSL Inclusion
====

I submitted https://github.com/publicsuffix/list/pull/469 back in June 2017, which added `netlify.com` and `bitballoon.com` domains to the list. These domains were included because they are used for customer sites. Each subdomain on the domain belongs to a different customer, so inclusion on the list was necessary to prevent multi-site cookies.

As announced in customer emails and the [Netlify community forum](https://community.netlify.com/t/changes-coming-to-netlify-site-urls/8918), we're migrating all of our customer subdomains to `netlify.app` on April 14, 2020. This means that the customer subdomains currently on `netlify.com` will all be on `netlify.app` instead. `<customer-subdomain>.netlify.com` URLs will have a forced 301 redirect to `<customer-subdomain>.netlify.app`

DNS Verification via dig
=======

```
dig +short TXT _psl.netlify.app
"https://github.com/publicsuffix/list/pull/1012"
```

make test
=========

I ran the test and got an error 127 because `autoreconf` was not found. The output was identical when run on the master branch (both are pasted into [this hastebin](https://paste.yunohost.org/xezexoveqe.bash)), so I figure I'll wait to see if Travis fails before I bother fixing locally. **Travis passed, so I think we're good?**

Extra info
=========

One thing I haven't done in this PR is remove the `netlify.com` and `bitballoon.com` domains. `bitballoon.com` currently redirects to `netlify.com` and could probably be removed now; `netify.com` I would think we would want to wait until April 14 before removing. I also wanted to be sure that removal was the proper action here.

Let me know if you'd prefer that I remove one or both of those domains in this PR. Otherwise, I'll file another on April 14 for removal.