### PR TITLE
add startengine.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13283,6 +13283,10 @@ atl.jelastic.vps-host.net
 njs.jelastic.vps-host.net
 ric.jelastic.vps-host.net
 
+// StartEngine: https://www.startengine.com
+// Submitted by Devender Gollapally <devender@startengine.com>
+startengine.com
+
 // Sony Interactive Entertainment LLC : https://sie.com/
 // Submitted by David Coles <david.coles@sony.com>
 playstation-cloud.com


### PR DESCRIPTION
* [*] Description of Organization
* [*] Reason for PSL Inclusion
* [*] DNS verification via dig
* [*] Run Syntax Checker (make test)
* [*] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://www.startengine.com

My name is Devender Gollapally, I'am a Principal Engineer at StartEngine.

StartEngine is a FinTech organization. We provide companies a platform and services to raise capital from the crowd.

Reason for PSL Inclusion
====

We provision all new companies with a `*.startengine.com` subdomain. Because of this, requests between companies using `*startengine.com` domains are considered to be same site, leaving them open to CSRF.

We are looking to add `startengine.com` to the Public Suffix List to improve cookie security for all of our companies who do not yet make use of a custom domain.

DNS Verification via dig
=======

```
➜ dig +short TXT _psl.startengine.com
"https://github.com/publicsuffix/list/pull/1287"
```

make test
=========

```
PASS: test-is-public
PASS: test-is-public-all
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
➜  list git:(startengine_com) ✗
```

Domain Registration
================
[Registrar Registration Expiration Date: 2026-11-17T16:10:24Z](https://www.godaddy.com/whois/results.aspx?checkAvail=1&tmskey=tmskey%3D123&domain=startengine.com)
