### PR TITLE
Add bluebite.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10866,6 +10866,10 @@ blackbaudcdn.net
 // Submitted by Luke Bratch <luke@bratch.co.uk>
 of.je
 
+// Blue Bite, LLC : https://bluebite.com
+// Submitted by Joshua Weiss <admin.engineering@bluebite.com>
+bluebite.io
+
 // Boomla : https://boomla.com
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net


### PR DESCRIPTION
Description of Organization
====

**Organization Website:** https://bluebite.com

Blue Bite provides tools for create dynamic, personalized digital experiences. Brands use the Experience Studio to create web apps hosted on the brands dedicated subdomain.

Reason for PSL Inclusion
====

1. Blue Bite distributes subdomains to mutually-untrusting parties. On the newest version of our platform we allow customers more direct control over page content. We would like cookies to be isolated between each brand's subdomain for increased security.

2. Our customers would also benefit from their branded subdomain being highlighted as an important part of the overall domain.

Our domain `bluebite.io` is set to expire on `2024-03-28` which is greater than 2 years from today. We commit to maintaining more than two years on our domain's registration.

DNS Verification via dig
=======

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/1313"
```

make test
=========

```
test_NFKC: OK
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
```