### PR TITLE
Add mcdir.ru and vps.mcdir.ru

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12273,6 +12273,11 @@ mayfirst.org
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru
 
+// McHost : https://mchost.ru
+// Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
+mcdir.ru
+vps.mcdir.ru
+
 // Memset hosting : https://www.memset.com
 // Submitted by Tom Whitwell <domains@memset.com>
 miniserver.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://mchost.ru

McHost is a hosting provider. We provide free subdomains in `.mcdir.ru` and `.vps.mcdir.ru` domains for our customers.

Reason for PSL Inclusion
====

McHost's customers are allowed to publish their own sites in the .mcdir.ru suffix, so we need to restrict cookie sharing between these subdomains.

DNS Verification via dig
=======

```
dig +short TXT _psl.mcdir.ru
"https://github.com/publicsuffix/list/pull/1051"
```

```
dig +short TXT _psl.vps.mcdir.ru
"https://github.com/publicsuffix/list/pull/1051"
```

make test
=========

```
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
