### PR TITLE
Add cafjs.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10899,6 +10899,10 @@ uk0.bigv.io
 dh.bytemark.co.uk
 vm.bytemark.co.uk
 
+// Caf.js Labs LLC : https://www.cafjs.com
+// Submitted by Antonio Lain <antlai@cafjs.com>
+cafjs.com
+
 // callidomus : https://www.callidomus.com/
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X ] Description of Organization
* [ X] Reason for PSL Inclusion
* [ X] DNS verification via dig
* [ X] Run Syntax Checker (make test)

* [ X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website:  https://www.cafjs.com

My name is Antonio Lain, I'm the founder of Caf.js Labs LLC and the creator of the Caf.js framework.

Caf.js Labs hosts third-party applications implemented with the Caf.js framework, providing a simple deployment model that takes care of flexing resources, authenticating users, updating devices, managing subscriptions, and billing.

Reason for PSL Inclusion
====
Third-party applications deployed in our platform get a subdomain qualified by the publisher of the app. For example, if the user 'antonio' deploys an app 'helloworld', the URL for the app would be 'https://antonio-helloworld.cafjs.com'.

Unfortunately, another app deployed by joe, e.g., 'https://joe-myapp.cafjs.com`,
could perform cookie attacks on the previous app, since they are currently assumed to be the same site by the browser.

The registration term for 'cafjs.com' is greater than 2 years, and it will be extended automatically in advance of expiration.
```
$ whois cafjs.com | grep "Registry Expiry"
   Registry Expiry Date: 2024-12-18T19:35:07Z
```
No previous PR

DNS Verification via dig
=======

```
dig +short  TXT _psl.cafjs.com
"https://github.com/publicsuffix/list/pull/1228"
```

make test
=========

Test run successfully
