### PR TITLE
Add kasserver.com to Private Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10687,6 +10687,10 @@ barsy.ca
 *.compute.estate
 *.alces.network
 
+// all-inkl.com : https://all-inkl.com
+// Submitted by Werner Kaltofen <wk@all-inkl.com>
+kasserver.com
+
 // Altervista: https://www.altervista.org
 // Submitted by Carlo Cannas <tech_staff@altervista.it>
 altervista.org


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->
// kasserver.com : Submitted by Werner Kaltofen wk@all-inkl.com
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====
Web hosting company
Organization Website: all-inkl.com is a web hosting brand of Neue Medien Muennich GmbH

Reason for PSL Inclusion
====
The domain offer customers free subdomains (Cookie Security)

DNS Verification via dig
=======
 dig +short -t txt _psl.kasserver.com
 \"https\://github.com/publicsuffix/ list/pull/1016"

make test
=========
no mistakes
