### PR TITLE
Remove github.dev from PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11953,7 +11953,6 @@ gsj.bz
 // GitHub, Inc.
 // Submitted by Patrick Toomey <security@github.com>
 githubusercontent.com
-github.dev
 githubpreview.dev
 github.io
 


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Exclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: github.com

I'm a software engineer at GitHub working on the Codespaces product.

Reason for PSL Exclusion
====

We no longer want `github.dev` to be included in the PSL. The original intent for the addition was predicting several use cases that are no longer valid for our plans with `github.dev`. We have some initiatives that require removal.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

Do I still need to update DNS to this PR even though it is a removal? You can see the current record points to the PR where we added the domain: https://github.com/publicsuffix/list/pull/1290

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
