### PR TITLE
Add header for a registry RSS feed URL for .no (Norid AS official)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4703,6 +4703,7 @@ nl
 // Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
 // Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
 // Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
+// RSS feed: https://teknisk.norid.no/en/feed/
 no
 // Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
 fhs.no


### PR DESCRIPTION
Description of Organization
====

Norid AS runs the registry for Norwegian domain names. All domains directly under .no are registered with us. In addition to processing applications we develop the domain name policy according to the needs of society. We are also responsible for the technical operation and development of associated services. We also handle other national tasks related to our core activities.

In order to develop and adapt the rules for allocating domain names, we co-operate with various stakeholders. We also take social responsibility by working to keep the domain name system reliable and robust, and to ensure that it is governed in an open and democratic way.

The service is regulated by the Domain Name Regulations and is supervised by the Norwegian Communications Authority (Nkom). Norid is not a public administrative agency, and the allocation of domain names is based on private law. We are a neutral party, and the business is run non-profit. Norid is a subsidiary in the Uninett Group.

Organization Website: https://www.norid.no

I am a senior systems developer at Norid AS.

Reason for PSL Inclusion
====

Our ccTLD (no) was already listed here. This PR is just an update where we added an RSS feed URL.

DNS Verification via dig
=======

N/A

make test
=========

...
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc

