### PR TITLE
Please add Koobin domains to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12378,6 +12378,12 @@ uni5.net
 // Submitted by Roy Keene <rkeene@knightpoint.com>
 knightpoint.systems
 
+// KoobinEvent, SL: https://www.koobin.com
+// Submitted by Iván Oliva <ivan.oliva@koobin.com>
+koobin.cat
+koobin.com
+koobin.es
+
 // KUROKU LTD : https://kuroku.ltd/
 // Submitted by DisposaBoy <security@oya.to>
 oya.to


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: <!-- https://example.com -->https://www.koobin.com

<!--
Please tell us who you are and represent (i.e. individual, non-profit volunteer, engineer at a business)
and what you do (i.e. DynDNS, Hosting, etc)
-->
I'm Iván Oliva, developer at KoobinEvent, SL. We provide a ticketing platform for third parties, as SaaS. These third parties can be theaters, sports clubs, operas, concert halls and so on.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, etc) and clearly
confirm that any private section names hold registration term
longer than 2 years and shall maintain more than 1 year 
term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->
Our clients ticketing sites are published on subdomains of one of our domains (koobin.cat, koobin.com, koobin.es), and run independently, so they must not share cookies between them.

Some samples:
https://screenbox.koobin.cat
https://liceubarcelona.koobin.com
https://theproject.koobin.es

Besides, we do not run any website directly on any of the submitted domains, since our corporate website runs under www.koobin.com.

I hereby confirm that our three affected domains (koobin.cat, koobin.com, koobin.es) hold registration term longer than 2 years and maintain more than 2 years term.

We have been directed to the PSL because we allow our clients to setup tracking codes in their ticketing sites (Facebook Pixels among them), and some of them have not been allowed by Facebook to verify their subdomains on Business Manager. Then, Facebook, in their help articles, says that adding the main domains to the PSL should certain help.

I will be glad to further clarify my petition if there is still any doubt about it.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

DNS verification records added:

```
dig TXT _psl.koobin.cat
"https://github.com/publicsuffix/list/pull/1323"
```

```
dig TXT _psl.koobin.com
"https://github.com/publicsuffix/list/pull/1323"
```

```
dig TXT _psl.koobin.es
"https://github.com/publicsuffix/list/pull/1323"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
Test ran.


Thanks a lot in advance.