### PR TITLE
Revert #1071 "Add algorithmia.com" to remove entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10680,12 +10680,6 @@ barsy.ca
 // Submitted by Werner Kaltofen <wk@all-inkl.com>
 kasserver.com
 
-// Algorithmia, Inc. : algorithmia.com
-// Submitted by Eli Perelman <eperelman@algorithmia.io>
-*.algorithmia.com
-!teams.algorithmia.com
-!test.algorithmia.com
-
 // Altervista: https://www.altervista.org
 // Submitted by Carlo Cannas <tech_staff@altervista.it>
 altervista.org


### PR DESCRIPTION
Reverts publicsuffix/list#1071

Ended up not being the long-term solution we needed, so reverting to keep the list clean.