### PR TITLE
Add Creditas.com to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11118,6 +11118,18 @@ static-access.net
 // Submitted by Ales Krajnik <ales.krajnik@craynic.com>
 realm.cz
 
+// Creditas: https://www.creditas.com/
+// Submitted by Mauricio Shoji <mauricio.shoji@creditas.com>
+creditas.com
+creditas.com.br
+creditas.com.mx
+ajuda.creditas.com
+app.creditas.com
+auto.creditas.com
+imovel.creditas.com
+solucoes.creditas.com
+store-mx.creditas.com
+
 // Cryptonomic : https://cryptonomic.net/
 // Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
 *.cryptonomic.net


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website:  https://www.creditas.com/ 


Creditas is the largest fintech for secured loans in Brazil. With secured loans, Creditas can provide lower interest rates for its clients and thus help people achieve their life projects. Currently having 4 offices in Brazil, 1 office in Spain and 1 office in Mexico. There are more than 2,000 employees. The company was valuated in US$1.75 billion in December of 2020.


Reason for PSL Inclusion
====
We're adding our domains and subdomains to PSL for cookie security, for registration on Facebook and for following Apple's demands for IOS14 data policy updates.
With that registration done and consequently registrated on Facebook, we are going to be able to configure our conversion events to optimize online campaign strategies. Otherwise, companies that does not follow this instructions will have all campaigns set-up on Facebook paused until this registration is done. Which means a huge financial impact.



DNS Verification via dig
=======

dig +short TXT _psl.creditas.com
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.creditas.com.br
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.creditas.com.mx
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.ajuda.creditas.com
"https://github.com/publicsuffix/list/pull/1295"

dig +short TXT _psl.app.creditas.com
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.auto.creditas.com
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.imovel.creditas.com
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.solucoes.creditas.com
https://github.com/publicsuffix/list/pull/1295

dig +short TXT _psl.store-mx.creditas.com
https://github.com/publicsuffix/list/pull/1295

make test
====

Making check in tests
  CC       test-is-public.o
  CC       test-is-public-builtin.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all

Testsuite summary for libpsl 0.21.1
TOTAL: 5
PASS:  5
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0


Additional information
====

creditas.com - expires: 2029-03-31
creditas.com.br - expires: 2029-10-16
creditas.com.mx - expires: 2022-03-30   // we're talking to our office to extend this expiration date for at least +2 year.