### PR TITLE
Add lohmus.me to the private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12357,6 +12357,10 @@ loginline.io
 loginline.services
 loginline.site
 
+// Lõhmus Family, The
+// Submitted by Heiki Lõhmus <hostmaster at lohmus dot me>
+lohmus.me
+
 // LubMAN UMCS Sp. z o.o : https://lubman.pl/
 // Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
 krasnik.pl


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

The Lõhmus Family

I am Heiki Lõhmus and I own the domain name `lohmus.me`, which I use to provide DNS services to various members of the Lõhmus family.

Reason for PSL Inclusion
====

The delegated zones under `lohmus.me` are operated by various family members of varying technical skill independently of each other. As a consequence, `lohmus.me` ought to be treated as a public suffix for the purposes of cookie security, HSTS preloading, and accessing third-party services such as Cloudflare and Let's Encrypt.

The domain has been registered for the maximum registration period of the `me` TLD (10 years) and I shall ensure that the remaining validity period is longer than two years while the domain remains listed as a public suffix.

```
$ whois lohmus.me
Domain Name: LOHMUS.ME
Registry Expiry Date: 2030-09-22T12:40:55Z
```

DNS Verification via dig
=======

```
$ drill TXT _psl.lohmus.me
;; ANSWER SECTION:
_psl.lohmus.me.	209	IN	TXT	"https://github.com/publicsuffix/list/pull/1161"
```

make test
=========

[All tests pass](https://paste.sr.ht/~repentinus/7c0c1d7ae1a5d36562f7d67c586383dd9b687e0f).