### PR TITLE
add torproject.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13270,6 +13270,11 @@ arvo.network
 azimuth.network
 tlon.network
 
+// Tor Project, Inc. : https://torproject.org
+// Submitted by Antoine Beaupré <anarcat@torproject.org
+torproject.net
+pages.torproject.net
+
 // TownNews.com : http://www.townnews.com
 // Submitted by Dustin Ward <dward@townnews.com>
 bloxcms.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://torproject.org/

I'm the senior sysadmin at the Tor Project, Inc. (proof at [the people page as well](https://www.torproject.org/about/people/)) empowered to represent the interests of the company (and the project) insofar as technical resources like DNS are concerned. 

Reason for PSL Inclusion
====

The torproject.org domain is the main domain used by the Tor
Project. All machines under that domain are managed by the TPA
team (Tor Project sysAdmins).

The torproject.net domain, however, can be delegated to third parties
and is less trusted.

This is the same policy as the `debian.net` domain.

We will possibly start hosting "GitLab pages" under the
pages.torproject.net domain.

The goal of those changes is to make it more difficult to operate
cross-site scripting attacks by setting cookies across that those
domains.


DNS Verification via dig
=======

```
$ dig +short TXT _psl.torproject.net
"https://github.com/publicsuffix/list/pull/1196"
$ dig +short TXT _psl.pages.torproject.net
"https://github.com/publicsuffix/list/pull/1196"
```

make test
=========

Output of `make test`: https://paste.anarc.at/publish/2021-01-27-j5kfz4GOKxeW_Nvr0Nv1p8eSOolo52QlYU0Uv2q_kow/stdin.txt