### PR TITLE
sourcehut: add srht.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13185,6 +13185,10 @@ small-web.org
 // Submitted by Ian Streeter <ian@snowplowanalytics.com>
 try-snowplow.com
 
+// SourceHut : https://sourcehut.org
+// Submitted by Drew DeVault <sir@cmpwn.com>
+srht.site
+
 // Stackhero : https://www.stackhero.io
 // Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
 stackhero-network.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://sourcehut.org

I am the principal engineer at SourceHut. We are a software development forge, and provide hosting for static websites as one of our services.

Reason for PSL Inclusion
====

This domain (srht.site) provides hosting for arbitrary user content. Each subdomain represents an independent entity and information sharing between pages is considered a security issue.

DNS Verification via dig
=======

```
dig +short TXT _psl.srht.site
"https://github.com/publicsuffix/list/pull/1218"
```

make test
=========

:heavy_check_mark: works

:vomiting_face: autotools