### PR TITLE
Add eurodir.ru

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11611,6 +11611,10 @@ tr.eu.org
 uk.eu.org
 us.eu.org
 
+// Eurobyte : https://eurobyte.ru
+// Submitted by Evgeniy Subbotin <e.subbotin@eurobyte.ru>
+eurodir.ru
+
 // Evennode : http://www.evennode.com/
 // Submitted by Michal Kralik <support@evennode.com>
 eu-1.evennode.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://eurobyte.ru

Eurobyte is a hosting provider. We provide free subdomains in `.eurodir.ru` domain for our customers.

Reason for PSL Inclusion
====

Eurobyte's customers are allowed to publish their own sites in the .eurodir.ru suffix, so we need to restrict cookie sharing between these subdomains.

DNS Verification via dig
=======

```
dig +short TXT _psl.eurodir.ru
"https://github.com/publicsuffix/list/pull/1052"
```

make test
=========

```
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
