### PR TITLE
Add pleskns.com suffix to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12644,6 +12644,7 @@ platterp.us
 // Submitted by Anton Akhtyamov <program-managers@plesk.com>
 pdns.page
 plesk.page
+pleskns.com
 
 // Port53 : https://port53.io/
 // Submitted by Maximilian Schieder <maxi@zeug.co>


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

This is adding of pleskns.com domain in addition to pdns.page and plesk.page domains which were added here https://github.com/publicsuffix/list/pull/1022.

Description of Organization
====
Organization Website: https://www.plesk.com/

Plesk is the leading WebOps hosting platform to run, automate and grow applications, websites and hosting businesses. Being the only OS agnostic platform, Plesk is running on more than 420,000 servers, automating 11M+ websites and 19M+ mailboxes. Available in more than 32 languages across 140 countries, 50% of the top 100 service providers worldwide are partnering with Plesk today.

Reason for PSL Inclusion
====
- We issue LetsEncrypt certificates for server's hostnames for our customers
- We want our customers' sites to be isolated for other customers (cookies, suffix highlighting, etc)

DNS Verification via dig
=======
```
 dig TXT _psl.pleskns.com +short
“https://github.com/publicsuffix/list/pull/1048”
```

make test
=========
```
Testsuite summary for libpsl 0.21.0

# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```