### PR TITLE
add paywhirl.com for site users

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12912,6 +12912,10 @@ pagefrontapp.com
 // Submitted by Yann Guichard <yann@pagexl.com>
 pagexl.com
 
+// Paywhirl, Inc : https://paywhirl.com/
+// Submitted by Daniel Netzer <dan@paywhirl.com>
+*.paywhirl.com
+
 // pcarrier.ca Software Inc: https://pcarrier.ca/
 // Submitted by Pierre Carrier <pc@rrier.ca>
 bar0.net


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://paywhirl.com

I am CTO of Paywhirl Inc - We are a recurring payment processor with a number of tools available for 3rd parties and custom development. 

Reason for PSL Inclusion
====

We provide subdomain `*.paywhirl.com` to our users, allowing them to implement 3rd party tools and manage them. 

The domains hold registration terms longer than 2 years and we will maintain the registration term above this threshold.

DNS Verification via dig
=======

```
dig +short TXT _psl.paywhirl.com 
"https://github.com/publicsuffix/list/pull/1237"
```

make test
=========

The test ran successfully.
