### PR TITLE
Adding Scalable storefront domains to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13166,6 +13166,14 @@ sandcats.io
 logoip.de
 logoip.com
 
+// Scalable : https://scalable.inc/
+// Submitted by Jeremy Kerr <jeremy.kerr@scalable.inc>
+chipchipstore.com
+chipstage.com
+chipstores.com
+mychipchip.com
+onchipchip.com
+
 // schokokeks.org GbR : https://schokokeks.org/
 // Submitted by Hanno Böck <hanno@schokokeks.org>
 schokokeks.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13169,7 +13169,6 @@ logoip.com
 // Scalable : https://scalable.inc/
 // Submitted by Jeremy Kerr <jeremy.kerr@scalable.inc>
 chipchipstore.com
-chipstage.com
 chipstores.com
 mychipchip.com
 onchipchip.com


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Websites: https://scalable.inc & https://www.chipchip.com/

My name is Jeremy Kerr <jeremy.kerr@scalable.inc>. I am a DevOps engineer representing Scalable.

Scalable builds physical and software infrastructure to help entrepreneurs compete against the giants in e-commerce today. We provide merchants with a platform to sell customized merchandise online, to run a successful business with low overhead.

Reason for PSL Inclusion
====

The following rationale is the same for all 4 domains:
  * `chipchipstore.com` (expires May 4, 2024)
  * `chipstores.com` (expires March 7, 2025)
  * `mychipchip.com` (expires May 3, 2024)
  * `onchipchip.com` (expires May 4, 2024)

1. Remove any up-front costs for new merchants, by giving them subdomains instead of requiring domain registration.

2. Cookie security between subdomains. Each subdomain is a different business and we want to keep them isolated from each other. We are hoping after browsers refresh the PSL, they'll use these inclusions to better isolate consumer privacy for visitors of multiple storefronts, to supplement our other security measures.

3. Enable merchants using our product to advertise on 3rd-party platforms like Facebook & Google. We have read through https://github.com/publicsuffix/list/issues/1245 and recognize the issues raised. We don't want to impose an additional burden, but wanted to be up-front that this is one of the reasons we're hoping for inclusion.

_We registered these domains with these purposes in-mind, PSL inclusion does not risk breaking any pre-existing functionality for us or for our customers._

An example of a current storefront is https://www.animalthreads.com/. Future storefronts on the free subdomain model will look like:
  * `<brand>.chipchipstore.com`
  * `<brand>.chipstores.com`
  * `<brand>.mychipchip.com`
  * `<brand>.onchipchip.com`

DNS Verification via dig
=======

```
dig +short TXT _psl.chipchipstore.com
"https://github.com/publicsuffix/list/pull/1312"
```

```
dig +short TXT _psl.chipstores.com
"https://github.com/publicsuffix/list/pull/1312"
```

```
dig +short TXT _psl.mychipchip.com
"https://github.com/publicsuffix/list/pull/1312"
```

```
dig +short TXT _psl.onchipchip.com
"https://github.com/publicsuffix/list/pull/1312"
```

make test
=========

I ran the tests.
