### PR TITLE
Add of.je

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10868,6 +10868,10 @@ bnr.la
 // Submitted by Paul Crowder <paul.crowder@blackbaud.com>
 blackbaudcdn.net
 
+// Blatech : http://www.blatech.net
+// Submitted by Luke Bratch <luke@bratch.co.uk>
+of.je
+
 // Boomla : https://boomla.com
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net


### PR DESCRIPTION
Blatech is a free and open internet-based organisation that, among other things, runs a semi-private free domain name service issuing domains under the pseudo-TLD of.je.

The primary reason for needing to be part of the Public Suffix List is that Let's Encrypt uses it, causing issue for our users who want to use Let's Encrypt.