### PR TITLE
Add orsites.com to the list of domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12762,6 +12762,10 @@ opensocial.site
 // Submitted by Sven Marnach <sven@opencraft.com>
 opencraft.hosting
 
+// OpenResearch GmbH: https://openresearch.com/
+// Submitted by Philipp Schmid <ops@openresearch.com>
+orsites.com
+
 // Opera Software, A.S.A.
 // Submitted by Yngve Pettersen <yngve@opera.com>
 operaunite.com


### PR DESCRIPTION
* [X]  Description of Organization
* [X]  Reason for PSL Inclusion
* [X]  DNS verification via dig
* [X]  Run Syntax Checker (make test)
* [X]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

# Description of Organization
I am a partner of OpenResearch GmbH, a software development company. We are working mostly in the area of IoT solutions and automotive.

Organization website: https:/openresearch.com

# Reason for PSL Inclusion

We are using *.orsites.com to automatially deploy web projects that have no relation to each other.

# Registration Duration
* orsites.com is registered for more than two years (until 2023-03-26 11:05:48).

# DNS Verification via dig
```
dig +short TXT _psl.orsites.com
"https://github.com/publicsuffix/list/pull/1157"
```

# make test
Successful output of `make test`: https://pastebin.ubuntu.com/p/dKg9Jgpz9k/
