### PR TITLE
Add Jozi.biz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11169,6 +11169,10 @@ debian.net
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
+// DNS Africa Ltd https://dns.business
+// Submitted by Calvin Browne <calvin@dns.business>
+jozi.biz
+
 // DNShome : https://www.dnshome.de/
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://dns.business

DNS Africa Ltd is a back-end registry provider, based in Mauritius. We look after the .Africa infrastructure, with an affiliated organisation (Domain Name Services (PTY) LTD) looking after the ZA infrastructure, dotCapeTown, dotJoburg and dotDurban.

Reason for PSL Inclusion
====

Jozi.Biz is an open zone, with registrations available to the public via our https://gateway.africa SRS platform. Each delegation therein is potentially to a different, unaffiliated registrant.

DNS Verification via dig
=======

```
dig +short TXT _psl.jozi.biz
"https://github.com/publicsuffix/list/pull/1088"
```


make test
=========
git clone https://github.com/publicsuffix/list.git
cd list
make test
Did the above - had to pull in a couple of dependencies on Ubuntu Focal, but eventually got:

```
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```