### PR TITLE
Remove some Jelastic Domains from PSL due to their end of service (Mods #1023 #1063 #1092 #1095 #1151)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12217,12 +12217,7 @@ ch.trendhosting.cloud
 de.trendhosting.cloud
 jele.club
 clicketcloud.com
-ams.cloudswitches.com
-au.cloudswitches.com
-sg.cloudswitches.com
 dopaas.com
-elastyco.com
-nv.elastyco.com
 hidora.com
 paas.hosted-by-previder.com
 rag-cloud.hosteur.com
@@ -12237,7 +12232,6 @@ lon.wafaicloud.com
 ryd.wafaicloud.com
 j.scaleforce.com.cy
 jelastic.dogado.eu
-paas.leviracloud.eu
 fi.cloudplatform.fi
 demo.datacenter.fi
 paas.datacenter.fi

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12205,6 +12205,8 @@ jele.cloud
 it1.eur.aruba.jenv-aruba.cloud
 it1.jenv-aruba.cloud
 it1-eur.jenv-arubabiz.cloud
+keliweb.cloud
+cs.keliweb.cloud
 oxa.cloud
 tn.oxa.cloud
 uk.oxa.cloud
@@ -12216,6 +12218,7 @@ us.reclaim.cloud
 ch.trendhosting.cloud
 de.trendhosting.cloud
 jele.club
+amscompute.com
 clicketcloud.com
 dopaas.com
 hidora.com
@@ -12237,6 +12240,8 @@ demo.datacenter.fi
 paas.datacenter.fi
 jele.host
 mircloud.host
+paas.beebyte.io
+sekd1.beebyteapp.io
 jele.io
 ocs.opusinteractive.io
 cloud.unispace.io
@@ -12254,6 +12259,7 @@ ams1.jls.docktera.net
 jls-sto1.elastx.net
 jls-sto2.elastx.net
 jls-sto3.elastx.net
+faststacks.net
 fr-1.paas.massivegrid.net
 lon-1.paas.massivegrid.net
 lon-2.paas.massivegrid.net
@@ -12266,6 +12272,7 @@ j.scaleforce.net
 jelastic.tsukaeru.net
 atl.jelastic.vps-host.net
 njs.jelastic.vps-host.net
+sdscloud.pl
 unicloud.pl
 mircloud.ru
 jelastic.regruhosting.ru

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12205,8 +12205,6 @@ jele.cloud
 it1.eur.aruba.jenv-aruba.cloud
 it1.jenv-aruba.cloud
 it1-eur.jenv-arubabiz.cloud
-keliweb.cloud
-cs.keliweb.cloud
 oxa.cloud
 tn.oxa.cloud
 uk.oxa.cloud
@@ -12218,7 +12216,6 @@ us.reclaim.cloud
 ch.trendhosting.cloud
 de.trendhosting.cloud
 jele.club
-amscompute.com
 clicketcloud.com
 dopaas.com
 hidora.com
@@ -12240,8 +12237,6 @@ demo.datacenter.fi
 paas.datacenter.fi
 jele.host
 mircloud.host
-paas.beebyte.io
-sekd1.beebyteapp.io
 jele.io
 ocs.opusinteractive.io
 cloud.unispace.io
@@ -12259,7 +12254,6 @@ ams1.jls.docktera.net
 jls-sto1.elastx.net
 jls-sto2.elastx.net
 jls-sto3.elastx.net
-faststacks.net
 fr-1.paas.massivegrid.net
 lon-1.paas.massivegrid.net
 lon-2.paas.massivegrid.net
@@ -12272,7 +12266,6 @@ j.scaleforce.net
 jelastic.tsukaeru.net
 atl.jelastic.vps-host.net
 njs.jelastic.vps-host.net
-sdscloud.pl
 unicloud.pl
 mircloud.ru
 jelastic.regruhosting.ru


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Removal
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Jelastic is a Multi-Cloud PaaS (Platform as a Service) with decentralized network of independent cloud hosting service providers located across the Globe.

Organization Website: https://jelastic.com



<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Removal
====

The domains cloudswitches.com and leviracloud.eu are removed from PSL due to end of services, that were provided by the partners. 
The owner of shared domain elastyco.com has requested to remove his domain from PSL.

DNS Verification via dig
=======
```
dig txt +short _psl.elastyco.com                                                                                                                        ✔  10061  
"https://github.com/publicsuffix/list/pull/1188"
```
Other domains are eliminated by the partners.

make test
=========

Tested OK. 
<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
