### PR TITLE
Added ghost.io to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11870,6 +11870,10 @@ gentlentapis.com
 lab.ms
 cdn-edges.net
 
+// Ghost Foundation : https://ghost.org
+// Submitted by Matt Hanley <security@ghost.org>
+ghost.io
+
 // GitHub, Inc.
 // Submitted by Patrick Toomey <security@github.com>
 github.io


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://ghost.org

Ghost is a proud non-profit organisation building open source technology for journalism. We've built a sustainable business around a free core application, funded by a premium platform as a service to run it on.

Reason for PSL Inclusion
====

Ghost's managed hosting service - Ghost(Pro) - allows users to deploy their own instance of Ghost to a subdomain of `ghost.io`. These instances are independent instances, and as such browsers should treat them as separate sites for Cookies and other security purposes.

DNS Verification via dig
=======

```
dig +short TXT _psl.ghost.io
"https://github.com/publicsuffix/list/pull/1180"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Domain Expiry
=========

```
❯ whois ghost.io | grep Expiry
Registry Expiry Date: 2028-10-01T23:06:09Z
```