### PR TITLE
Add Selecteev.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13200,6 +13200,10 @@ spdns.org
 // Submitted by Artem Kondratev <accounts@seidat.com>
 seidat.net
 
+// Selecteev : https://selecteev.io
+// Submitted by Alban Dumouilla <alban@selecteev.io>
+selecteev.io
+
 // Senseering GmbH : https://www.senseering.de
 // Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
 senseering.net


### PR DESCRIPTION
**Reason of this Pull Request**
Selecteev.io is a SaaS that allows people to create call for applications for candidates to apply to programs and events. We provide specific subdomains for each call for applications with a custom design.
Every subdomain is in the form of foo.selecteev.io with an example here : https://demo.selecteev.io

We need people to be able to track their marketing efforts for their call for applications, notably on facebook which uses Public Suffix list to validate domains on some of its tools.

**Dig request output**
```
dig +short TXT _psl.selecteev.io
"https://github.com/publicsuffix/list/pull/1283"
```



Extra info
I am the founder of Selecteev and am mandated to make this request.