### PR TITLE
Add hosp.uk to our existing domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11815,11 +11815,11 @@ app.os.stg.fedoraproject.org
 
 // FearWorks Media Ltd. : https://fearworksmedia.co.uk
 // submitted by Keith Fairley <domains@fearworksmedia.co.uk>
+couk.me
+ukco.me
 conn.uk
 copro.uk
-couk.me
 hosp.uk
-ukco.me
 
 // Fermax : https://fermax.com/
 // submitted by Koen Van Isterdael <k.vanisterdael@fermax.be>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11818,6 +11818,7 @@ app.os.stg.fedoraproject.org
 conn.uk
 copro.uk
 couk.me
+hosp.uk
 ukco.me
 
 // Fermax : https://fermax.com/


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: www.fearworkshosting.co.uk

FearWorks Media Ltd. provides web hosting and email services. I am the founder and director.

Reason for PSL Inclusion
====

The subdomains under the hosp.uk domain are assigned to different hospitality customers of our company. We assign subdomains such as examplehotel.hosp.uk, etc. Our clients can use the assigned subdomain(s) to access their admin systems, backends and frontends.

We want to protect the user-created subdomains under the hosp.uk domains from cross-subdomain cookie/state sharing and also allow generation of Let's Encrypt SSL certificates for the custom subdomains.

The domain has a validity of at least 2 years and we'll continue to maintain it.

DNS Verification via dig
=======

```
dig +short TXT _psl.hosp.uk
"https://github.com/publicsuffix/list/pull/1308"
```

make test
=========

Test run and passed.