### PR TITLE
REMOVE ra-ru.ru, zsew.ru (#1149)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12974,8 +12974,6 @@ perspecta.cloud
 // PE Ulyanov Kirill Sergeevich : https://airy.host
 // Submitted by Kirill Ulyanov <k.ulyanov@airy.host>
 lk3.ru
-ra-ru.ru
-zsew.ru
 
 // Planet-Work : https://www.planet-work.com/
 // Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>


### PR DESCRIPTION
Delete domain ra-ru.ru and zsew.ru added via https://github.com/publicsuffix/list/pull/1149

```
% dig _psl.ra-ru.ru. +short txt
"https://github.com/publicsuffix/list/pull/1306"
```

```
% dig _psl.zsew.ru. +short txt
"https://github.com/publicsuffix/list/pull/1306"
```