### PR TITLE
Update Mythic Beasts domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12513,8 +12513,11 @@ pp.ru
 // Submitted by Paul Cammish <kelduum@mythic-beasts.com>
 hostedpi.com
 customer.mythic-beasts.com
+caracal.mythic-beasts.com
+fentiger.mythic-beasts.com
 lynx.mythic-beasts.com
 ocelot.mythic-beasts.com
+oncilla.mythic-beasts.com
 onza.mythic-beasts.com
 sphinx.mythic-beasts.com
 vs.mythic-beasts.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://mythic-beasts.com

This is an amendment to the entry originally added in [PR #1075](https://github.com/publicsuffix/list/pull/1075).

Mythic Beasts is a hosting company offering a mix of web hosting, virtual and dedicated servers, as well as hosted Raspberry Pi servers.

vs.mythic-beasts.com is used by Virtual Servers.
x.mythic-beasts.com is used by Dedicated Servers.
hostedpi.com is used by Hosted Raspberry Pi servers.
customer.mythic-beasts.com is used by a mix of hosting.
All others used by customer web hosting.

Domains hostedpi.com, mythic-beasts.com and retrosnub.com all have an expiry date greater than 2 years and are in active use so will be maintained with greater than 2 year expiry.

Reason for PSL Inclusion
====

A number of customers use the customer sub-domains and server hostnames for testing and various administration interfaces. Adding them to the PSL should negate most cross-domain cookie-related worries.

A number of records have already been added (see [PR #1075](https://github.com/publicsuffix/list/pull/1075)), and further hosting servers are being added to meet demand.

DNS Verification via dig
=======
```
$ dig +short TXT _psl.caracal.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1185"
```
```
$ dig +short TXT _psl.oncilla.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1185"
```
```
$ dig +short TXT _psl.fentiger.mythic-beasts.com
"https://github.com/publicsuffix/list/pull/1185"
```

make test
=========

The test ran okay locally, currently pending CI.
