### PR TITLE
Adds is-a.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12246,6 +12246,10 @@ iopsys.se
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
 
+// is-a.dev: https://is-a.dev
+// Submitted by Akshay Nair <phenax5@gmail.com>
+is-a.dev
+
 // IServ GmbH : https://iserv.eu
 // Submitted by Kim-Alexander Brodowski <info@iserv.eu>
 mein-iserv.de


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.


Description of Organization
====

Organization Website: https://is-a.dev

Is-a-dev is a service that allows developers to register a `name.is-a.dev` subdomain for their personal websites.


Reason for PSL Inclusion
====

Let's Encrypt issuance. This domain has been registered for the next 4 years and the service will be maintained for longer


DNS Verification via dig
=======

```
dig +short TXT _psl.is-a.dev
"https://github.com/publicsuffix/list/pull/1327"
```


make test
=========

I've run the test and validated that nothing is breaking with the added changes
