### PR TITLE
Add redpwnc.tf

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13087,6 +13087,10 @@ g.vbrplsbx.io
 // Submitted by David Fischer <team@readthedocs.org>
 readthedocs.io
 
+// redpwn : https://redpwn.net
+// Submitted by Philip Papurt <philip@redpwn.net>
+redpwnc.tf
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com>
 rhcloud.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://redpwn.net

redpwn is a team which competes in security competitions known as CTFs. redpwn organizes an annual competition, [redpwnCTF](https://ctf.redpwn.net). I help organize the competition and am responsible for parts of its infrastructure.

Reason for PSL Inclusion
====

redpwnCTF uses the domain `redpwnc.tf` to host security challenges for competition participants. Subdomains of `redpwnc.tf` are used for intentionally insecure services that are designed to be compromised. To isolate participants from each other and provide cookie security, we would like to add `redpwnc.tf` to the PSL.

`redpwnc.tf` expires on 2023-03-24, which is 2 years from today.

DNS Verification via dig
=======

```
dig +short TXT _psl.redpwnc.tf
"https://github.com/publicsuffix/list/pull/1241"
```

make test
=========

Local tests have passed.
