### PR TITLE
Add nel.family

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12636,6 +12636,10 @@ to.work
 // Submitted by Tocknicsu <admin@nctu.me>
 nctu.me
 
+// Nelson Family: https://nel.family/
+// Submitted by Bradley Nelson <bradley@nel.family>
+nel.family
+
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
 netlify.app


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Several private families that shares a TLD

Reason for PSL Inclusion
====

This domain is used be many people related to the Nelson Family. It is used for several commercial purposes as well as the FQDN for several home networks.

DNS Verification via dig
=======
```
dig +short TXT _psl.nel.family
"https://github.com/publicsuffix/list/pull/1262"
```

make test
=========

https://gist.github.com/BCNelson/4cbeb064496e357e282f7e79b29f8a45

Example Domains
======
```
paul.nel.family
craig.nel.family
h.nel.family
```

