### PR TITLE
Add .wed

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10227,6 +10227,9 @@ weber
 // website : 2014-04-03 DotWebsite Inc.
 website
 
+// wed : 2013-10-01 Atgron, Inc.
+wed
+
 // wedding : 2014-04-24 Minds + Machines Group Limited
 wedding
 


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [ ] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [ ] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: <!-- https://example.com -->

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

Even though .WED is listed [by ICANN](https://www.icann.org/resources/registries/gtlds/v2/gtlds.json) as having a terminated contract, there are reasons it might make sense to still include it at present:

* There are still live websites that use the .wed TLD, such as [get.wed](http://get.wed/), [atgron.wed](https://www.atgron.wed/), and even [may27.wed](https://may27.wed/). This is not the case for any other site on any other terminated TLD listed on [Google Search](https://www.google.com/search?q=site%3A.wed), which makes .wed unique in that regard.
* It is still listed by ICANN as an active TLD in this other [list of TLDs](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), as well as in the [Root Zone Database](https://www.iana.org/domains/root/db) where is managed by "Emergency Back-End Registry Operator Program - ICANN." Every other terminated TLD is missing from the first list and has status "not assigned" in the second list.
* Despite being listed as `"contractTerminated" : true` [by ICANN](https://www.icann.org/resources/registries/gtlds/v2/gtlds.json), the record for .wed contains a null `removalDate`. Every other TLD which is listed as `contractTerminated` either has no `delegationDate` or has a non-null `removalDate` in the past.

As long as .wed continues to be managed by ICANN's [EBERO](https://www.icann.org/resources/pages/ebero-2013-04-02-en), we might want to maintain it in the list of active TLDs. If the list of new gTLDs must be auto-generated, then the logic for adding TLDs should be adjusted to account for the last point above.

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
See discussions in #1174 and #1175.