### PR TITLE
Added AdPage.io pagebuilder project domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13232,4 +13232,10 @@ enterprisecloud.nu
 // Submitted by Ben Aubin <security@mintere.com>
 mintere.site
 
+// AdPage.io : https://adpage.io/
+// Submited by Jordi van Tuil <jordi@adpage.io>
+project.fastpages.io
+projects.webpages.one
+campaign.direct
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: <!-- https://adpage.io -->

AdPage is a landingpage builder tool. We publish projects on 3 different domains by default. People are able to connect their own domains through DNS too. We regularly monitor all content published on our domains.

Reason for PSL Inclusion
====

To gain trust on our domain, and prevent malicious warnings from being shown in browsers.

DNS Verification via dig
=======

```
dig +short TXT _psl.project.fastpages.io
"https://github.com/publicsuffix/list/pull/1062"
```

```
dig +short TXT _psl.projects.webpages.one
"https://github.com/publicsuffix/list/pull/1062"
```

```
dig +short TXT _psl.campaign.direct
"https://github.com/publicsuffix/list/pull/1062"
```

make test
=========

Test passed successfully.
