### PR TITLE
Del ptplus.fit NXD from Private

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12985,7 +12985,6 @@ hzc.io
 // Revitalised Limited : http://www.revitalised.co.uk
 // Submitted by Jack Price <jack@revitalised.co.uk>
 wellbeingzone.eu
-ptplus.fit
 wellbeingzone.co.uk
 
 // Rochester Institute of Technology : http://www.rit.edu/


### PR DESCRIPTION
Housekeeping:
ptplus.fit from #300 is **no longer registered**
there is no anticipated impact due to non-existence of domain name
domain non-existence verified at registry

