### PR TITLE
Add shop.brendly.rs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10887,6 +10887,10 @@ square7.de
 bplaced.net
 square7.net
 
+// Brendly : https://brendly.rs
+// Submitted by Dusan Radovanovic <dusan.radovanovic@brendly.rs>
+shop.brendly.rs
+
 // BrowserSafetyMark
 // Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
 browsersafetymark.io


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====
Organization Website: https://brendly.rs

My name is Dusan, I'm a CTO at Brendly.

Brendly is an e-commerce organization. We provide merchants with tools and services to sell their products online and/or in-person, with the ultimate goal of making commerce better for everyone.

Reason for PSL Inclusion
====
In addition to allowing merchants to purchase and/or connect their domain name to their shops, we provision all new merchants with a *.shop.brendly.rs subdomain. Because of this, requests between shops using *.shop.brendly.rs domains are considered to be samesite, leaving them open to CSRF.

We're looking to add shop.brendly.rs to the Public Suffix List to improve cookie security for all of our merchants who do not yet make use of a custom domain.

DNS Verification via dig
=======

```
dig +short TXT _psl.shop.brendly.rs
"https://github.com/publicsuffix/list/pull/1309"
```


make test
=========
Tests passed OK.


DOMAINS
=========
Our domain is valid until August 2021 but has an automatic renewal every year. Our provider doesn't sell licences for more then one year.