### PR TITLE
add mediatech.by and mediatech.dev domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12546,6 +12546,11 @@ mcdir.ru
 mcpre.ru
 vps.mcdir.ru
 
+// Mediatech : https://mediatech.by
+// Submitted by Evgeniy Kozhuhovskiy <ugenk@mediatech.by>
+mediatech.by
+mediatech.dev
+
 // Medicom Health : https://medicomhealth.com
 // Submitted by Michael Olson <molson@medicomhealth.com>
 hra.health


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

Organization Website: https://mediatech.by https://mediatech.dev

We're company developing applications and solutions for TV and OTT

Reason for PSL Inclusion
====

We're hosting different clients applications/sites/api under our mediatech.by / mediatech.dev subdomains.

DNS Verification via dig
=======

```
$  dig +short TXT _psl.mediatech.by
"https://github.com/publicsuffix/list/pull/1333"
$  dig +short TXT _psl.mediatech.dev
"https://github.com/publicsuffix/list/pull/1333"
```

-->

make test
=========

All the tests passed.
