### PR TITLE
Add service magnet to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13149,6 +13149,10 @@ seidat.net
 // Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
 senseering.net
 
+// Service Magnet : https://myservicemagnet.com
+// Submitted by Dave Sanders <dave@myservicemagnet.com>
+magnet.page
+
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua


### PR DESCRIPTION
This replaces #1230 and cleans up the merge change to only be the public_suffix_list.dat file, as requested by @dnsguru 

-----

Adding our root domain for our subdomained users for Magnet pages.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Service Magnet is a lead generation toolset for the small business service industry. Our customers provide information to us that allows us to generate and maintain landing pages for specific online advertisements so that non-technical users can benefit from online advertising for their businesses.

Each of our customers is assigned a specific subdomain, very much like Squarespace, Heroku, or Carrd does for their customers. We need these subdomains recognized as their own websites.

Organization Website: https://myservicemagnet.com

Note: our website is our marketing information. Our customers pages are hosted at X.magnet.page, which is what this request is for.

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

We require PSL inclusion primarily so that Facebook and other advertising platforms recognize the customers websites as different stand-alone sites. Currently because of the TLD+1 rules that Facebook uses, they lump all of our magnet pages under the same domain. We reached out to the Carrd folks and they reported that the way they got around this limitation was by submitting their domain here.

This makes sense because our customer websites should be seen as completely separate and unique, even with the same base domain.

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->

DNS Verification via dig
=======

```
dig +short TXT _psl.magnet.page
"https://github.com/publicsuffix/list/pull/1230"
```

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

Yes, I ran make test locally on my fork and from what I could tell everything passed.

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
