### PR TITLE
Add gred.al suffix to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11945,6 +11945,10 @@ withyoutube.com
 // Submitted by Aaron Marais <its_me@aaronleem.co.za>
 graphox.us
 
+// Gredal server: https://media.gred.al
+// Submitted by Mathias Gredal <mathias@gred.al>
+gred.al
+
 // Group 53, LLC : https://www.group53.com
 // Submitted by Tyler Todd <noc@nova53.net>
 awsmppl.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: [https://media.gred.al](https://media.gred.al)

Gredal is a small server running several services under the gred.al domain, for a limited set of people.  

Reason for PSL Inclusion
====

Gred.al should be listed in the PSL to provide cookie security and to allow password managers to apply the correct password on different subdomains.

DNS Verification via dig
=======

```
dig +short TXT _psl.gred.al
"https://github.com/publicsuffix/list/pull/1017"
```
make test
=========

OK
