### PR TITLE
Add minisite.ms

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13223,6 +13223,10 @@ seidat.net
 // Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
 senseering.net
 
+// Sendmsg: https://www.sendmsg.co.il
+// Submitted by Assaf Stern <domains@comstar.co.il>
+sendmsg.co.il
+
 // Service Magnet : https://myservicemagnet.com
 // Submitted by Dave Sanders <dave@myservicemagnet.com>
 magnet.page

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13225,7 +13225,7 @@ senseering.net
 
 // Sendmsg: https://www.sendmsg.co.il
 // Submitted by Assaf Stern <domains@comstar.co.il>
-sendmsg.co.il
+minisite.ms
 
 // Service Magnet : https://myservicemagnet.com
 // Submitted by Dave Sanders <dave@myservicemagnet.com>


### PR DESCRIPTION
* [x] Description of Organization
Organization Website: https://sendmsg.co.il
sendmsg provides solutions to business owners to communicate with their customers for about 10 years.
We provide a landing pages platform and serving solution for our customers.
Registered users get their own subdomain (e.g. username.minisite.ms) on which their sites are hosted.

* [x] Reason for PSL Inclusion
Some of our customers are using custom domain with their landing pages that created with our platform. However, some prefer to use a dedicated subdomain under the minisite.ms domain.


* [x] DNS verification via dig
$ dig TXT _psl.minisite.ms
#1344


* [x] Run Syntax Checker (make test)
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================


* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.
minisite.ms is valid till 2024-05-01


