### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6327,7 +6327,6 @@ cv.ua
 dn.ua
 dnepropetrovsk.ua
 dnipropetrovsk.ua
-dominic.ua
 donetsk.ua
 dp.ua
 if.ua


### PR DESCRIPTION
removing formerly public domain:
dominic.ua
my official email as listed in IANA database, UA admin contact is dk@cctld.ua.
for list of all public domains under UA, as well as special reserved names, please consult:
https://hostmaster.ua/2ld/

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [NA] Reason for PSL Inclusion
* [NA] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://hostmaster.ua

Hostmaster.UA is a registry operator for UA ccTLD.  I am representing them and .UA registry.

Reason for PSL Inclusion
====
We are removing this domain, it is no longer listed as public.
https://hostmaster.ua/2ld/

DNS Verification via dig
=======

This domain is managed by a third party.  Therefore, we are not able to create it.
We can of course ask them to add it but I would rather avoid this step.  Please advice.

(example dig command:
```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```
Note that XXXX is replaced with the number of your pull request.
)

make test
=========

The removal of single line should not break things.  Anyway, test was performed by github.

Please consider adding secondary email contact <sia@nest.org> in the future (IANA db listed.)