### PR TITLE
Add Danger Science Group domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11119,6 +11119,12 @@ curv.dev
 cyon.link
 cyon.site
 
+// Danger Science Group: https://dangerscience.com/
+// Submitted by Skylar MacDonald <skylar@dangerscience.com>
+fnwk.site
+folionetwork.site
+platform0.app
+
 // Daplie, Inc : https://daplie.com
 // Submitted by AJ ONeal <aj@daplie.com>
 daplie.me


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://dangerscience.com

We are a software development company that hosts some of our own web applications, including the [Folio Network](https://folio.network) portfolio site creator, and a not-yet-publicly-available PaaS platform called Platform 0.

Reason for PSL Inclusion
====

The included domain names can be used as subdomains by customers to create websites/applications, and we would like to make it harder for cookies to be set across multiple of these sites in case of nefarious activity.

`folionetwork.site` and `fnwk.site` are used by [Folio Network](https://folio.network) users for their portfolios, and `platform0.app` will be the default domains on Platform 0-hosted applications.

DNS Verification via dig
=======

```
dig +short TXT _psl.folionetwork.site
"https://github.com/publicsuffix/list/pull/1074"
```

```
dig +short TXT _psl.fnwk.site
"https://github.com/publicsuffix/list/pull/1074"
```

```
dig +short TXT _psl.platform0.app
"https://github.com/publicsuffix/list/pull/1074"
```

make test
=========

Ran the test locally and all was well. [Travis is happy too.](https://travis-ci.org/github/publicsuffix/list/builds/710927980)
