### PR TITLE
Add sendmsg.co.il

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13223,6 +13223,10 @@ seidat.net
 // Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
 senseering.net
 
+// Sendmsg: https://www.sendmsg.co.il
+// Submitted by Assaf Stern <domains@comstar.co.il>
+sendmsg.co.il
+
 // Service Magnet : https://myservicemagnet.com
 // Submitted by Dave Sanders <dave@myservicemagnet.com>
 magnet.page


### PR DESCRIPTION
* [x] Description of Organization
Sendmsg (https://sendmsg.co.il) provides solutions to business owners to communicate with their customers for about 10 years.
We provide a landing pages builder and serving solution for our customers using the https://sendmsg.co.il domain.
I'm working with the company R&D team to enable the services to their customers.

* [x] Reason for PSL Inclusion
Some of our customers are using custom domain w/ their landing pages that created with our platform. However, some prefer to use a dedicated subdomain under the sendmsg.co.il domain.

* [x] DNS verification via dig
$ dig TXT _psl.sendmsg.co.il
#1341


* [x] Run Syntax Checker (make test)
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================


* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
sendmsg.co.il is valid till 2024-02-23: https://www.isoc.org.il/whois


