### PR TITLE
Remove domains from Netlify entry: bitballoon.com and netlify.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12313,9 +12313,7 @@ nctu.me
 
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
-bitballoon.com
 netlify.app
-netlify.com
 
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.netlify.com/

I'm Jessica Parsons, staff technical writer at Netlify. Netlify is a platform people use to build, deploy, and serve websites.

Reason for PSL ~Inclusion~ Removal
====

This is a follow-up to #1012, where we added `netlify.app` as the new domain for Netlify customer sites. The migration is now complete; `netlify.com` is now used for Netlify-owned properties only, and `bitballoon.com` is no longer in use (permanently redirects to `netlify.com`/`netlify.app`).

DNS Verification via dig
=======

```
$ dig _psl.netlify.com TXT +short
"https://github.com/publicsuffix/list/pull/1020"
$ dig _psl.bitballoon.com TXT  +short
"https://github.com/publicsuffix/list/pull/1020"
```

make test
=========

My laptop doesn't have the proper dependencies, so I'm filing as draft to let Travis do the work. 😄 

...and Travis says 👍 
