### PR TITLE
Adding lnwshop.com lnwx.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12440,6 +12440,11 @@ we.bs
 // Submitted by Kenny Niehage <hello@yahe.sh>
 localzone.xyz
 
+// LNW Co., Ltd. : https://lnw.co.th
+// Submitted by Kasidiss Jumrus <keng@lnw.co.th>
+lnwshop.com
+lnwx.com
+
 // Log'in Line : https://www.loginline.com/
 // Submitted by Rémi Mach <remi.mach@loginline.com>
 loginline.app


### PR DESCRIPTION
* [X] Description of Organization
* [x] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://lnw.co.th

Our platform provide storefront website to our clients.

Some current examples:
* premiumstore.lnwshop.com
* demopremium.lnwx.com

Reason for PSL Inclusion
====

These storefront website owners are attempting to set up conversion tracking and inclusion in the public suffix list is required for the cookie security with changes in iOS 14.5 as per https://www.facebook.com/business/help/331612538028890?id=428636648170202

* lnwshop.com registered on 2010-10-06
* lnwx.com registered on 2008-12-26

DNS Verification via dig
=======

```
dig +short TXT _psl.lnwx.com
"https://github.com/publicsuffix/list/pull/1285"
```

```
dig +short TXT _psl.lnwshop.com
"https://github.com/publicsuffix/list/pull/1285"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
