### PR TITLE
Add Mythic Beasts domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12335,6 +12335,19 @@ net.ru
 org.ru
 pp.ru
 
+// Mythic Beasts : https://www.mythic-beasts.com
+// Submitted by Paul Cammish <kelduum@mythic-beasts.com>
+hostedpi.com
+customer.mythic-beasts.com
+lynx.mythic-beasts.com
+ocelot.mythic-beasts.com
+onza.mythic-beasts.com
+sphinx.mythic-beasts.com
+vs.mythic-beasts.com
+x.mythic-beasts.com
+yali.mythic-beasts.com
+cust.retrosnub.co.uk
+
 // Nabu Casa : https://www.nabucasa.com
 // Submitted by Paulus Schoutsen <infra@nabucasa.com>
 ui.nabu.casa


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: [https://mythic-beasts.com](https://mythic-beasts.com)

Mythic Beasts is a hosting company offering a mix of web hosting, virtual and dedicated servers, as well as hosted Raspberry Pi servers.

* `vs.mythic-beasts.com` is used by Virtual Servers.
* `x.mythic-beasts.com` is used by Dedicated Servers.
* `hostedpi.com` is used by Hosted Raspberry Pi servers.
* `customer.mythic-beasts.com` is used by a mix of hosting.
* All others used by customer web hosting.

Reason for PSL Inclusion
====

A number of customers use the customer sub-domains and server hostnames for testing and various administration interfaces. Adding them to the PSL should negate most cross-domain cookie-related worries.

DNS Verification via dig
=======

```bash
dig +short TXT _psl.hostedpi.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.customer.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.lynx.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.ocelot.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.onza.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.sphinx.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.vs.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.x.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.yali.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1075"
```

```bash
dig +short TXT _psl.cust.retrosnub.co.uk
"https://github.com/publicsuffix/list/pull/1075"
```

make test
=========

The test ran okay locally, and via the tests here.
