### PR TITLE
Add mcpre.ru, mcdir.me to mchost.ru subsection

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12478,6 +12478,7 @@ mcpe.me
 
 // McHost : https://mchost.ru
 // Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
+mcdir.me
 mcdir.ru
 vps.mcdir.ru
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12480,6 +12480,7 @@ mcpe.me
 // Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
 mcdir.me
 mcdir.ru
+mcpre.ru
 vps.mcdir.ru
 
 // Memset hosting : https://www.memset.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://mchost.ru

McHost is a hosting provider. We provide free subdomains in `.mcdir.me`, `.mcdir.ru` and `.vps.mcdir.ru` domains for our customers.

Reason for PSL Inclusion
====

McHost's customers are allowed to publish their own sites in the .mcdir.me suffix, so we need to restrict cookie sharing between these subdomains. These domain names and DNS records will be kept renewed.

DNS Verification via dig
=======

```
dig +short TXT _psl.mcdir.me
"https://github.com/publicsuffix/list/pull/1206"
```
```
dig +short TXT _psl.mcpre.ru
"https://github.com/publicsuffix/list/pull/1206"
```
make test
=========

```
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
