### PR TITLE
Add shoparena.pl domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11195,6 +11195,10 @@ shop.th
 // Submitted by Paul Fang <mis@draytek.com>
 drayddns.com
 
+// DreamCommerce : https://shoper.pl/
+// Submitted by Konrad Kotarba <konrad.kotarba@dreamcommerce.com>
+shoparena.pl
+
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com


### PR DESCRIPTION
* [x]  Description of Organization
* [x]  Reason for PSL Inclusion
* [x]  DNS verification via dig
* [x]  Run Syntax Checker (make test)
* [x]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

# Description of Organization
DreamCommerce owns Shoper SaaS e-commerce platform. Each store is running under (`*.shoparena.pl`) domain.

# Reason for PSL Inclusion
We'd like to block cookies between instances of Shoper application, each one running under different `shoparena.pl` subdomain and owned by diffrent customers.

The domain is registered until 2024 and I shall ensure that the remaining validity period is longer than two years while the domain remains listed as a public suffix.

```
$ whois shoparena.pl
DOMAIN NAME:           shoparena.pl
registrant type:       organization
nameservers:           ns1.dcsaas.net.
                       ns2.dcsaas.net.
created:               2013.08.09 15:20:52
last modified:         2020.12.04 09:56:24
renewal date:          2024.08.09 15:20:52
```

# DNS Verification via dig
```
$ dig TXT _psl.shoparena.pl
;; ANSWER SECTION:
_psl.shoparena.pl.  280 IN  TXT "https://github.com/publicsuffix/list/pull/1162"
```

# make test
```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```