### PR TITLE
Del cloudeity.net NXD from Private

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11068,10 +11068,6 @@ cloudns.pro
 cloudns.pw
 cloudns.us
 
-// Cloudeity Inc : https://cloudeity.com
-// Submitted by Stefan Dimitrov <contact@cloudeity.com>
-cloudeity.net
-
 // CNPY : https://cnpy.gdn
 // Submitted by Angelo Gladding <angelo@lahacker.net>
 cnpy.gdn


### PR DESCRIPTION
Housekeeping

cloudeity.net is **no longer registered**, which empties this section - removing to reverse #534 

NXD (non-existent domain) verified non-registered at registry
no impact anticipated due to non-existence of domain

