### PR TITLE
update public suffix for .ST zone

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6093,7 +6093,6 @@ com.st
 consulado.st
 edu.st
 embaixada.st
-gov.st
 mil.st
 net.st
 org.st


### PR DESCRIPTION
Removed gov.st from the list of reserved domains since this zone acting as independent on its own.
This zone should be completely removed from the file

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.nic.st
ST Registry AB
.ST domain zone administrator

Reason for PSL Inclusion
====
gov.st is a private zone and not reserved as subdomain. This zone is used directly by government of Sao Tome. Domain was excluded from list of reserved domains on: https://www.nic.st/terms-of-service 

DNS Verification via dig
=======
TO BE DONE

```
dig +short TXT _psl.gov.st
"https://github.com/publicsuffix/list/pull/1094"
```

make test
=========
test done

```
# make test
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
```

