### PR TITLE
Add clothesmentor.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11077,6 +11077,10 @@ r.cdn77.net
 rsc.cdn77.org
 ssl.origin.cdn77-secure.org
 
+// Clothes Mentor : https://clothesmentor.com
+// Submitted by Sean Marrs <smarrs@ntyfranchise.com>
+clothesmentor.com
+
 // Cloud DNS Ltd : http://www.cloudns.net
 // Submitted by Aleksander Hristov <noc@cloudns.net>
 cloudns.asia


### PR DESCRIPTION
Add Clothes Mentor

Add clothesmentor.com to PSL

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://clothesmentor.com

Clothes Mentor is a franchise resale retail fashion boutique. Stores under the Clothes Mentor are sold by the franchisor NTY Franchise Co., LLC.

My name is Sean Marrs and I am the IT Administrator for NTY Franchise Co., LLC. 

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====
We would like to be added to the list to provide security for our franchisees and their websites. 

While we own and maintain clothesmentor.com, each of our franchise locations have a website as a subdomain of clothesmentor.com. (ex. sanduskyoh.clothesmentor.com). These subdomain sites are also their ecommerce sites hosted by Shopify. We would like to provide our franchisees and their customers a secure ecommerce environment.

Clothesmentor.com is registered with GoDaddy.com and is good until 2024. 

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.clothesmentor.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

```
dig +short TXT _psl.clothesmentor.com
"https://github.com/publicsuffix/list/pull/1261"
```

make test
=========
I tried to run it but I keep getting error 127, autoreconf not found. 
Assistance would be appreciated. 
<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->