### PR TITLE
Adoveo patch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,38 +54,73 @@ Example:
 Description of Organization
 ====
 
-Organization Website: https://adoveo.com
+Organization Website: <!-- https://example.com -->
 
-Adoveo is a digital marketing company which provide creation of interactive landing pages for high end brands in FMCG, Retail and charity. We need to become a part of the list to make it possible for our customers own their subdomains under adoveo.com.
+<!--
+Please tell us who you are and represent (i.e. individual, 
+non-profit volunteer, engineer at a business) and what you 
+do (i.e. DynDNS, Hosting, etc)
 
+For the org description, there is less interest in the 
+promotional / marketing information about the org and more 
+a focus on having concise description of the core focus of 
+the submitting org, specifically with context/connection 
+to this request.
+-->
 
 Reason for PSL Inclusion
 ====
 
-With iOS14.5 launch, in accordance with their AppTrackingTransparency framework, Facebook will start processing pixel conversion events from iOS 14 devices using Aggregated Event Measurement to preserve user privacy and help running effective campaigns. Specifically, Facebook would associate events triggered from a website to be associated with a Domain, the corresponding merchant's owned Facebook Ad Account, and the corresponding Pixel.
+<!--
+Please tell us why your domain(s) should be listed in the PSL
+(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
+Cloudflare etc) and clearly confirm that any private section 
+names hold registration term longer than 2 years and shall 
+maintain more than 1 year term in order to remain listed.
 
-Our customers needs to verify their website's domain with Facebook and this would be done at eTLD+1 level. In our case, it would be boutir.com
-
-However, as with our model, each merchant operates separately and independently. adoveo.com products, data, events are totally separated from those from bbb.adoveo.com. But now we cannot do it, as Facebook only verify eTLD+1 (i.e. adoveo.com) and would not verify and associate events with aaa.adoveo.com separately with bbb.adoveo.com. Our customers from aaa.adoveo.com and bbb.adoveo.com cannot pass through the verification step, and cannot effectively associate events triggered from their website to their domain.
-
-If adoveo.com can be listed in the PSL, Facebook can separately verify aaa.adoveo.com and bbb.adoveo.com, and different customers can associate events and track separately with different domain aaa.adoveo.com and bbb.adoveo.com
+Please also include the numbers of any past Issue # or PR # 
+specifically related to this submission or section.
+-->
 
 DNS Verification via dig
 =======
 
-dig +short TXT _psl.example.net
-https://github.com/publicsuffix/list/pull/1346
+<!--
+For each domain you'd like to add to the list please create
+a DNS verification record pointing to your pull request.
 
+For example, if you'd like to add example.com and example.net
+you would need to provide the following verifications:
+
+```
+dig +short TXT _psl.example.com
+"https://github.com/publicsuffix/list/pull/XXXX"
+```
+
+```
+dig +short TXT _psl.example.net
+"https://github.com/publicsuffix/list/pull/XXXX"
+```
+
+Note that XXXX is replaced with the number of your pull request.
+
+We ask that you leave this record in place while you want 
+your entry to remain in the PSL, so that future (TBD) 
+automation can remove entries where the record is not present.
+
+-->
 
 make test
 =========
 
-# TOTAL: 5
-# PASS:  5
-# SKIP:  0
-# XFAIL: 0
-# FAIL:  0
-# XPASS: 0
-# ERROR: 0
+<!--
+Please verify that you followed the correct syntax and nothing broke
+
+git clone https://github.com/publicsuffix/list.git
+cd list
+make test
+
+Simply let us know that you ran the test
+-->
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,73 +54,38 @@ Example:
 Description of Organization
 ====
 
-Organization Website: <!-- https://example.com -->
+Organization Website: https://adoveo.com
 
-<!--
-Please tell us who you are and represent (i.e. individual, 
-non-profit volunteer, engineer at a business) and what you 
-do (i.e. DynDNS, Hosting, etc)
+Adoveo is a digital marketing company which provide creation of interactive landing pages for high end brands in FMCG, Retail and charity. We need to become a part of the list to make it possible for our customers own their subdomains under adoveo.com.
 
-For the org description, there is less interest in the 
-promotional / marketing information about the org and more 
-a focus on having concise description of the core focus of 
-the submitting org, specifically with context/connection 
-to this request.
--->
 
 Reason for PSL Inclusion
 ====
 
-<!--
-Please tell us why your domain(s) should be listed in the PSL
-(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
-Cloudflare etc) and clearly confirm that any private section 
-names hold registration term longer than 2 years and shall 
-maintain more than 1 year term in order to remain listed.
+With iOS14.5 launch, in accordance with their AppTrackingTransparency framework, Facebook will start processing pixel conversion events from iOS 14 devices using Aggregated Event Measurement to preserve user privacy and help running effective campaigns. Specifically, Facebook would associate events triggered from a website to be associated with a Domain, the corresponding merchant's owned Facebook Ad Account, and the corresponding Pixel.
 
