### PR TITLE
psl.ninja individual domain holder request.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11180,6 +11180,10 @@ builtwithdark.com
 // Submitted by Richard Li <secalert@datawire.io>
 edgestack.me
 
+// David Dworken : https://daviddworken.com
+// Submitted by David Dworken <david@daviddworken.com>
+psl.ninja
+
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://daviddworken.com

Hi! I'm an individual security researcher interested in having access to a domain that is on the PSL. 

Reason for PSL Inclusion
====

A number of times in the past I have wished that I had a test domain on the PSL that I could use for testing code that interacts with site based restrictions as used in browsers. As one example of this, I wish to have a domain on the PSL to allow me to create better POCs for potential issues around browser's site-keyed double caches. 

I have registered `psl.ninja` for the next 3 years and will keep it renewed and under my control indefinitely. 

DNS Verification via dig
=======

```
dig +short TXT _psl.psl.ninja      
"https://github.com/publicsuffix/list/pull/1195"
```

make test
=========

Tests pass :+1: 