### PR TITLE
Fix broken links in nic.lk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3785,7 +3785,7 @@ gov.lc
 // li : https://en.wikipedia.org/wiki/.li
 li
 
-// lk : http://www.nic.lk/seclevpr.html
+// lk : https://www.nic.lk/index.php/domain-registration/lk-domain-naming-structure
 lk
 gov.lk
 sch.lk
@@ -6918,11 +6918,11 @@ yt
 қаз
 
 // xn--fzc2c9e2c ("Lanka", Sinhalese-Sinhala) : LK
-// http://nic.lk
+// https://nic.lk
 ලංකා
 
 // xn--xkc2al3hye2a ("Ilangai", Tamil) : LK
-// http://nic.lk
+// https://nic.lk
 இலங்கை
 
 // xn--mgbc0a9azcg ("Morocco/al-Maghrib", Arabic) : MA


### PR DESCRIPTION
A minor fix to update URLs leading to `nic.lk`. No actual domain changes. 

This PR replaces a dead link `http://www.nic.lk/seclevpr.html` that was dead for years with the most relevant page that mentions the public suffixes the NIC maintains.

In addition, there are two `https` upgrades for `http://nic.lk`.

Thank you.