### PR TITLE
Adding accessoticketing.com subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10658,6 +10658,15 @@ graphox.us
 // accesso Technology Group, plc. : https://accesso.com/
 // Submitted by accesso Team <accessoecommerce@accesso.com>
 *.devcdnaccesso.com
+*.cf.accessoticketing.com
+*.as.accessoticketing.com
+*.oc.accessoticketing.com
+*.eu.accessoticketing.com
+*.na.accessoticketing.com
+*.na2.accessoticketing.com
+*.meg-na.accessoticketing.com
+*.meg-eu.accessoticketing.com
+*.meg-as.accessoticketing.com
 
 // Adobe : https://www.adobe.com/
 // Submitted by Ian Boston <boston@adobe.com>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====

acces­so Tech­nol­o­gy Group plc, the pre­mier tech­nol­o­gy solu­tions provider to leisure, enter­tain­ment and cul­tur­al mar­kets

Organization Website: accesso.com

Reason for PSL Inclusion
====

accesso hosts eCommerce solutions for our clients who are affected by the iOS 14 changes. We are seeking to add to the PSL to enable our clients to use certain tracking pixels and features otherwise disabled by the iOS 14 update.

DNS Verification via dig
=======

```
TBA
```

make test
=========

This test ran with no syntax errors