### PR TITLE
Add Woods Valldata lottery and raffle domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13615,6 +13615,10 @@ meinforum.net
 // Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
 raffleentry.org.uk
 weeklylottery.org.uk
+affinitylottery.org.uk
+test-raffleentry.org.uk
+test-weeklylottery.org.uk
+test-affinitylottery.org.uk
 
 // WP Engine : https://wpengine.com/
 // Submitted by Michael Smith <michael.smith@wpengine.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13613,12 +13613,12 @@ meinforum.net
 
 // Woods Valldata : https://www.woodsvalldata.co.uk/
 // Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
-raffleentry.org.uk
-weeklylottery.org.uk
 affinitylottery.org.uk
+raffleentry.org.uk
+test-affinitylottery.org.uk
 test-raffleentry.org.uk
 test-weeklylottery.org.uk
-test-affinitylottery.org.uk
+weeklylottery.org.uk
 
 // WP Engine : https://wpengine.com/
 // Submitted by Michael Smith <michael.smith@wpengine.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13612,7 +13612,7 @@ community-pro.net
 meinforum.net
 
 // Woods Valldata : https://www.woodsvalldata.co.uk/
-// Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
+// Submitted by Chris Whittle <chris.whittle@woodsvalldata.co.uk>
 affinitylottery.org.uk
 raffleentry.org.uk
 test-affinitylottery.org.uk

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13611,6 +13611,11 @@ diskussionsbereich.de
 community-pro.net
 meinforum.net
 
+// Woods Valldata : https://www.woodsvalldata.co.uk/
+// Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
+raffleentry.org.uk
+weeklylottery.org.uk
+
 // WP Engine : https://wpengine.com/
 // Submitted by Michael Smith <michael.smith@wpengine.com>
 // Submitted by Brandon DuRette <brandon.durette@wpengine.com>


### PR DESCRIPTION
* [ X ] Description of Organization
* [ X ] Reason for PSL Inclusion
* [x] DNS verification via dig
* [ X ] Run Syntax Checker (make test)

* [ X ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organisation
====
Organisation Website: https://www.woodsvalldata.co.uk/
WoodsValldata is a charity fundraising service provider.
I am a software developer at WoodsValldata catering for the hosted raffle and lottery websites that we provide.

Reason for PSL Inclusion
====
Our raffle and lottery domains are used to issue subdomains to our clients for the sole purpose of running their lottery and/or raffle websites.
We wish to lock down the Cookie Security of these websites so that cross-contamination cannot occur on the domains that we wish to add to the PSL.

DNS Verification via dig
=======

make test
=========
I have followed the test as outlined in https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change
and the output hasn't come back with any errors.
