### PR TITLE
add hostyhosting.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12020,6 +12020,9 @@ ngo.ng
 ng.school
 sch.so
 
+// HostyHosting (hostyhosting.com)
+hostyhosting.io
+
 // Häkkinen.fi
 // Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
 häkkinen.fi


### PR DESCRIPTION
We'll be providing subdomains as part of hosting services, and would like to restrict setting cookies on `.hostyhosting.io`.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.hostyhosting.com/

I'm an owner of HostyHosting. We'll be providing hosting services, and as part of those services will be issue subdomains of `hostyhosting.io`.

Reason for PSL Inclusion
====

To prevent cookies from being set on `.hostyhosting.io`.

DNS Verification via dig
=======
```
dig +short TXT _psl.hostyhosting.io
"https://github.com/publicsuffix/list/pull/1046"
```

make test
=========

Ran the tests.
