### PR TITLE
Update Polish regional domains, missing kielce.pl 

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5707,6 +5707,7 @@ kaszuby.pl
 katowice.pl
 kepno.pl
 ketrzyn.pl
+kielce.pl
 klodzko.pl
 kobierzyce.pl
 kolobrzeg.pl


### PR DESCRIPTION

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [X] Run Syntax Checker (make test)



Description of Organization
====
The domain is used by Polish Kielce City Hall and maintained by Kielce University of Technology (tu.kielce.pl). Local entrepreneurs can lease its subdomains.

Reason for PSL Inclusion
====
I am not a mainainer of that domain, but it is missing from Poland regional domains section.
It can be registered here: http://www.man.kielce.pl/index.php?l=uslugi&p=dns


make test
=========

TOTAL: 5
PASS:  5
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0

