### PR TITLE
Removal of *.hosting.ovh.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12860,7 +12860,6 @@ outsystemscloud.com
 // OVHcloud: https://ovhcloud.com
 // Submitted by Vincent Cassé <vincent.casse@ovhcloud.com>
 *.webpaas.ovh.net
-*.hosting.ovh.net
 
 // OwnProvider GmbH: http://www.ownprovider.com
 // Submitted by Jan Moennich <jan.moennich@ownprovider.com>


### PR DESCRIPTION

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://ovhcloud.com

OVHcloud is an european company that provide Cloud services and hosting services.

Reason for PSL Inclusion
====

We revert this https://github.com/publicsuffix/list/pull/1193 to be able to generate certificates

DNS Verification via dig
=======

```
dig +short TXT _psl.ovh.net
"https://github.com/publicsuffix/list/pull/1193"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

Extra info
=========

As explained in this issue : https://github.com/publicsuffix/list/issues/1209 , due to `*.hosting.ovh.net` line, we can't anymore generate certificate and our customers will not be able to use their services successfully once the current certificate will expire.
 
We must fix it before the certificate expiration date which is very soon, so it became urgent to find a way to fix it.
As we do not have at this time a sweet solution to do so, we choose to temporary remove this line.

@sleevi & @dnsguru I tag you directly here because you was the reviewers during the previous pull request
Thank you in advance for your support
