### PR TITLE
Add Appspace to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10798,6 +10798,11 @@ tele.amune.org
 // Submitted by Apigee Security Team <security@apigee.com>
 apigee.io
 
+// Appspace : https://www.appspace.com
+// Submitted by Appspace Security Team <security@appspace.com>
+appspacehosted.com
+appspaceusercontent.com
+
 // Aptible : https://www.aptible.com/
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com


### PR DESCRIPTION
* added appspacehosted.com
* added appspaceusercontent.com

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.appspace.com

Appspace is a content management platform for digital communication.

Reason for PSL Inclusion
====

The appspacehosted.com domain is used for hosting customer specific content and should not be allowed to share cookies across subdomains/customers. The appspaceusercontent.com hosts customer generated html content and should not be allowed to persist cookies across subdomains/customers.

DNS Verification via dig
=======

```
dig +short TXT _psl.appspacehosted.com
"https://github.com/publicsuffix/list/pull/1197"
```

```
dig +short TXT _psl.appspaceusercontent.com
"https://github.com/publicsuffix/list/pull/1197"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

Test Passed
