### PR TITLE
Add secaas.hk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12056,6 +12056,10 @@ ravendb.me
 development.run
 ravendb.run
 
+// Hong Kong Productivity Council: https://www.hkpc.org/
+// Submitted by SECaaS Team <summchan@hkpc.org>
+secaas.hk
+
 // HOSTBIP REGISTRY : https://www.hostbip.com/
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
 bpl.biz


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://www.hkpc.org/

We are representing Hong Kong Productivity Council - SECaaS Team. SECaaS is a platform providing
secure authentication as a service to developers.

Reason for PSL Inclusion
====

Developers can register their own app at `<app>.secaas.hk` to host authentication
service. We'd like to include it in PSL to improve security of the session cookie.

DNS Verification via dig
=======

```
; <<>> DiG 9.10.6 <<>> @1.1.1.1 TXT _psl.secaas.hk
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49348
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;_psl.secaas.hk.                        IN      TXT

;; ANSWER SECTION:
_psl.secaas.hk.         300     IN      TXT     "https://github.com/publicsuffix/list/pull/1138"

;; Query time: 22 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Mon Nov 02 19:59:58 HKT 2020
;; MSG SIZE  rcvd: 102
```

make test
=========

https://travis-ci.org/github/publicsuffix/list/builds/740821137