### PR TITLE
Adding adimo.co.uk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13163,10 +13163,6 @@ hzc.io
 wellbeingzone.eu
 wellbeingzone.co.uk
 
-// Rico Developments Limited : https://adimo.co
-// Submitted by Colin Brown <hello@adimo.co>
-adimo.co
-
 // Rochester Institute of Technology : http://www.rit.edu/
 // Submitted by Jennifer Herting <jchits@rit.edu>
 git-pages.rit.edu

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13163,6 +13163,10 @@ hzc.io
 wellbeingzone.eu
 wellbeingzone.co.uk
 
+// Rico Developments Limited : https://adimo.co
+// Submitted by Colin Brown <hello@adimo.co>
+adimo.co.uk
+
 // Rochester Institute of Technology : http://www.rit.edu/
 // Submitted by Jennifer Herting <jchits@rit.edu>
 git-pages.rit.edu

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13163,6 +13163,10 @@ hzc.io
 wellbeingzone.eu
 wellbeingzone.co.uk
 
+// Rico Developments Limited : https://adimo.co
+// Submitted by Colin Brown <hello@adimo.co>
+adimo.co
+
 // Rochester Institute of Technology : http://www.rit.edu/
 // Submitted by Jennifer Herting <jchits@rit.edu>
 git-pages.rit.edu


### PR DESCRIPTION
This is a follow up to a previous PR that was using our primary domain name. I've created this PR that uses a secondary domain that simply redirects to the primary. There is less risk as the secondary is not linked anywhere. https://github.com/publicsuffix/list/pull/1342

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

__Submitter affirms the following:__ 
  * [x] This request was _not_ made to work around vendor limits other than those listed in rationale (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as an example)
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting 

Description of Organization
====

Organization Website: https://adimo.co & https://adimo.co.uk (for which this change applies)

We are a global shoppable technology provider for brands across the world. our clients include Nestlé, Unilever, SC Johnson and many other large multi national organisations. These brands use our technology to make their websites shoppable, allowing consumers to add products to their online retailer's shopping cart.

Reason for PSL Inclusion
====

Our clients frequently use our landing pages on social media and the urls to the pages have the subdomain campaigns.adimo.co. There are trust and security issues with this for our clients, consumers see this domain name in the url (such as on Twitter) and there is no mention of the brand name in the domain which confuses users. We desire to have a subdomain setup for each of our clients to circumvent this, such as clientA.adimo.co.uk, clientB.adimo.co.uk etc. The subdomain will give the brand what they desire and the inclusion in PSL will overcome the cookie issues we're having around security with multiple subdomains.

DNS Verification via dig
=======

```
dig +short TXT _psl.adimo.co.uk
"https://github.com/publicsuffix/list/pull/1343"
```

make test
=========

```
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
=========

Domain adimo.co.uk expires Nov 2023, with auto renewal.
