### PR TITLE
Add rs.ba suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -292,6 +292,9 @@ mil.ba
 net.ba
 org.ba
 
+// rs.ba : http://urc.rs/index.php/page/301
+rs.ba
+
 // bb : https://en.wikipedia.org/wiki/.bb
 bb
 biz.bb


### PR DESCRIPTION
Subdomain rs.ba, is domain for Republic of Srpska entity (part of Bosnia and Herzegovina). Applications for domain registrations are submitted through [form](http://urc.rs/index.php/page/301) on Computer Center of University of Banja Luka web site, or by writing email to 

* [ ] Description of Organization
* [ ] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [ ] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: <!-- https://example.com -->

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

Extra info
====
What else do I know about it.
Ternary DNS servers for .rs.ba domain are hosted by https://bitlab.rs/en/
