### PR TITLE
Add ravpage.co.il

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11877,6 +11877,10 @@ forgeblocks.com
 framer.app
 framercanvas.com
 
+// RavPage : https://www.ravpage.co.il
+// Submitted by Roni Horowitz <roni@responder.co.il>
+ravpage.co.il
+
 // Frederik Braun https://frederik-braun.com
 // Submitted by Frederik Braun <fb@frederik-braun.com>
 0e.vc


### PR DESCRIPTION
* [x] Description of Organization
Responder (https://responder.co.il) provides solutions to business owners to communicate with their customers for about 15 years.
We provide a landing pages builder and serving solution for our customers using the https://ravpage.co.il domain.
I'm working w/ the company R&D team to enable the services to their customers.

* [x] Reason for PSL Inclusion
Some of our customers are using custom domain w/ their landing pages that created w/ our platform. However, some prefer to use a dedicated subdomain under the ravpage.co.il domain.
* [x] DNS verification via dig
$ dig TXT _psl.ravpage.co.il
https://github.com/publicsuffix/list/pull/1250

* [x] Run Syntax Checker (make test)
Here is a summary of the make test:
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
ravpage.co.il is valid till 2026-03-30: https://www.isoc.org.il/whois