### PR TITLE
Add pages.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11039,7 +11039,7 @@ cloudcontrolapp.com
 cloudera.site
 
 // Cloudflare, Inc. : https://www.cloudflare.com/
-// Submitted by Jake Riesterer <publicsuffixlist@cloudflare.com>
+// Submitted by Cloudflare Team <publicsuffixlist@cloudflare.com>
 pages.dev
 trycloudflare.com
 workers.dev

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11040,6 +11040,7 @@ cloudera.site
 
 // Cloudflare, Inc. : https://www.cloudflare.com/
 // Submitted by Jake Riesterer <publicsuffixlist@cloudflare.com>
+pages.dev
 trycloudflare.com
 workers.dev
 


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.cloudflare.com/

We're extending our [Workers Sites](https://blog.cloudflare.com/workers-sites/) offering to allow easy deployment of it to <subdomain>.jamsite.app.

I am the product manager for this product at Cloudflare. We already set up an alias to be contacted over, when setting up our workers.dev suffix (publicsuffixlist@cloudflare.com).

Reason for PSL Inclusion
====

Cloudflare customers will given a subdomain of jamsite.app for each project, to which they can deploy their serverless websites. Because subdomains are each controlled by different customers, they should be treated as separate domains for cookie purposes.

DNS Verification via dig
=======

```
dig +short TXT _psl.pages.dev
"https://github.com/publicsuffix/list/pull/1093"
```

make test
=========
Locally executed tests have passed.
