### PR TITLE
Del xenapponazure.com NXD from Private

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10976,10 +10976,6 @@ c.la
 // Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org
 
-// Citrix : https://citrix.com
-// Submitted by Alex Stoddard <alex.stoddard@citrix.com>
-xenapponazure.com
-
 // Civilized Discourse Construction Kit, Inc. : https://www.discourse.org/
 // Submitted by Rishabh Nambiar & Michael Brown <team@discourse.org>
 discourse.group


### PR DESCRIPTION
Housekeeping; 
Clearing out expired name

xenapponazure.com #82 Domain Name No Longer Registered

Verified non-existence at registry
no impact expected from non-registered domain names
