### PR TITLE
Add hosting and paas from OVHcloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12828,6 +12828,11 @@ skygearapp.com
 // Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
 outsystemscloud.com
 
+// OVHcloud: https://ovhcloud.com
+// Submitted by Vincent Cassé <vincent.casse@ovhcloud.com>
+*.webpaas.ovh.net
+*.hosting.ovh.net
+
 // OwnProvider GmbH: http://www.ownprovider.com
 // Submitted by Jan Moennich <jan.moennich@ownprovider.com>
 ownprovider.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://ovhcloud.com

OVHcloud is an european company that provide Cloud services and hosting services.

Reason for PSL Inclusion
====

In our hosting offer and Paas offer, we provide sudomains to allow developers to test their websites. We want to improve the cookie security on theses staging subdomains.

Our Paas offers are delivered as subdomains of [region].webpaas.ovh.net
Our hosting offers are delivered as sudomains of [clusterNumber].hosting.ovh.net

DNS Verification via dig
=======

```
dig +short TXT _psl.ovh.net
"https://github.com/publicsuffix/list/pull/1193"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Domain Expiry
===========

```
% whois ghost.io | grep Expiry
Registry Expiry Date: 2028-10-01T23:06:09Z
```