### PR TITLE
Add winred.com to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13597,6 +13597,10 @@ wmflabs.org
 toolforge.org
 wmcloud.org
 
+// WinRed : https://winred.com
+// Submitted by WinRed Technical Services <support@winred.com>
+winred.com
+
 // WISP : https://wisp.gg
 // Submitted by Stepan Fedotov <stepan@wisp.gg>
 panel.gg


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://winred.com

WinRed is a fundraising technology built specifically for political campaigns to maximize their lead optimization and donor engagement initiatives. We provide a platform thats allows clients to quickly onboard and serve various types of landing pages using our domains, i.e. `client.winred.com/donate`. 

Reason for PSL Inclusion
====

We allow clients to setup their own custom domains for their fundraising initiatives, but we also provide all clients with a `*.winred.com` subdomain to serve as the primary endpoint for all their landing pages. Therefore, there is a need to isolate each of these clients to improve Cookie Security since this leaves each of those subdomains vulnerable to CSRF.

`winred.com` has recently been renewed for more than 2 years

DNS Verification via dig
=======


```
dig +short TXT _psl.winred.com
"https://github.com/publicsuffix/list/pull/1267"
```


make test
=========

TravisCI Build: https://travis-ci.org/github/publicsuffix/list/builds/766266468

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
