### PR TITLE
Add deno.dev and deno-staging.dev domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11168,6 +11168,11 @@ edgestack.me
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net
 
+// Deno Land Inc : https://deno.com/
+// Submitted by Luca Casonato <hostmaster@deno.com>
+deno.dev
+deno-staging.dev
+
 // deSEC : https://desec.io/
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io


### PR DESCRIPTION
Description of Organization
====

Organization Website: https://deno.land / https://deno.com

Deno Land Inc will provide hosting services to multiple tenants on subdomains of the https://deno.dev and https://deno-staging.dev domains.

Reason for PSL Inclusion
====

- We issue LetsEncrypt certificates for our customers
- We want our customers' sites to be isolated from other customers (cookies, suffix highlighting, etc)

DNS Verification via dig
=======

```
dig +short TXT _psl.deno.dev
"https://github.com/publicsuffix/list/pull/1167"
```

```
dig +short TXT _psl.deno-staging.dev
"https://github.com/publicsuffix/list/pull/1167"
```

make test
=========

```
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```