### PR TITLE
Remove fastpanel.direct for FASTVPS EESTI OU

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11728,12 +11728,11 @@ global.ssl.fastly.net
 
 // FASTVPS EESTI OU : https://fastvps.ru/
 // Submitted by Likhachev Vasiliy <lihachev@fastvps.ru>
-fastpanel.direct
 fastvps-server.com
-myfast.space
+fastvps.host
 myfast.host
 fastvps.site
-fastvps.host
+myfast.space
 
 // Featherhead : https://featherhead.xyz/
 // Submitted by Simon Menke <simon@featherhead.xyz>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Removal
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://fastvps.ru/

FASTVPS EESTI OU is hosting provider. I am the one of engineers working with infrastructure

Reason for PSL Removal
====
That domain was previously used as separate 3-rd level domains provided to our customers, but it is no longer the ussue, and it is not needed in the list. So we request the removal.
Also sorted our other domains to follow guidelines.

DNS Verification via dig
=======
```
$ dig +short TXT _psl.fastpanel.direct
"https://github.com/publicsuffix/list/pull/1024"
```

make test
=========

make test finished OK
http://ghostbin.fv.ee/paste/qr7qp/raw
