### PR TITLE
Add *.backyards.banzaicloud.io and *.banzai.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10851,6 +10851,7 @@ balena-devices.com
 // Banzai Cloud
 // Submitted by Gabor Kozma <info@banzaicloud.com>
 app.banzaicloud.io
+*.backyards.banzaicloud.io
 
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10849,10 +10849,11 @@ backplaneapp.io
 balena-devices.com
 
 // Banzai Cloud
-// Submitted by Gabor Kozma <info@banzaicloud.com>
+// Submitted by Janos Matyas <info@banzaicloud.com>
+*.banzai.cloud
 app.banzaicloud.io
 *.backyards.banzaicloud.io
-*.banzai.cloud
+
 
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10852,6 +10852,7 @@ balena-devices.com
 // Submitted by Gabor Kozma <info@banzaicloud.com>
 app.banzaicloud.io
 *.backyards.banzaicloud.io
+*.banzai.cloud
 
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>


### PR DESCRIPTION

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)


Description of Organization
====

Organization Website: https://banzaicloud.com

Hello there, I'm Janos Matyas, CTO of Banzai Cloud. 

Banzai Cloud simplifies the transition to a Cloud Native application stack by providing a range of services around Kubernetes and Istio.

Reason for PSL Inclusion
====
We already have an entry in the list for `app.banzaicloud.com` (thank you). 

We now have a new service called Backyards that will provide users DNS entries for publicly exposing their services from a managed cluster through Istio.

We'd like to differentiate DNS entries obtained through Backyards from other Banzai Cloud services.

Similarly to the previous entry we'd like all of these domain names to be compliant, including cookie handling, DNS sorting, and Let's Encrypt cert issuance.

DNS Verification via dig
=======
```
dig +short TXT _psl.banzai.cloud
"https://github.com/publicsuffix/list/pull/1025"

dig +short TXT _psl.backyards.banzaicloud.io
"https://github.com/publicsuffix/list/pull/1025"
```


make test
=========

Test result: https://gist.github.com/matyix/247dc9e6e13769f7d98931aeae1c54e6
