### PR TITLE
Del uklugs.org NXD from Private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12374,7 +12374,6 @@ swidnik.pl
 
 // Lug.org.uk : https://lug.org.uk
 // Submitted by Jon Spriggs <admin@lug.org.uk>
-uklugs.org
 glug.org.uk
 lug.org.uk
 lugs.org.uk


### PR DESCRIPTION
Housekeeping:
uklugs.org, part of #514  is no longer registered
Deleting this entry

Non-existent domain should have no impact on users or services
Confirmed non-existence at registry

