### PR TITLE
Added MoblyPage domain: mobly.page

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12574,6 +12574,10 @@ mintere.site
 // Submitted by Grayson Martin <grayson.martin@mobileeducation.us>
 forte.id
 
+// MoblyPage : https://moblypage.com
+// Submitted by Adriano Di Matteo <dev@moblypage.com>
+mobly.page
+
 // Mozilla Corporation : https://mozilla.com
 // Submitted by Ben Francis <bfrancis@mozilla.com>
 mozilla-iot.org


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [ ] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://moblypage.com/

MoblyPage is a platform for building mobile websites. I'm the web developer of this platform.
Registered users get their own subdomain (e.g. username.mobly.page) on which their sites are hosted.

#1303 

Reason for PSL Inclusion
====

We'd like to properly isolate each subdomain to prevent global cookie setting on mobly.page and highlight that each subdomain hosts sites of a different user, unrelated to the others.
It will also help us to verify subdomains on Facebook and to follow Apple's requests for updates to the IOS14 data policy.

DNS Verification via dig
=======

```
dig +short TXT _psl.mobly.page
"https://github.com/publicsuffix/list/pull/1303"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
