### PR TITLE
CI: Add Github Actions workflow for TLD updates PRs.

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           go-version: ^1.15
 
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S %Z')" >> $GITHUB_ENV
+      - name: Set current date
+        id: get-date
+        run: echo "::set-output name=now::$(date +'%Y-%m-%dT%H:%M:%S %Z')"
 
       - name: Run patchnewgtlds
         run: tools/patchnewgtlds
@@ -30,9 +31,9 @@ jobs:
         with:
           token: "${{ secrets.BOT_PAT }}"
           push-to-fork: tld-update-bot/list
-          commit-message: "util: gTLD data autopull updates for ${{ env.NOW }}"
-          title: "util: gTLD autopull updates for ${{ env.NOW }}"
-          body: "Public suffix list gTLD data updates from `tools/patchnewgtlds` for ${{ env.NOW }}."
+          commit-message: "util: gTLD data autopull updates for ${{ steps.get-date.outputs.now }}"
+          title: "util: gTLD autopull updates for ${{ steps.get-date.outputs.now }}"
+          body: "Public suffix list gTLD data updates from `tools/patchnewgtlds` for ${{ steps.get-date.outputs.now }}."
           committer: "GitHub <noreply@github.com>"
           author: "GitHub <noreply@github.com>"
           labels: tld-update

--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -1,0 +1,45 @@
+name: tld-update
+on:
+  schedule:
+    # Run every hour, at the 15 minute mark. E.g.
+    # 2020-11-29 00:15:00 UTC, 2020-11-29 01:15:00 UTC, 2020-11-29 02:15:00 UTC
+    - cron:  '15 * * * *'
+jobs:
+  psl-gtld-update:
+    name: Check for TLD data updates
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S %Z')" >> $GITHUB_ENV
+
+      - name: Run patchnewgtlds
+        run: tools/patchnewgtlds
+
+      - name: Create pull-request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: "${{ secrets.BOT_PAT }}"
+          push-to-fork: tld-update-bot/list
+          commit-message: "util: gTLD data autopull updates for ${{ env.NOW }}"
+          title: "util: gTLD autopull updates for ${{ env.NOW }}"
+          body: "Public suffix list gTLD data updates from `tools/patchnewgtlds` for ${{ env.NOW }}."
+          committer: "GitHub <noreply@github.com>"
+          author: "GitHub <noreply@github.com>"
+          labels: tld-update
+          branch: psl-gtld-update
+          delete-branch: true
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
## Summary

I wanted to describe the situation in detail but it made for a long PR description. Here's the important parts up front:

* Travis & the old gTLD PR automation is effectively broken.
* Let's move the gTLD automation into this repo, using Github actions.
* If you agree, stamp this PR with an approval.
* And we need to coordinate on adding the @tld-update-bot's Github "personal access token" as a secret env var in this repo's config. (_Alternatively: maintainers can make their own account and plug a PAT in._)

## Background

Since ~August 2019 the gTLD section of `public_suffix_list.dat` has been kept up to date by a combination of the `tools/newgtlds.go` command [in this repo][newgtlds-cmd] and automation I've been maintaining in [a separate Github repo][cpu-autopull]. To date the bot has opened [67 pull requests][pr-stats].

The automation in `cpu/psl-autopull` is based on a fork of [nbio/autopull][nbio-autopull] that @weppos has been using to keep [publicsuffix-go][psl-go] updated with this repo. It's implemented as a BASH script that is meant to be run by a CI provider (in our case, [Travis CI][autopull-travis]). Its configuration is spread between [the script][autopull-script] and Travis CI environment variables.

Unfortunately as of late the Travis CI platform has been letting us down. I've moved several other repos to Github Actions because the Travis CI open source build queue time was getting far too long. More importantly the "cron" build that is scheduled to run the autopull script once a day has not been running reliably. This is causing updates to arrive late (when I remember to kick the builds by hand...).

Many open source projects are replacing Travis with Github Actions and I think it makes sense here too.

[newgtlds-cmd]: https://github.com/publicsuffix/list/blob/7dfbaf93f1444ebb239403ebb897e17b508efe59/tools/newgtlds.go
[cpu-autopull]: https://github.com/cpu/psl-autopull
[pr-stats]: https://github.com/publicsuffix/list/pulls?q=is%3Apr+author%3Atld-update-bot+
[nbio-autopull]: https://github.com/nbio/autopull
[psl-go]: https://github.com/weppos/publicsuffix-go
[autopull-travis]: https://travis-ci.com/github/cpu/psl-autopull
[autopull-script]: https://github.com/cpu/psl-autopull/blob/master/autopull

## Github Actions

Replacing Travis with Github Actions has several advantages:

* The configuration is entirely in this repo, not spread across multiple repos & services.
* It removes a dependency on an external service & their billing/product changes. We already depend on Github.
* Better automation. The [create-pull-request][create-pr-action] action is clever enough to not open duplicates. The old Travis autopull automation would create duplicate PRs if they weren't merged fast enough.
* The Github actions cron schedule is much more flexible. This PR configures the workflow to run once an hour vs once a day with Travis.

[create-pr-action]: https://github.com/peter-evans/create-pull-request

## Bot Account

This branch configures [create-pull-request][create-pr-action] to open PRs from a fork using a Github [personal access token (PAT)][create-PAT] stored as a repository secret env var called `"BOT_PAT"`. 

**This will need to be set up by a repository administrator by following the [docs for creating an encrypted secret for a repository][create-secret].** 

The PAT must correspond to the Github account that owns the fork of the repository configured in the `push-to-fork` setting of the workflow.

I have configured the `push-to-fork` value to `tld-update-bot/list` on the assumption we'll be adding @tld-update-bot's PAT to the `BOT_PAT` secret var. **If the maintainers would prefer to create their own Github account please make sure to update this piece of config to point to the new account's fork.** Otherwise we should exchange the @tld-update-bot secret PAT value out of band using whatever is least painful for you (GPG, encrypting to SSH keys, quantum key exchange, smoke signals).

To be 100% explicit: in either case adding the PAT to the repo config as an encrypted env var does **not** grant any access to the repository to the bot. The bot opens PRs from a fork to avoid needing push access to this repository. No extra access should be configured.

I'll also note that it _is_ possible to not have any bot account, PAT, or fork involved by using the Github Action's default token. This is how I implemented [similar logic](https://github.com/zmap/zlint/pull/513) for another open source repo. It has one important caveat: without a dedicated bot github account the PRs opened by the workflow won't in turn run further workflows (e.g. unit tests, etc). I discuss some of this in detail [in this issue](https://github.com/zmap/zlint/issues/515). For this repository because the data format is more complex & not a Go datastructure I think it's important to maintain the separate bot account + full CI workflow potential for the automation PRs.

[create-PAT]: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
[create-secret]: https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository

## Future Work

It would be nice to move the repository CI from Travis to Github Actions as well. I suspect it will be a better experience overall. I would be willing to take this work on but thought it was best to put one toe in with this automation before revamping anything else.
