### PR TITLE
Add algorithmia.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10685,6 +10685,12 @@ barsy.ca
 // Submitted by Werner Kaltofen <wk@all-inkl.com>
 kasserver.com
 
+// Algorithmia, Inc. : algorithmia.com
+// Submitted by Eli Perelman <eperelman@algorithmia.io>
+*.algorithmia.com
+!teams.algorithmia.com
+!test.algorithmia.com
+
 // Altervista: https://www.altervista.org
 // Submitted by Carlo Cannas <tech_staff@altervista.it>
 altervista.org


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://algorithmia.com

Algorithmia provides the fastest time to value for enterprise machine learning. Rapidly deploy, serve, and manage machine learning models at scale. This PR is submitted by myself, Eli Perelman, representing Algorithmia as lead web engineer.

Reason for PSL Inclusion
====

We currently have a cookie set for `algorithmia.com`, but would like to share that with `teams.algorithmia.com` and `test.algorithmia.com` without sharing with our other subdomains that should not have access.

DNS Verification via dig
=======

```bash
dig +short TXT _psl.algorithmia.com
"https://github.com/publicsuffix/list/pull/1071"
```

```bash
dig +short TXT _psl.test.algorithmia.com
"https://github.com/publicsuffix/list/pull/1071"
```

```bash
dig +short TXT _psl.teams.algorithmia.com
"https://github.com/publicsuffix/list/pull/1071"
```

make test
=========

<details>
  <summary>results of <code>make test</code></summary>

```bash
➜ make test

cd linter;                                \
          ./pslint_selftest.sh;                     \
          ./pslint.py ../public_suffix_list.dat;
-n test_NFKC: 
OK
-n test_allowedchars: 
OK
-n test_dots: 
OK
-n test_duplicate: 
OK
-n test_exception: 
OK
-n test_punycode: 
OK
-n test_section1: 
OK
-n test_section2: 
OK
-n test_section3: 
OK
-n test_section4: 
OK
-n test_spaces: 
OK
-n test_wildcard: 
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
          cd libpsl;                                                                    \
          git pull;                                                                     \
          echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
          echo "CLEANFILES =" >> gtk-doc.make;                                          \
          autoreconf --install --force --symlink;
Already up to date.
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:36: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:36: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:36: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
configure.ac:11: installing 'build-aux/compile'
configure.ac:5: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/Users/eli/code/algorithmia/list/public_suffix_list.dat --with-psl-testfile=/Users/eli/code/algorithmia/list/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
  CCLD     test-registrable-domain
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-all
PASS: test-is-public-builtin
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

</details>