### PR TITLE
Add azurestaticapps.net dns suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12448,11 +12448,17 @@ eu.meteorapp.com
 co.pl
 
 // Microsoft Corporation : http://microsoft.com
-// Submitted by Mostafa Elzeiny <moelzein@microsoft.com>
+// Submitted by Mitch Webster <miwebst@microsoft.com>
 *.azurecontainer.io
 azurewebsites.net
 azure-mobile.net
 cloudapp.net
+azurestaticapps.net
+centralus.azurestaticapps.net
+eastasia.azurestaticapps.net
+eastus2.azurestaticapps.net
+westeurope.azurestaticapps.net
+westus2.azurestaticapps.net
 
 // minion.systems : http://minion.systems
 // Submitted by Robert Böttinger <r@minion.systems>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.microsoft.com

Reason for PSL Inclusion
====

Azure Static Web Apps allows users to host full stack web applications seamlessly. Users are given a generated hostname as a subdomain of the azurestaticapp.net domain, we are adding these domains (regional ones as well) to PSL to ensure one site cannot set a cookie for the whole domain.

DNS Verification via dig
=======
Added TXT records for all the domains we are adding. Example:

F:\list>nslookup -type=TXT _psl.westus2.azurestaticapps.net
Server:  cusqui001f5b2d--commoncorp-ip3.network.microsoft.com
Address:  10.50.10.50

Non-authoritative answer:
_psl.westus2.azurestaticapps.net        text =

        "https://github.com/publicsuffix/list/pull/1133"


make test
=========

https://travis-ci.org/github/publicsuffix/list/builds/739109276
