### PR TITLE
Add freemyip.com as Private domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11843,6 +11843,10 @@ freeboxos.fr
 // Submitted by Daniel Stone <daniel@fooishbar.org>
 freedesktop.org
 
+// freemyip.com : https://freemyip.com
+// Submitted by Cadence <contact@freemyip.com>
+freemyip.com
+
 // FunkFeuer - Verein zur Förderung freier Netze : https://www.funkfeuer.at
 // Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
 wien.funkfeuer.at


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====

Organization Website: https://freemyip.com

This is a Dynamic DNS service provider.

Reason for PSL Inclusion
====

This is dynamic dns service, which means subdomains are registered by independent 3rd parties. It's important to treat them separately for cookie security reasons.
The domain is registered until 2023-12-16 and the registration will be extended annually to keep the required term.


DNS Verification via dig
=======


```
dig +short TXT _psl.freemyip.com
"https://github.com/publicsuffix/list/pull/1187"
```


make test
=========

Test completed successfully.
