### PR TITLE
CI: remove "labels" config from tld-update.yml workflow.

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -40,7 +40,6 @@ jobs:
           body: "Public suffix list gTLD data updates from `tools/patchnewgtlds` for ${{ steps.get-date.outputs.now }}."
           committer: "GitHub <noreply@github.com>"
           author: "GitHub <noreply@github.com>"
-          labels: tld-update
           branch: psl-gtld-update
           delete-branch: true
 


### PR DESCRIPTION
The `.github/workflows/tld-update.yml` Github actions workflow used to update the gTLD data in the PSL dat file is presently configured to try and add a `tld-update` label to the PRs it creates.

In practice this requires admin access to the repo and we explicitly do not want the @tld-update-bot Github account used to create PRs to have that access.

The solution is simple: don't try to have the pull request action label the PR it creates. This will resolve the failure present in the action runs that create a PR (e.g. [this run](https://github.com/publicsuffix/list/runs/1938957607?check_suite_focus=true)).