### PR TITLE
Add novecore.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13281,6 +13281,10 @@ srht.site
 // Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
 stackhero-network.com
 
+// Staclar : https://staclar.com
+// Submitted by Matthias Merkel <matthias.merkel@staclar.com>
+novecore.site
+
 // staticland : https://static.land
 // Submitted by Seth Vincent <sethvincent@gmail.com>
 static.land


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://staclar.com

Staclar provides a variety of services to digital music companies, record labels and independent artists.

Reason for PSL Inclusion
====

Under novecore.site, we will be offering web hosting for artist websites. Listing in the PSL is requested for security reasons.

DNS Verification via dig
=======

```
dig +short TXT _psl.novecore.site
"https://github.com/publicsuffix/list/pull/1331"
```

make test
=========

Works