### PR TITLE
Add pagexl.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12578,6 +12578,10 @@ pgfog.com
 // Submitted by Jason Kriss <jason@pagefronthq.com>
 pagefrontapp.com
 
+// PageXL : https://pagexl.com
+// Submitted by Yann Guichard <yann@pagexl.com>
+pagexl.com
+
 // .pl domains (grandfathered)
 art.pl
 gliwice.pl


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

PageXL is a SaaS for building responsive one-page sites.

Organization Website: https://pagexl.com

Reason for PSL Inclusion
====

PageXL allows users to publish their sites to the pagexl.com domain suffix (eg. mysitename.pagexl.com) so we're requesting inclusion in the PSL primarily to ensure cookie isolation/security for sites hosted on the platform.

DNS Verification via dig
=======

```
dig +short TXT _psl.pagexl.com
"https://github.com/publicsuffix/list/pull/1029"
```

make test
=========

Ran and passed!