### PR TITLE
Add coachy.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13675,4 +13675,8 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// Coachy : https://www.coachy.net
+// Submitted by Dennis Spohr <support@coachy.net>
+*.coachy.net
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====
Coachy is a membership tool. Each of our coaches/clients get their own subdomain (customname.coachy.net)
Organization Website: https://www.coachy.net

I'm Dennis and the owner/developer of Coachy International Ltd, running coachy.net.

Reason for PSL Inclusion
====

We provision all new clients with a *.coachy.net subdomain. Because of this, requests between companies using *.coachy.net domains are considered to be same site, leaving them open to CSRF.

Our domain is not set to expire until 2023.

DNS Verification via dig
=======

```
dig +short TXT _psl.coachy.net
points to this URL
```

make test
=========

Yes I ran the test