### PR TITLE
Add awsglobalaccelerator.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10728,6 +10728,10 @@ us-west-2.elasticbeanstalk.com
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
 
+// Amazon Global Accelerator : https://aws.amazon.com/global-accelerator/
+// Submitted by Daniel Massaguer <psl-maintainers@amazon.com>
+awsglobalaccelerator.com
+
 // Amazon S3 : https://aws.amazon.com/s3/
 // Submitted by Luke Wells <psl-maintainers@amazon.com>
 s3.amazonaws.com


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->



* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration. (see comments on yearly auto-renewal)
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://docs.aws.amazon.com/global-accelerator/ , https://aws.amazon.com/

Amazon Web Services (AWS) is a cloud platform, offering a range of fully featured services from data centers globally.

AWS Global Accelerator is an AWS networking service that sends our customers' user’s traffic through Amazon Web Service’s global network infrastructure to customer endpoints (such as AWS Application Load Balancers (ALBs) or AWS EC2 instances). With Global Accelerator, our customers are provided two global static IPs as the entry point for their applications. 

Global Accelerator assigns each accelerator a default Domain Name System (DNS) subdomain, similar to 
       `a1234567890abcdef.awsglobalaccelerator.com`
, that points to the static IP addresses provided to the customer.

I'm an engineer working with AWS Global Accelerator team requesting to include the subdomain `awsglobalaccelerator.com` in the Public Suffix List on behalf of our team.


Reason for PSL Inclusion
====
By including `awsglobalaccelerator.com` in the PSL, applications like web browsers could correctly manage those subdomains (e.g., cookies, highlighting the subdomain, sorting by subdomain and not all the domain).


Note that the `awsglobalaccelerator.com` domain is auto-renewed yearly. 

```
whois awsglobalaccelerator.com | egrep "(^Updated Date|^Creation Date|Expiration Date)"
Updated Date: 2020-10-26T02:28:45-0700
Creation Date: 2018-11-26T19:24:11-0800
Registrar Registration Expiration Date: 2021-11-26T00:00:00-0800
```


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->
```
dig +short TXT _psl.awsglobalaccelerator.com
"https://github.com/publicsuffix/list/pull/1199"
```
make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

Tests pass

