### PR TITLE
Adding qoto.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12887,6 +12887,10 @@ byen.site
 // Submitted by Kor Nielsen <kor@pubtls.org>
 pubtls.org
 
+// QOTO, Org.
+// Submitted by Jeffrey Phillips Freeman <jeffrey.freeman@qoto.org>
+qoto.io
+
 // Qualifio : https://qualifio.com/
 // Submitted by Xavier De Cock <xdecock@gmail.com>
 qualifioapp.com


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: qoto.io

QOTO is a non-profit organization that provides free, open-source, federated, privacy centric services for open-source and community STEM projects. We use gitlab pages and host the user pages at qoto.io, however for reference our main gitlab site is at git.qoto.org. Domain is registered for 2 years and 10 months more right now.

Reason for PSL Inclusion
====

Our server issues Let's Encrypt for its user base, cookie security is also a concern. With several hundred projects being listed it is important we get listed on the suffix list.


DNS Verification via dig
=======

dig +short TXT _psl.qoto.io

make test
=========

Test ran and passed:

```bash
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

```bash
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
