### PR TITLE
Add vibe.to

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10804,6 +10804,10 @@ appspaceusercontent.com
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
+// ArtistHub : https://artisthub.io
+// Submitted by Derek Ruffner <derek@artisthub.io>
+vyb.to
+
 // ASEINet : https://www.aseinet.com/
 // Submitted by Asei SEKIGUCHI <mail@aseinet.com>
 user.aseinet.ne.jp

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10806,7 +10806,7 @@ on-aptible.com
 
 // ArtistHub : https://artisthub.io
 // Submitted by Derek Ruffner <derek@artisthub.io>
-vyb.to
+vibe.to
 
 // ASEINet : https://www.aseinet.com/
 // Submitted by Asei SEKIGUCHI <mail@aseinet.com>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://artisthub.io

I represent ArtistHub. We are a marketing platform for musicians. Our platform allows users to easily create landing pages for their music and brand.


Reason for PSL Inclusion
====

We would like to address iOS advertising limitations by allowing our users to create subdomains on vibe.to and verify them on Facebook. This is a step towards creating a more frictionless platform for our users.

vibe.to has been registered until 2024-04-23.

DNS Verification via dig
=======

```
dig +short TXT _psl.vibe.to
"https://github.com/publicsuffix/list/pull/1320"
```

make test
=========

The test completed successfully.
