### PR TITLE
Add forte.id

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12318,6 +12318,10 @@ cloudapp.net
 // Submitted by Robert Böttinger <r@minion.systems>
 csx.cc
 
+// MobileEducation, LLC : https://joinforte.com
+// Submitted by Grayson Martin <grayson.martin@mobileeducation.us>
+forte.id
+
 // Mozilla Corporation : https://mozilla.com
 // Submitted by Ben Francis <bfrancis@mozilla.com>
 mozilla-iot.org


### PR DESCRIPTION
* [x] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

MobileEducation, LLC provides online education services, primarily Forte. We allow schools and teachers to register vanity urls as subdomains of forte.id to make it easy for their students to join with a short link.

Organization Website: https://joinforte.com

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc).
-->

Our certificate provider allows for easy issuing of certificates on this list, and a wildcard certificate is not currently an option. Also preventing cookie bleed over respects user privacy & security.

dns verification
====

```
dig +short TXT _psl.forte.id
"https://github.com/publicsuffix/list/pull/1081"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

I have run the tests locally. Pass.
