### PR TITLE
Add noticeable.news

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12620,6 +12620,10 @@ nfshost.com
 *.northflank.app
 *.code.run
 
+// Noticeable : https://noticeable.io
+// Submitted by Laurent Pellegrino <security@noticeable.io>
+noticeable.news
+
 // Now-DNS : https://now-dns.com
 // Submitted by Steve Russell <steve@now-dns.com>
 dnsking.ch


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://noticeable.io

Noticeable is an all-in-one solution to update users effectively. You can use the service to engage customers or teammates with regular updates, get powerful feedback, and measure satisfaction.

I am the founder and CEO of Noticeable.

Reason for PSL Inclusion
====

User (third-party) content is served from subdomains of _noticeable.news_. Adding this domain to the PSL will stymie cookie stuffing attacks across these subdomains.

The registration term for _noticeable.news_ has just been extended and is greater than 2 years: `2023-09-19T18:26:06.55Z`.

DNS Verification via dig
=======

```
$ dig +short TXT _psl.noticeable.news
"https://github.com/publicsuffix/list/pull/1216"
```

make test
=========

`make test` completed successfully