### PR TITLE
Del linkitools.space NXD from Private

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12332,10 +12332,6 @@ co.technology
 // Submitted by Greg Holland <greg.holland@lmpm.com>
 app.lmpm.com
 
-// Linki Tools UG : https://linki.tools
-// Submitted by Paulo Matos <pmatos@linki.tools>
-linkitools.space
-
 // linkyard ldt: https://www.linkyard.ch/
 // Submitted by Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
 linkyard.cloud


### PR DESCRIPTION
Housekeeping
linkitools.space from #636 is no longer registered

NXD so no anticipated impact
NXD validated with registry - domain no longer registered

Only entry in section so also removing comment header for entry

