### PR TITLE
Add bip.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10969,6 +10969,10 @@ co.com
 aus.basketball
 nz.basketball
 
+// Bip : https://bip.sh
+// Submitted by Joel Kennedy <joel@bip.sh>
+bip.sh
+
 // BRS Media : https://brsmedia.com/
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 radio.am

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10969,10 +10969,6 @@ co.com
 aus.basketball
 nz.basketball
 
-// Bip : https://bip.sh
-// Submitted by Joel Kennedy <joel@bip.sh>
-bip.sh
-
 // BRS Media : https://brsmedia.com/
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 radio.am
@@ -11235,6 +11231,10 @@ drud.us
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org
+
+// Bip : https://bip.sh
+// Submitted by Joel Kennedy <joel@bip.sh>
+bip.sh
 
 // bitbridge.net : Submitted by Craig Welch, abeliidev@gmail.com
 bitbridge.net


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://bip.sh

Bip is a static web hosting provider. Customers are provisioned a subdomain of bip.sh to host their website on.

Reason for PSL Inclusion
====

Bip customers are provided with a subdomain of bip.sh to host their website on. These subdomains are controlled by different customers, so inclusion in this list will restrict cookie sharing between them.

DNS Verification via dig
=======

```
dig +short TXT _psl.bip.sh
"https://github.com/publicsuffix/list/pull/1098"
```

make test
=========

Local tests have passed.