-Please also include the numbers of any past Issue # or PR # 
-specifically related to this submission or section.
--->
+Our customers needs to verify their website's domain with Facebook and this would be done at eTLD+1 level. In our case, it would be boutir.com
+
+However, as with our model, each merchant operates separately and independently. adoveo.com products, data, events are totally separated from those from bbb.adoveo.com. But now we cannot do it, as Facebook only verify eTLD+1 (i.e. adoveo.com) and would not verify and associate events with aaa.adoveo.com separately with bbb.adoveo.com. Our customers from aaa.adoveo.com and bbb.adoveo.com cannot pass through the verification step, and cannot effectively associate events triggered from their website to their domain.
+
+If adoveo.com can be listed in the PSL, Facebook can separately verify aaa.adoveo.com and bbb.adoveo.com, and different customers can associate events and track separately with different domain aaa.adoveo.com and bbb.adoveo.com
 
 DNS Verification via dig
 =======
 
-<!--
-For each domain you'd like to add to the list please create
-a DNS verification record pointing to your pull request.
-
-For example, if you'd like to add example.com and example.net
-you would need to provide the following verifications:
-
-```
-dig +short TXT _psl.example.com
-"https://github.com/publicsuffix/list/pull/XXXX"
-```
-
-```
 dig +short TXT _psl.example.net
-"https://github.com/publicsuffix/list/pull/XXXX"
-```
+https://github.com/publicsuffix/list/pull/XXXX
 
-Note that XXXX is replaced with the number of your pull request.
-
-We ask that you leave this record in place while you want 
-your entry to remain in the PSL, so that future (TBD) 
-automation can remove entries where the record is not present.
-
--->
 
 make test
 =========
 
-<!--
-Please verify that you followed the correct syntax and nothing broke
-
-git clone https://github.com/publicsuffix/list.git
-cd list
-make test
-
-Simply let us know that you ran the test
--->
+# TOTAL: 5
+# PASS:  5
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -74,7 +74,7 @@ DNS Verification via dig
 =======
 
 dig +short TXT _psl.example.net
-https://github.com/publicsuffix/list/pull/XXXX
+https://github.com/publicsuffix/list/pull/1346
 
 
 make test

--- a/linter/test_spaces.input-e
+++ b/linter/test_spaces.input-e
@@ -1,0 +1,19 @@
+// test:
+// - leading space
+// - trailing space, empty line with spaces
+// - leading tab
+// - trailing tab
+// - line ends with CRLF (pslint_selftest will add one to e.example.com and removed it after testing)
+// - empty line with spaces
+
+// ===BEGIN ICANN DOMAINS===
+
+// example.com: https://www.iana.org/domains/reserved
+ a.example.com
+b.example.com 
+	c.example.com
+d.example.com	
+e.example.com
+  
+
+// ===END ICANN DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13723,4 +13723,8 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// Adoveo : hhtps://adoveo.com
+// Submitted by Umapathi Tallapragada <umapathi@adoveo.com>
+adoveo.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [ ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
Adoveo is a digital marketing company which provide creation of interactive landing pages for high end brands in FMCG, Retail and charity. We need to become a part of the list to make it possible for our customers own their subdomains under adoveo.com.
Organization Website: https://adoveo.com

Reason for PSL Inclusion
====

With iOS14.5 launch, in accordance with their AppTrackingTransparency framework, Facebook will start processing pixel conversion events from iOS 14 devices using Aggregated Event Measurement to preserve user privacy and help running effective campaigns. Specifically, Facebook would associate events triggered from a website to be associated with a Domain, the corresponding merchant's owned Facebook Ad Account, and the corresponding Pixel.

Our customers needs to verify their website's domain with Facebook and this would be done at eTLD+1 level. In our case, it would be boutir.com

However, as with our model, each merchant operates separately and independently. adoveo.com products, data, events are totally separated from those from bbb.adoveo.com. But now we cannot do it, as Facebook only verify eTLD+1 (i.e. adoveo.com) and would not verify and associate events with aaa.adoveo.com separately with bbb.adoveo.com. Our customers from aaa.adoveo.com and bbb.adoveo.com cannot pass through the verification step, and cannot effectively associate events triggered from their website to their domain.

If adoveo.com can be listed in the PSL, Facebook can separately verify aaa.adoveo.com and bbb.adoveo.com, and different customers can associate events and track separately with different domain aaa.adoveo.com and bbb.adoveo.com

DNS Verification via dig
=======

dig +short TXT _psl.adoveo.com
"https://github.com/publicsuffix/list/1346"


make test
=========

# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0

