### PR TITLE
accesso - Adding devcdnaccesso

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10654,6 +10654,10 @@ ltd.ua
 // 611coin : https://611project.org/
 611.to
 
+// accesso Technology Group, plc. : https://accesso.com/
+// Submitted by accesso Team <accessoecommerce@accesso.com>
+*.devcdnaccesso.com
+
 // Adobe : https://www.adobe.com/
 // Submitted by Ian Boston <boston@adobe.com>
 adobeaemcloud.com
@@ -11868,7 +11872,7 @@ shw.io
 flynnhosting.net
 
 // Forgerock : https://www.forgerock.com
-// Submitted by Roderick Parr <roderick.parr@forgerock.com> 
+// Submitted by Roderick Parr <roderick.parr@forgerock.com>
 forgeblocks.com
 
 // Framer : https://www.framer.com


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====

acces­so Tech­nol­o­gy Group plc, the pre­mier tech­nol­o­gy solu­tions provider to leisure, enter­tain­ment and cul­tur­al mar­kets

Organization Website: accesso.com

Reason for PSL Inclusion
====

accesso hosts eCommerce solutions for our clients who are affected by the iOS 14 changes. We are seeking to add to the PSL to test an integration that will effectively counter the effects of the iOS 14 changes. 

DNS Verification via dig
=======

```
dig +short TXT devcdnaccesso.com
"https://github.com/publicsuffix/list/pull/1248"
```

make test
=========

This test ran with no syntax errors