### PR TITLE
Add edgecompute.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11781,6 +11781,7 @@ u.channelsdvr.net
 
 // Fastly Inc. : http://www.fastly.com/
 // Submitted by Fastly Security <security@fastly.com>
+edgecompute.app
 fastly-terrarium.com
 fastlylb.net
 map.fastlylb.net


### PR DESCRIPTION
Hello,

Jonathan Foote from the Fastly security team here, adding another PSL entry for the organization.

Update: This PR is ready for review.

Thanks,
Jon

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: [www.fastly.com](https://www.fastly.com)

Fastly’s global edge cloud platform processes, serves, and secures applications for users. See [www.fastly.com](https://www.fastly.com) for more information.

Reason for PSL Inclusion
====

User (third-party) content is served from subdomains of edgecompute.app. Adding this domain to the PSL will stymie cookie stuffing attacks across these subdomains.

The registration term for edgecompute.app is greater than 2 years in the future, and it will be extended automatically in advance of expiration. 

```
% whois edgecompute.app | grep "Registry Expiry"
Registry Expiry Date: 2025-09-26T17:20:49Z
```

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

DNS is ready for verification

```
% dig +short TXT _psl.edgecompute.app
"https://github.com/publicsuffix/list/pull/1212"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

`make test` completed successfully
