### PR TITLE
Add splitmetrics.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13292,6 +13292,10 @@ try-snowplow.com
 // Submitted by Drew DeVault <sir@cmpwn.com>
 srht.site
 
+// SplitMetrics : https://splitmetrics.com/
+// Submitted by Raman Shyrko <raman.shyrko@splitmetrics.com>
+splitmetrics.com
+
 // Stackhero : https://www.stackhero.io
 // Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
 stackhero-network.com


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://splitmetrics.com

SplitMetrics is the comprehensive mobile A/B testing platform enabling validation of ideas, concepts, and features via fully transparent A/B tests for iOS and Android on the product, search, and category pages. Trusted by Google, Rovio, Wargaming, and other market leaders, SplitMetrics is the accelerator that helps reach new levels of profitability and app growth for small, mid, and enterprise-size businesses. 

We provide each client with a pre-made landing page (a website) that our system generates specifically for their app or game. This page has a unique URL, but the domain is the same for each client. This domain is owned by us - SplitMetrics Inc. 

Сonsidering the latest privacy policy updates, we want to offer our clients a unique subdomain that they could pick for their business. For example:
- Google has a bunch of apps such as Gmail, Google Maps. They can pick google.splitmetrics.com for all projects.
- Rovio (Angry Birds) has many mobile games. They can pick rovio.splitmetrics.com

Reason for PSL Inclusion
====

1. We wish to give ownership to our clients over the landing pages they use to a/b testing their mobile apps and games. All clients run experiments on our domain, but we want to provide each client with their unique subdomain. 
2. We want to continue isolating cookies between each client’s subdomain (and each test) because sharing cookies contradicts a/b testing nature and services we provide. 
3. We want to allow our clients to set aggregated measurements in Facebook Events Manager for their Facebook pixels for events that come from their subdomain that they choose on our platform (in accordance with Facebook's domain verification docs). 

DNS Verification via dig
=======

The referenced domain (splitmetrics.com) has been registered until 23 May 2022. We also commit to maintaining our domain’s registration every year.

```
dig TXT +short _psl.splitmetrics.com
"https://github.com/publicsuffix/list/pull/1336"
```

make test
=========

```
test_NFKC: OK
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
```
