### PR TITLE
Adds *.gateway.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11933,9 +11933,9 @@ publishproxy.com
 withgoogle.com
 withyoutube.com
 *.gateway.dev
-cloudfunctions.net
 cloud.goog
 translate.goog
+cloudfunctions.net
 
 blogspot.ae
 blogspot.al

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11932,6 +11932,7 @@ pagespeedmobilizer.com
 publishproxy.com
 withgoogle.com
 withyoutube.com
+*.gateway.dev
 cloudfunctions.net
 cloud.goog
 translate.goog


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://cloud.google.com/api-gateway

Engineer at Google on the Cloud API Gateway team.

Reason for PSL Inclusion
====

Cloud API Gateway hosts fully managed HTTP and gRPC proxies with API policy enforcement features for GCP customers. The proxies receive a default hostname `<gateway ID>.<region code>.gateway.dev`

Our customers are not related to each other and there is no mutual trust between the gateways. By adding an entry to the public suffix list we'd like to prevent our customers from setting cookies on each `<region code>.gateway.dev` subdomain. Our use case is similar to `*.r.appspot.com` already included in the list.


DNS Verification via dig
=======

```
dig +short TXT _psl.gateway.dev
"https://github.com/publicsuffix/list/pull/1117"
```

make test
=========

Make test passed.

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
