### PR TITLE
Added fireweb.app to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11808,6 +11808,10 @@ filegear-sg.me
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
+// Firewebkit : https://www.firewebkit.com
+// Submitted by Majid Qureshi <mqureshi@amrayn.com>
+fireweb.app
+
 // FLAP : https://www.flap.cloud
 // Submitted by Louis Chemineau <louis@chmn.me>
 flap.id
@@ -13537,8 +13541,4 @@ gsj.bz
 сочи.рус
 спб.рус
 я.рус
-
-// Firewebkit : https://www.firewebkit.com
-// Submitted by Majid Qureshi <mqureshi@amrayn.com>
-fireweb.app
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13537,4 +13537,8 @@ gsj.bz
 сочи.рус
 спб.рус
 я.рус
+
+// Firewebkit : https://www.firewebkit.com
+// Submitted by Majid Qureshi <mqureshi@amrayn.com>
+fireweb.app
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://firewebkit.com

Firewebkit is tools and services available to develop the website.

Reason for PSL Inclusion
====
Firewebkit provides free domains for the developers looking to quickly setup something (which is this fireweb.app)

DNS Verification via dig
=======

```
dig +short TXT _psl.fireweb.app
"https://github.com/publicsuffix/list/pull/1181"
```

make test
=========
Test ran fine with no failure
