### PR TITLE
Add vercel.app and vercel.dev and update now.sh listing in private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13017,6 +13017,7 @@ lib.de.us
 // Vercel, Inc : https://vercel.com/
 // Submitted by Connor Davis <security@vercel.com>
 vercel.app
+vercel.dev
 now.sh
 
 // Viprinet Europe GmbH : http://www.viprinet.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13014,6 +13014,11 @@ lib.de.us
 // Submitted by Danko Aleksejevs <danko@very.lv>
 2038.io
 
+// Vercel, Inc : https://vercel.com/
+// Submitted by Connor Davis <security@vercel.com>
+vercel.app
+now.sh
+
 // Viprinet Europe GmbH : http://www.viprinet.com
 // Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management
@@ -13116,10 +13121,6 @@ noho.st
 // Submitted by registry <hostmaster@nic.za.net>
 za.net
 za.org
-
-// Zeit, Inc. : https://zeit.domains/
-// Submitted by Olli Vanhoja <olli@zeit.co>
-now.sh
 
 // Zine EOOD : https://zine.bg/
 // Submitted by Martin Angelov <martin@zine.bg>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://vercel.com (previously zeit.co)

Vercel is a developer platform that makes deploying performant frontend websites easy. We currently provide users with *.now.sh domains if they don't have their own. We're going to be offering *.vercel.app and *.vercel.dev soon so we need to be included in this list.

Reason for PSL Inclusion
====

- We issue LetsEncrypt certificates for our customers
- We want our customers' sites to be isolated for other customers (cookies, suffix highlighting, etc)

DNS Verification via dig
=======

```
$ dig +short TXT _psl.vercel.app
"https://github.com/publicsuffix/list/pull/1019"
```
```
$ dig +short TXT _psl.vercel.dev
"https://github.com/publicsuffix/list/pull/1019"
```
```
$ dig +short TXT _psl.now.sh
"https://github.com/publicsuffix/list/pull/1019"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Notes
=========

- ZEIT has been renamed to Vercel: https://vercel.com/blog/zeit-is-now-vercel
- Olli Vanhoja no longer works at the company