### PR TITLE
Update to pythonanywhere entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13002,6 +13002,11 @@ byen.site
 // Submitted by Kor Nielsen <kor@pubtls.org>
 pubtls.org
 
+// PythonAnywhere LLP: https://www.pythonanywhere.com
+// Submitted by Giles Thomas <giles@pythonanywhere.com>
+*.pythonanywhere.com
+*.eu.pythonanywhere.com
+
 // QOTO, Org.
 // Submitted by Jeffrey Phillips Freeman <jeffrey.freeman@qoto.org>
 qoto.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13034,8 +13034,8 @@ pubtls.org
 
 // PythonAnywhere LLP: https://www.pythonanywhere.com
 // Submitted by Giles Thomas <giles@pythonanywhere.com>
-*.pythonanywhere.com
-*.eu.pythonanywhere.com
+pythonanywhere.com
+eu.pythonanywhere.com
 
 // QOTO, Org.
 // Submitted by Jeffrey Phillips Freeman <jeffrey.freeman@qoto.org>


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====

Organization Website: https://www.pythonanywhere.com/

PythonAnywhere is an online software development and web-hosting environment, run by a UK company PythonAnywhere LLP. We have a US-hosted site at https://www.pythonanywhere.com/, and a separate EU-hosted system at https://eu.pythonanywhere.com.

We allow users of our US-hosted system to create websites at theirusername.pythonanywhere.com, and users of our EU-hosted system to create websites at theirusername.eu.pythonanywhere.com so that they don't need to buy their own domain or learn about DNS just in order to get a website online.

Reason for PSL Inclusion
====

We would like our two domains to be on the PSL to improve cookie security. We believe that using the *. prefix was incorrect and so we are removing that.

We do not have any concerns regarding Let's Encrypt as we provide HTTP security for subdomains of our own site via appropriately-configured wildcard certs.

pythonanywhere.com currently is registered up to 2025-03-24, so for comfortably more than two years.

DNS Verification via dig
=======

```
dig +short TXT _psl.pythonanywhere.com
"https://github.com/publicsuffix/list/pull/1298"
```

```
dig +short TXT _psl.eu.pythonanywhere.com
"https://github.com/publicsuffix/list/pull/1298"
```


make test
=========
The tests ran with 5 passes and no fails or errors.
