### PR TITLE
Add boutir.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10876,6 +10876,10 @@ of.je
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net
 
+// Boutir : https://www.boutir.com
+// Submitted by Eric Ng Ka Ka <ngkaka@boutir.com>
+boutir.com
+
 // Boxfuse : https://boxfuse.com
 // Submitted by Axel Fontaine <axel@boxfuse.com>
 boxfuse.io


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Boutir (https://www.boutir.com) helps individual merchants to build and host their online webstore. Merchant can use their own custom domain, or use *.boutir.com (e.g. https://ingoodhandsof.boutir.com), therefore we would like to have boutir.com in the public suffix list and have it as eTLD

I'm founder of Boutir, and built Boutir with other engineers in the team. 

Boutir is a SAAS business, merchants can subscribe our monthly / yearly plan to setup, maintain and operate their online webstore using our mobile app. There is also a free plan for merchants and they can setup their store (e.g. xxx.boutir.com) in 10 mins. 

Organization Website: https://www.boutir.com

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

With iOS14.5 launch, in accordance with their AppTrackingTransparency framework, Facebook will start processing pixel conversion events from iOS 14 devices using Aggregated Event Measurement to preserve user privacy and help running effective campaigns. Specifically, Facebook would associate events triggered from a website to be associated with a Domain, the corresponding merchant's owned Facebook Ad Account, and the corresponding Pixel.

Merchant needs to verify their website's domain with Facebook and this would be done at eTLD+1 level. In our case, it would be boutir.com 

However, as with our model, each merchant operates separately and independently. aaa.boutir.com products, data, events are totally separated from those from bbb.boutir.com. But now we cannot do it, as Facebook only verify eTLD+1 (i.e. boutir.com) and would not verify and associate events with aaa.boutir.com separately with bbb.boutir.com. Merchants from aaa.boutir.com and bbb.boutir.com cannot pass through the verification step, and cannot effectively associate events triggered from their website to their domain. 

If boutir.com can be listed in the PSL, Facebook can separately verify aaa.boutir.com and bbb.boutir.com, and different merchants can associate events and track separately with different domain aaa.boutir.com and bbb.boutir.com 

boutir.com registration for is up to 19/10/2023, longer than 2 years from now. 

We have a past issue #1202. The issue has been closed as I have not provided response on time while we are still discussing with Facebook to see if we have to make the domain boutir.com listed on PSL. After confirming with Facebook side, the issue has been closed and thus I re-create a new issue for this. 


<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->

DNS Verification via dig
=======

dig +short TXT _psl.boutir.com
"https://github.com/publicsuffix/list/pull/1225"

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
