### PR TITLE
Add goupile.fr to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12078,6 +12078,10 @@ blogspot.tw
 blogspot.ug
 blogspot.vn
 
+// Goupile : https://goupile.fr
+// Submitted by Niels Martignene <hello@goupile.fr>
+goupile.fr
+
 // Group 53, LLC : https://www.group53.com
 // Submitted by Tyler Todd <noc@nova53.net>
 awsmppl.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://interhop.org/projets/esante

We are a french association (InterHop) and we will host independent subdomains based on our Goupile (AGPL v3) product.

Goupile is a free and open-source electronic data capture application that strives to make form creation and data entry powerful, easy and secure for healthcare research.

Reason for PSL Inclusion
====

Each customer will be (or already is) provided with their own subdomain (xxx.goupile.fr).
We want to increase the anti-CSRF security between customer subdomains through SameSite=Lax cookies (and maybe Strict later on).

DNS Verification via dig
=======

```
dig +short TXT _psl.goupile.fr
"https://github.com/publicsuffix/list/pull/1307"
```

make test
=========

Tests passed OK
https://pastebin.com/JBm6t8S4

Domain registration
=========

Domain paid for until 19 nov. 2023