### PR TITLE
Update Email address for GOV.UK Platform as a Service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11936,7 +11936,7 @@ glitch.me
 lolipop.io
 
 // GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
-// Submitted by Tom Whitwell <tom.whitwell@digital.cabinet-office.gov.uk>
+// Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>
 cloudapps.digital
 london.cloudapps.digital
 


### PR DESCRIPTION
Previously the email address was for an individual, in order to ensure that there is
deliverability for any emails regarding this suffix it would be prudent to
use our team support address for this purpose.

As this is not a change to the domains which were included in https://github.com/publicsuffix/list/pull/765 the previous information on that PR is still valid.

Tests have been run and pass
