### PR TITLE
Add ticket.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13390,6 +13390,11 @@ cust.testing.thingdust.io
 *.firenet.ch
 *.svc.firenet.ch
 
+// ticket i/O GmbH : https://ticket.io
+// Submitted by Christian Franke <it@ticket.io>
+ticket.io
+
+
 // Tlon.io : https://tlon.io
 // Submitted by Mark Staarink <mark@tlon.io>
 arvo.network


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://ticket.io

We are a ticket service provider and sell tickets on behalf of our clients (event organizers). Registered event organizers get their own subdomain (e.g. username.ticket.io) on which their shop are hosted.

Reason for PSL Inclusion
====

We'd like to properly isolate each subdomain to prevent global cookie setting on ticket.io and highlight that each subdomain hosts sites of a different user, unrelated to the others.


DNS Verification via dig
=======

```
dig +short TXT _psl.ticket.io
"https://github.com/publicsuffix/list/pull/1277"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
