### PR TITLE
UPDATE TO SLD ON HOSTBIP SECTION

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12060,9 +12060,6 @@ ravendb.run
 
 // HOSTBIP REGISTRY : https://www.hostbip.com/
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
-bpl.biz
-orx.biz
-ng.city
 biz.gl
 ng.ink
 col.ng
@@ -12070,8 +12067,15 @@ firm.ng
 gen.ng
 ltd.ng
 ngo.ng
+edu.scot
 ng.school
 sch.so
+
+// No longer operated by Hostbip, these entries should be adopted and/or removed by current operators
+// Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
+bpl.biz
+orx.biz
+ng.city
 
 // HostyHosting (hostyhosting.com)
 hostyhosting.io


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://hostbip.com

'HostBip' is a 'PDNR' (Private Domain Name Registry), allowing 3rd parties to register domain names in a variety of domain name extensions/suffixes. This pull request adds or updates the entries for a number of domain extensions that we operate, and disclaims a number of domain names we no longer operating registry services for.

Reason for PSL Inclusion
====

'HostBip' has an existing section in the 'Public Suffix List', and is updating the section to include additional domain extensions/suffixes in its portfolio.

This request is seeking to add these to the PSL so the individuals/institutions operating under these suffixes can gain access to services such as Let's Encrypt, Cloudflare and that other third party systems may better be able to identify the level at which the personal/private name has been registered.

DNS Verification via dig
=======

```
dig +short TXT _psl.edu.scot
"https://github.com/publicsuffix/list/pull/XXXX"
```

make test
=========

I ran the test with make test.

```
=============================================
Testsuite summary for libpsl 0.21.0
=============================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
=============================================
```
