### PR TITLE
Add small-web.org domain under Small Technology Foundation (private)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12928,6 +12928,10 @@ bounty-full.com
 alpha.bounty-full.com
 beta.bounty-full.com
 
+// Small Technology Foundation : https://small-tech.org
+// Submitted by Aral Balkan <aral@small-tech.org>
+small-web.org
+
 // Stackhero : https://www.stackhero.io
 // Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
 stackhero-network.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://small-tech.org

Small Technology Foundation is a tiny and independent two-person not-for-profit based in Ireland. We advocate for and build small technology to protect personhood and democracy in the digital network age.

Reason for PSL Inclusion
====

As part of the [Small Web initiative](https://ar.al/2020/08/07/what-is-the-small-web/), we will be enabling our patrons to host their own web sites and apps at the `small-web.org` public suffix. We want to ensure that this is done securely regarding cookie security/domain scoping.

DNS Verification via dig
=======

```
dig +short TXT _psl.small-web.org
"https://github.com/publicsuffix/list/pull/1086"
```

make test
=========

Ran the test and all tests passed.
