### PR TITLE
Adding *.spinup.click

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13307,6 +13307,10 @@ spacekit.io
 // Submitted by Stefan Neufeind <info@speedpartner.de>
 customer.speedpartner.de
 
+// Spinup srl: https://www.spin-up.it/
+// Submitted by Flavio Li Volsi <flavio.livolsi@spin-up.it>
+*.spinup.click
+
 // Standard Library : https://stdlib.com
 // Submitted by Jacob Lee <jacob@stdlib.com>
 api.stdlib.com


### PR DESCRIPTION
- [x] Description of Organization
- [x] Reason for PSL inclusion
- [x] DNS verification via dig
- [x] Run Syntax Checker (make test)
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

## Description of Organization

Organization website: https://www.spin-up.it/

I am CPO at Spinup srl - We are a media tech company providing services for our clients such as lead generation through our proprietary platforms.

## Reason for PSL inclusion

We built several tools in order to generate leads for our clients (e.g.: chatbot, wizard and so on). Each tool is associated to a third-level (e.g.: wizards.spinup.click) and each client is associated to a fourth-level (e.g.: vodafone.wizards.spinup.click). We use subdomains as a security boundary, so that each client is provided with an isolated context. Furthermore we recently got audited from one of our biggest clients - Vodafone - who demanded we'd adopt this measure.

## DNS verification via dig

```
dig +short TXT _psl.spinup.click
"https://github.com/publicsuffix/list/pull/1278"
```

## Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

spinup.click is registered since 2021-02-19 and it's valid till 2025-02-19