### PR TITLE
Add subdomains of pythonanywhere.com and of eu.pythonanywhere.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13002,6 +13002,11 @@ byen.site
 // Submitted by Kor Nielsen <kor@pubtls.org>
 pubtls.org
 
+// PythonAnywhere LLP: https://www.pythonanywhere.com
+// Submitted by Giles Thomas <giles@pythonanywhere.com>
+*.pythonanywhere.com
+*.eu.pythonanywhere.com
+
 // QOTO, Org.
 // Submitted by Jeffrey Phillips Freeman <jeffrey.freeman@qoto.org>
 qoto.io


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.pythonanywhere.com/

PythonAnywhere is an online software development and web-hosting environment, run by a UK company PythonAnywhere LLP.  We have a US-hosted site at https://www.pythonanywhere.com/, and a separate EU-hosted system at https://eu.pythonanywhere.com.

We allow users of our US-hosted system to create websites at *theirusername*`.pythonanywhere.com`, and users of our EU-hosted system to create websites at *theirusername*`.eu.pythonanywhere.com` so that they don't need to buy their own domain or learn about DNS just in order to get a website online.


Reason for PSL Inclusion
====

We would like our two domains to be on the PSL to improve cookie security.  

We do *not* have any concerns regarding Let's Encrypt as we provide HTTP security for subdomains of our own site via appropriately-configured wildcard certs.

`pythonanywhere.com` currently is registered up to 2025-03-24, so for comfortably more than two years.


DNS Verification via dig
=======

```
$ dig +short TXT _psl.pythonanywhere.com
"https://github.com/publicsuffix/list/pull/1229"
$ dig +short TXT _psl.eu.pythonanywhere.com
"https://github.com/publicsuffix/list/pull/1229"
```

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```