### PR TITLE
Add *.kctf.cloud to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11995,6 +11995,8 @@ goip.de
 
 // Google, Inc.
 // Submitted by Eduardo Vela <evn@google.com>
+*.kctf.cloud
+*.ctfcompetition.com
 run.app
 a.run.app
 web.app

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11996,7 +11996,6 @@ goip.de
 // Google, Inc.
 // Submitted by Eduardo Vela <evn@google.com>
 *.kctf.cloud
-*.ctfcompetition.com
 run.app
 a.run.app
 web.app


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://www.google.com

Google LLC is an American multinational technology company that specializes in Internet-related services and products, which include online advertising technologies, a search engine, cloud computing, software, and hardware. 

This project is to support https://github.com/google/kctf - infrastructure to run CTF competitions.

Reason for PSL Inclusion
====

`*.kctf.cloud` needs to be added for `Cookie Security` and for `Let's Encrypt` issuance limits, as it's meant as a public service self-registering TLD for security testing. It is a free public service, and we already are hitting LetsEncrypt limits (and also, we already have issues with some security configurations that require unique sites).

Registration expiration:
https://domains.google.com/registrar/search/whois/kctf.cloud?searchTerm=kctf.cloud
```
kctf.cloud - Registry Expiry Date: 2031-01-02T08:40:53Z
```


DNS Verification via dig
=======

https://toolbox.googleapps.com/apps/dig/#TXT/_psl.kctf.cloud

```
dig +short TXT _psl.kctf.cloud
"https://github.com/publicsuffix/list/pull/1272"
```


make test
=========

See attached file

[test.log](https://github.com/publicsuffix/list/files/6285260/test.log)

Fixes https://github.com/google/kctf/issues/288