### PR TITLE
Add service.one as a public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11585,6 +11585,10 @@ mytuleap.com
 onred.one
 staging.onred.one
 
+// One.com: https://www.one.com/
+// Submitted by Jacob Bunk Nielsen <jbn@one.com>
+service.one
+
 // Enonic : http://enonic.com/
 // Submitted by Erik Kaareng-Sunde <esu@enonic.com>
 enonic.io


### PR DESCRIPTION
Description of Organization
====

One.com is a web hosting company specializing in shared hosting. One.com is one of the largest hosting providers in Northern Europe with 1.5 million domain names hosted under the one.com brand and close to a million domain names hosted under other brands.

Organization Website: https://www.one.com/


Reason for PSL Inclusion
====

service.one will be used to provide our customers with host names for accessing services on our network when there is not yet any other host name connected with the customer account.

Each customer will find their services under &lt;some name&gt;.&lt;some unique per customer identifier&gt;.service.one.

service.one should be included in PSL primarily for cookie security.

DNS Verification via dig
=======
```
$ dig txt +short _psl.service.one
"https://github.com/publicsuffix/list/pull/1115"
```

make test
=========
DONE, all tests pass, no test failures.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)