### PR TITLE
Update the existing Names.of.London Public List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12508,18 +12508,18 @@ pony.club
 of.fashion
 in.london
 of.london
+from.marketing
+with.marketing
 for.men
+repair.men
 and.mom
 for.mom
 for.one
+under.one
 for.sale
+that.win
 from.work
 to.work
-from.marketing
-with.marketing
-repair.men
-under.one
-that.win
 
 // NCTU.ME : https://nctu.me/
 // Submitted by Tocknicsu <admin@nctu.me>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12521,7 +12521,6 @@ repair.men
 under.one
 that.win
 
-
 // NCTU.ME : https://nctu.me/
 // Submitted by Tocknicsu <admin@nctu.me>
 nctu.me

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12503,11 +12503,9 @@ cust.retrosnub.co.uk
 ui.nabu.casa
 
 // Names.of.London : https://names.of.london/
-// Submitted by James Stevens <registry@names.of.london> or <james@jrcs.net>
+// Submitted by James Stevens <registry[at]names.of.london> or <publiclist[at]jrcs.net>
 pony.club
 of.fashion
-on.fashion
-of.football
 in.london
 of.london
 for.men
@@ -12515,8 +12513,14 @@ and.mom
 for.mom
 for.one
 for.sale
-of.work
+from.work
 to.work
+from.marketing
+with.marketing
+repair.men
+under.one
+that.win
+
 
 // NCTU.ME : https://nctu.me/
 // Submitted by Tocknicsu <admin@nctu.me>


### PR DESCRIPTION
* [ X] Description of Organization
* [ X] Reason for PSL Inclusion
* [X ] DNS verification via dig
* [X ] Run Syntax Checker (make test)

* [ X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====

Organization Website: https://Names.of.London/

"Names.of.London" is a business registering second level domains, mostly in new-GTLDs
In some ways similar to the old CentralNIC model (uk.com etc), but in newGTLDs



Reason for PSL Inclusion
====

Sub-Domains can be owned & operated by independent legal entities.

Existing domains are already listed, this pull-request updates the list to remove domains no longer relevant and add ones that are going to be kept & operated long term.



DNS Verification via dig
=======

"_psl" records all exist for our original inclusion, but need updating when I know the pull request number.


make test
=========

make test run & passed