### PR TITLE
exclude gov.st from publicsuffix since host act as public domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6097,7 +6097,6 @@ com.st
 consulado.st
 edu.st
 embaixada.st
-gov.st
 mil.st
 net.st
 org.st


### PR DESCRIPTION
removed gov.st from list of reserved domains since this zone acting as independent on its own

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://www.nic.st
ST Registry AB
.ST domain zone administrator

Reason for PSL Inclusion
====
gov.st is operated as public domain and not reserved as subdomain. This zone is used directly by government of Sao Tome. Domain was excluded from list of reserved domains on: https://www.nic.st/terms-of-service 
We don't want to keep it in this list as well as change it to private zone.

DNS Verification via dig
=======
DONE

```
dig +short TXT _psl.gov.st
"https://github.com/publicsuffix/list/pull/1257"
```

make test
=========
test done

```
$ make test
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC: 
OK
-n test_allowedchars: 
OK
-n test_dots: 
OK
-n test_duplicate: 
OK
-n test_exception: 
OK
-n test_punycode: 
OK
-n test_section1: 
OK
-n test_section2: 
OK
-n test_section3: 
OK
-n test_section4: 
OK
-n test_spaces: 
OK
-n test_wildcard: 
OK
```