### PR TITLE
[WIP] Add slerp.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13244,7 +13244,7 @@ siteleaf.net
 
 // Slerp.com: https://www.slerp.com
 // Submitted by Jason Torres <jason@slerp.com>
-slerp.com
+*.slerp.com
 
 // Skyhat : http://www.skyhat.io
 // Submitted by Shante Adam <shante@skyhat.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13242,6 +13242,10 @@ vipsinaapp.com
 // Submitted by Skylar Challand <support@siteleaf.com>
 siteleaf.net
 
+// Slerp.com: https://www.slerp.com
+// Submitted by Jason Torres <jason@slerp.com>
+slerp.com
+
 // Skyhat : http://www.skyhat.io
 // Submitted by Shante Adam <shante@skyhat.io>
 bounty-full.com


### PR DESCRIPTION
- [x] Description of Organization
- [x] Reason for PSL Inclusion
- [x] DNS verification via dig
- [ ] Run Syntax Checker (make test)
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

## Description of Organization

I'm Jason Torres. CTO of Slerp.com

Slerp is powering hundreds of premium brands, generating millions in order revenues for businesses big and small across various sectors. We are an international team headquartered in Shoreditch, London.

We provide our merchants their own subdomains for their store pages.

We're adding slerp.com to the Public Suffix List for cookie security and for our users to verify our subdomain.

## DNS Verification via dig

➜ dig +short TXT _psl.slerp.com
`https://github.com/publicsuffix/list/pull/1293`

## make test


## Domain Registration
[Registrar Registration Expiration Date: 2027-01-12T00:00:00Z](https://www.whois.com/whois/slerp.com) -- pending additional registration info