### PR TITLE
Adding Oddle.me to the domain list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12858,6 +12858,10 @@ static.observableusercontent.com
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
 
+// Oddle : https://oddle.me
+// Submitted by Son Nguyen <son.nguyen@oddle.me>
+oddle.me
+
 // OMG.LOL : <https://omg.lol>
 // Submitted by Adam Newbold <adam@omg.lol>
 omg.lol


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

**### Description of Organization**
Oddle is a SaaS platform that helps restaurants go online. Oddle provides restaurants with their own online ordering system which enables them to receive and manage orders from their customers. Oddle currently serves over 3,000 restaurants globally.

**### Reason for PSL Inclusion**
Restaurants using our platform are able to build their own e-commerce webstore. They will be given their own oddle.me subdomain, removing the need for them to buy a domain to go online. For example, the url for a restaurant A would be https://restauranta.oddle.me. Some examples of our actual customers include https://genkisushi.oddle.me/, https://penangplace.oddle.me/ and https://taicheong.oddle.me/. We would like to include oddle.me domain for improved cookie security. Do note that all subdomains are covered by our wildcard SSL certs.

**### DNS Verification via dig**
dig +short TXT _psl.oddle.me
"https://github.com/publicsuffix/list/pull/1246"

**### Run Syntax Checker (make test)**
All tests are passed