### PR TITLE
Add Smoove domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13694,6 +13694,6 @@ enterprisecloud.nu
 // Submitted by Dan Kozak <dan@smoove.io>
 vp4.me
 smoove.io
-vplus.com
+viplus.com
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13690,4 +13690,10 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// Smoove.io : https://www.smoove.io/
+// Submitted by Dan Kozak <dan@smoove.io>
+vp4.me
+smoove.io
+vplus.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
* [x] **Description of Organization**
====
Organization Website: https://www.smoove.io We are an ESP and marketing platform that gives businesses from all over the world a full set of tools they can use for marketing. from newsletters to landing pages to full marketing automation.
====

* [x] **Reason for PSL Inclusion**
====
We provide our customers the option to create landing pages using sub domains that are under our domains: 
vp4.me
viplus.com
smoove.io
for example: danafb1.vp4.me 
We want to allow our customers to set aggregated measurements in Facebook Events Manager for their Facebook pixels for events that come from their subdomain that they choose on our platform (in accordance with Facebook's domain verification docs). The referenced domains have been registered until 2024. 
We also commit to maintaining more than 2 (two) years on our domain's registration
====

* [x] **DNS verification via dig**
====
```
dig +short TXT _psl.vp4.me
"https://github.com/publicsuffix/list/pull/1328"
```

```
dig +short TXT _psl.viplus.com
"https://github.com/publicsuffix/list/pull/1328"
```

```
dig +short TXT _psl.smoove.io
"https://github.com/publicsuffix/list/pull/1328"
```
====

* [x] **Run Syntax Checker (make test)**
====
test succeded
test output:
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
====