### PR TITLE
Add rdv.to domains for pcarrier.ca Software Inc.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12642,6 +12642,13 @@ pagefrontapp.com
 // Submitted by Yann Guichard <yann@pagexl.com>
 pagexl.com
 
+// pcarrier.ca Software Inc: https://pcarrier.ca/
+// Submitted by Pierre Carrier <pc@rrier.ca>
+bar0.net
+bar1.net
+bar2.net
+rdv.to
+
 // .pl domains (grandfathered)
 art.pl
 gliwice.pl


### PR DESCRIPTION
# Background

`rdv.to` is a point of rendez-vous for a distributed web of actors.
We use `*.bar0.net`, `*.bar1.net`, `*.bar2.net` as tiers of actors.
`*.rdv.to` is used for isolation of HTTP traffic.
We absolutely want each entity to be perceived as its own in every possible way, and would appreciate an extra layer of security with regards to cookies and in any web handling platform semantics available whatsoever.

# Dig request output
```
pcarrier@pcarrier-desk:~$ dig +short TXT _psl.rdv.to
"https://github.com/publicsuffix/list/pull/1039"
pcarrier@pcarrier-desk:~$ dig +short TXT _psl.bar0.net
"https://github.com/publicsuffix/list/pull/1039"
pcarrier@pcarrier-desk:~$ dig +short TXT _psl.bar1.net
"https://github.com/publicsuffix/list/pull/1039"
pcarrier@pcarrier-desk:~$ dig +short TXT _psl.bar2.net
"https://github.com/publicsuffix/list/pull/1039"
```

# Tests
I'll be honest, in WSL both Ubuntu 20.04 and 18.04 after `apt install build-essential autoconf autopoint` still ran into this during `make test`:
```
Already up to date.
configure.ac:65: error: possibly undefined macro: AC_MSG_ERROR
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:82: error: possibly undefined macro: AC_LINK_IFELSE
configure.ac:83: error: possibly undefined macro: AC_LANG_PROGRAM
configure.ac:188: error: possibly undefined macro: AC_SEARCH_LIBS
configure.ac:221: error: possibly undefined macro: AC_MSG_CHECKING
configure.ac:226: error: possibly undefined macro: AC_MSG_RESULT
```