### PR TITLE
Update platform.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12635,7 +12635,10 @@ on-web.fr
 
 // Platform.sh : https://platform.sh
 // Submitted by Nikola Kotur <nikola@platform.sh>
-*.platform.sh
+bc.platform.sh
+ent.platform.sh
+eu.platform.sh
+us.platform.sh
 *.platformsh.site
 
 // Platter: https://platter.dev


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://platform.sh

Platform.sh is modern PaaS hosting solution so teams can focus on building experience and not on managing infrastructure.

Reason for PSL Update
====

We worked hard to remove our main domain `platform.sh` from the PSL and this pull-request would enable us to achieve that goal. Now we only need four entities in the list. 

DNS Verification via dig
=======

```
dig +short TXT _psl.bc.platform.sh
"https://github.com/publicsuffix/list/pull/1061"
```
and

```
dig +short TXT _psl.eu.platform.sh
"https://github.com/publicsuffix/list/pull/1061"
```
and

```
dig +short TXT _psl.us.platform.sh
"https://github.com/publicsuffix/list/pull/1061"
```

and

```
dig +short TXT _psl.ent.platform.sh
"https://github.com/publicsuffix/list/pull/1061"
```

make test
=========

Tests are green!