### PR TITLE
Add peterjin.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13488,4 +13488,9 @@ impertrix.com
 // GignoSystemJapan: http://gsj.bz
 // Submitted by GignoSystemJapan <kakutou-ec@gsj.bz>
 gsj.bz
+
+// Peterjin.org : https://www.peterjin.org/
+// Submitted by Peter H. Jin <peter@peterjin.org>
+peterjin.org
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization

Peter Jin (.org) produces a variety of webapps and hosts them on its own domain name.

====

Organization Website: https://www.peterjin.org/

Reason for PSL Inclusion
====

The web apps hosted on each subdomain are diverse and varied, and more recently, we needed to add subdomains that contain login information. Because of the possibility of cookie hijacking/injection with JavaScript, we need to add peterjin.org to the PSL.

DNS Verification via dig
=======

https://dnsviz.net/d/_psl.peterjin.org/X8rDEQ/dnssec/

make test
=========
```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```