### PR TITLE
Add flap.id domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11809,6 +11809,10 @@ filegear-sg.me
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
+// FLAP : https://www.flap.cloud
+// Submitted by Louis Chemineau <louis@chmn.me>
+flap.id
+
 // fly.io: https://fly.io
 // Submitted by Kurt Mackey <kurt@fly.io>
 fly.dev


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: www.flap.cloud

I am Louis Chemineau, founder of the FLAP company in France.

FLAP offers managed hosting for popular open source software. To ease the setup for the customer, FLAP can provide a domain name ending by `flap.id`.

Reason for PSL Inclusion
====

This change will improve the cookie security.

The `flap.id` domain is in the private section. It is registered for more than 2 years.

DNS Verification via dig
=======

```
dig +short TXT _psl.flap.id
"https://github.com/publicsuffix/list/pull/1160"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
