### PR TITLE
Add clickrising.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10996,6 +10996,10 @@ cleverapps.io
 // Submitted by Mathilde Blanchemanche <mathilde@clic2000.fr>
 clic2000.net
 
+// ClickRising : https://clickrising.com/
+// Submitted by Umut Gumeli <infrastructure-publicsuffixlist@clickrising.com>
+clickrising.net
+
 // Cloud66 : https://www.cloud66.com/
 // Submitted by Khash Sajadi <khash@cloud66.com>
 c66.me


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://clickrising.com/

Hi, I'm Umut, CTO of ClickRising.

ClickRising is the revolutionary sponsorship platform where content creators and apps come together.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->

We provide some clients a custom `*.clickrising.net` subdomain for their dashboards.

We're looking to add `clickrising.net` to the Public Suffix List to improve cookie security for all of our clients.

The domain is registered for 2+ years.

DNS Verification via dig
=======

```
dig +short TXT _psl.clickrising.net
"https://github.com/publicsuffix/list/pull/1192"
```

make test
=========

Test passed OK
