### PR TITLE
Add appudo.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10800,6 +10800,10 @@ apigee.io
 appspacehosted.com
 appspaceusercontent.com
 
+// Appudo UG (haftungsbeschränkt) : https://www.appudo.com
+// Submitted by Alexander Hochbaum <admin@appudo.com>
+appudo.net
+
 // Aptible : https://www.aptible.com/
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com


### PR DESCRIPTION
* [x]  Description of Organization
* [x]  Reason for PSL Inclusion
* [x]  DNS verification via dig
* [x]  Run Syntax Checker (make test)
* [x]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration. (see comments on yearly auto-renewal)

**Submitter affirms the following:**

* [x]  We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)
* [x]  This request was not submitted with the objective of working around other third party limits
* [x]  The Guidelines were carefully read and understood, and this request conforms
* [x]  The submission follows the guidelines on formatting

# Description of Organization
Organization Website: https://www.appudo.com

Appudo UG (haftungsbeschränkt) offers web-based applications and services.

# Reason for PSL Inclusion
We want the ability to dynamically register a DNS name for the installation and secure usage of our applications with user or third-party-provided machines.

Note that the appudo.net domain is auto-renewed yearly.

```
whois appudo.net | egrep "(^Updated Date|^Creation Date|Expiration Date)"                          
Updated Date: 2021-05-22T10:35:02Z
Creation Date: 2011-05-21T12:02:12Z                               
Registrar Registration Expiration Date: 2022-05-21T12:02:12Z
```

# DNS Verification via dig
```
dig +short TXT _psl.appudo.net
"https://github.com/publicsuffix/list/pull/1340"
```

# make test
```
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```
