### PR TITLE
Add wien.funkfeuer.at to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11812,6 +11812,10 @@ freeboxos.fr
 // Submitted by Daniel Stone <daniel@fooishbar.org>
 freedesktop.org
 
+// FunkFeuer - Verein zur Förderung freier Netze : https://www.funkfeuer.at
+// Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
+wien.funkfeuer.at
+
 // Futureweb OG : http://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 *.futurecms.at


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://wiki.funkfeuer.at/wiki/Regionen/Wien/Verein

FunkFeuer is an association with various initiatives throughout Austria. These initiatives all have their own sub-domain within the funkfeuer.at namespace. These sub-domains are fully delegated out to the initiatives and allocate their member domains underneath as they see fit.
This adds the community sub-domain for Vienna.

Reason for PSL Inclusion
====

FunkFeuer Wien is an non-profit association from Vienna, Austria. It delegates Domains below `wien.funkfeuer.at` to its members.

DNS Verification via dig
=======

```
dig +short TXT _psl.wien.funkfeuer.at
"https://github.com/publicsuffix/list/pull/1041"
```

make test
=========

Test showed no errors.