### PR TITLE
Add frontgatetickets.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11896,6 +11896,10 @@ freedesktop.org
 // Submitted by Cadence <contact@freemyip.com>
 freemyip.com
 
+// frontgatetickets.com : https://www.frontgatetickets.com
+// Submitted by Ben Paulsen <ben.paulsen@frontgatetickets.com>
+frontgatetickets.com
+
 // FunkFeuer - Verein zur Förderung freier Netze : https://www.funkfeuer.at
 // Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
 wien.funkfeuer.at


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://www.frontgatetickets.com

I am Ben Paulsen, Vice President of Product Development at Front Gate Tickets.  I oversee both Front Gate's engineering and product teams.

Front Gate Tickets is a full service ticketing solutions platform for music festival promoters.  It is a division of Ticketmaster.  We maintain 100+ white label ecommerce / ticketing sites for our clients.

Some examples of our sites:

https://stubbs.frontgatetickets.com/
https://bonnaroo.frontgatetickets.com/
https://outsidelands.frontgatetickets.com/
https://edclasvegas.frontgatetickets.com/

Reason for PSL Inclusion
====

In full transparency, we were directed toward adding ourselves to the PSL as a result of the newly imposed rules / limitations of IOS / Facebook (#1245).  That said, I believe our domain is appropriate for the list as each one of our ticketing sites is a unique brand (for unique clients) and we would certainly benefit from the added protection afforded by limiting cookie sharing across these sites.

DNS Verification via dig
=======

```
dig +short TXT _psl.frontgatetickets.com
"https://github.com/publicsuffix/list/pull/1315"
```

make test
=========

Tests have been run.
