### PR TITLE
Removing private subregistry aprendemas.cl due to deprecation.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -734,7 +734,6 @@ gouv.ci
 // cl : https://www.nic.cl
 // Confirmed by .CL registry <hsalgado@nic.cl>
 cl
-aprendemas.cl
 co.cl
 gob.cl
 gov.cl


### PR DESCRIPTION
* [ X ] Description of Organization
* [ X ] Reason for PSL Removal
* [ ] DNS verification via dig
* [ X ] Run Syntax Checker (make test)

* [ X ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [ X ] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [ X ] This request was _not_ submitted with the objective of working around other third party limits
  * [ X ] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [ X ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [ X ] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Mineduc is the Ministry of Education of the Chilean Government, responsible for promoting development at all levels of education at both public and private institutions.

Organization Website: https://www.mineduc.cl/

I work for NIC Chile (Hugo Salgado hsalgado@nic.cl), the .CL registry, submitting this PR on behalf of Mineduc. We're coordinated to validate the change. .CL whois doesn't list contact emails, but I can provide you with any proof at your request.

Reason for PSL Exclusion
====

I'm asking on behalf of Mineduc (Ministry of Education of the Chilean Government) to rollback the inclusion of "aprendemas.cl" in the PSL, for project abandonment. No subdomains were actually registered under aprendemas.cl, and no digital certificates were issued.

The inclusion was made by myself in PR [#1001 ](https://github.com/publicsuffix/list/pull/1001).


DNS Verification via dig
=======

Right now the TXT is pointing to the previous PR for inclusion:

```
dig +short TXT _psl.aprendemas.cl
"'https://github.com/publicsuffix/list/pull/1001'"

```
But I'll update it after knowing the final PR number for this rollback request.



make test
=========

Tests run, all PASSED.

