### PR TITLE
Add *.svc.firenet.ch and *.firenet.ch to existing thingdust.io listing

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12933,6 +12933,8 @@ cust.dev.thingdust.io
 cust.disrec.thingdust.io
 cust.prod.thingdust.io
 cust.testing.thingdust.io
+*.firenet.ch
+*.svc.firenet.ch
 
 // Tlon.io : https://tlon.io
 // Submitted by Mark Staarink <mark@tlon.io>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====
Organization Website: https://thingdust.com

We are a small startup that provides a solution for measuring the occupancy of workplace environments (primarily shared desk and meeting rooms). Every customer gets his own instance with his own subdomain provided by us.

Reason for PSL Inclusion
====
firenet.ch is our domain which we use for our internal services (jenkins, monitoring, ...). The services are independent of each other and it causes issues with password-remember and cookies now that we have quite a bunch of these services.

DNS Verification via dig
=======

```
dig +short TXT _psl.firenet.ch
"https://github.com/publicsuffix/list/pull/1031"
```

```
dig +short TXT _psl.svc.firenet.ch
"https://github.com/publicsuffix/list/pull/1031"
```

make test
=========
Did run and complete without error
