### PR TITLE
add seclab.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10796,6 +10796,10 @@ tele.amune.org
 // Submitted by Apigee Security Team <security@apigee.com>
 apigee.io
 
+// AppSec Monkey : https://www.appsecmonkey.com/
+// Submitted by Teo Selenius <teo@appsecmonkey.com>
+seclab.app
+
 // Appspace : https://www.appspace.com
 // Submitted by Appspace Security Team <security@appspace.com>
 appspacehosted.com


### PR DESCRIPTION
### Reason of this pull request

I am an individual (not a registered company), building a cybersecurity e-learning platform on AppSec Monkey (www.appsecmonkey.com), and the labs will run under *.seclab.app domains. To get an authentic experience for my students, I need the lab machines to be cross-site, so that, e.g., attacker.seclab.app and target.seclab.app will have their own eTLD+1.  For this reason I am submitting seclab.app to the PSL.

#### DNS verification

```
dig +short TXT _psl.seclab.app
"https://github.com/publicsuffix/list/pull/1286"
```

#### Expiration

April 7, 2024.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
