### PR TITLE
addition of ss sld's sch.ss and me.ss

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6087,8 +6087,10 @@ biz.ss
 com.ss
 edu.ss
 gov.ss
+me.ss
 net.ss
 org.ss
+sch.ss
 
 // st : http://www.nic.st/html/policyrules/
 st


### PR DESCRIPTION
* [ x] Description of Organization
* [x ] Reason for PSL Inclusion
* [ x] DNS verification via dig
* [ x] Run Syntax Checker (make test)

Description of Organization
====
Individual.

Reason for PSL Inclusion
====
This adds missing entries that are stated on https://registry.nic.ss/ (pointed to via https://www.iana.org/domains/root/db/ss.html)

DNS Verification via dig
=======
Requesting DNS Verification be set aside as we are updating the entry for an existing entry to align it with the registry listed information that is verifiably listed at the authoritative registry listed with the IANA.

make test
=========
Ran with no issues.
