### PR TITLE
Add pyqt.site to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13583,4 +13583,8 @@ gsj.bz
 сочи.рус
 спб.рус
 я.рус
+
+// PyQt BBS : https://pyqt.site/
+// Submitted by Irony <892768447@qq.com>
+pyqt.site
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://pyqt.site

This is a forum for users to discuss PyQt

Reason for PSL Inclusion
====

Accelerate and protect your site with [Cloudflare](https://cloudflare.com), It's error that pyqt.site is not a registered domain

DNS Verification via dig
=======

```
dig +short TXT _psl.pyqt.site
"https://github.com/publicsuffix/list/pull/1200"
```

```
dig +short TXT psl.pyqt.site
"https://github.com/publicsuffix/list/pull/1200"
```

make test
=========

I ran the test and it passed succesfully.
