### PR TITLE
Add Sika.com to public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13230,6 +13230,10 @@ shopware.store
 // Submitted by Oliver Graebner <security@mo-siemens.io>
 mo-siemens.io
 
+// Sika AG : https://www.sika.com/
+// Submitted by Sergio Fernandes <dns@int.sika.com>
+sika.com
+
 // SinaAppEngine : http://sae.sina.com.cn/
 // Submitted by SinaAppEngine <saesupport@sinacloud.com>
 1kapp.com


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://www.sika.com

Sika is a specialty chemicals company with a leading position in the development and production of systems and products for bonding, sealing, damping, reinforcing and protecting in the building sector and motor vehicle industry. Sika has subsidiaries in 100 countries around the world and manufactures in over 300 factories. Its 25,000 employees generated annual sales of CHF 7.88 billion in 2020. At the end of 2019, Sika won the Swiss Technology Award for an innovative new adhesive technology.

Reason for PSL Inclusion
====

- Cookie Security
- Subdomain registration on Facebook.

"To that end, businesses that host their websites on platforms that have already registered their domain in the Public Suffix List can now verify associated subdomains for the purpose of event configuration. For example, a business that hosts their website on jasper.myplatform.com will now be able to verify this domain and configure their top 8 events for use in conversion optimization and will no longer be required to host their domain separately or transition to link click or landing page view optimization.

Additionally, multi-national or regional businesses that have already registered their domain (for example, jaspersmarket.com) in the Public Suffix List can now verify the subdomains (for example, uk.jaspersmarket.com and us.jaspersmarket.com) and configure their top 8 events for use in conversion optimization."



DNS Verification via dig
=======

```
dig +short TXT _psl.sika.com
"https://github.com/publicsuffix/list/pull/1294"
```

make test
=========

make test - Done - All PASS, no Errors.

Extra info
====

sika.com domain is auto extended on a yearly basis, with no end date applied, therefore, it doesn't show a remaining expiring date bigger than 2 years. This is maintained by sika registrar supplier CSC.

Domain status: ACT
Registration date:
Registration Expiry Date:29-Jul-2021
Paid Until Date:31-Dec-2999
