### PR TITLE
Add ddns5.com to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11207,6 +11207,10 @@ builtwithdark.com
 // Submitted by Richard Li <secalert@datawire.io>
 edgestack.me
 
+// DDNS5 : https://ddns5.com
+// Submitted by Cameron Elliott <cameron@cameronelliott.com>
+ddns5.com
+
 // Debian : https://www.debian.org/
 // Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
 debian.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---

(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://ddns5.com

ddns5.com is a free service to support HTTP based dynamic DNS
to support and enable rapid-deployment of WebRTC relays and servers.
WebRTC servers require SSL when accessed from browsers in order 
for browsers to enable camera recording. Thus easy dynamic DNS setup
allows users to learn WebRTC in the quickest way possible. 
(When combined with WebRTC relays supporting ddns5.com)

ddns5.com is created and run by an individual, Cameron Elliott,
with more info at http://cameronelliott.com

ddns5.com is run on a .com domain rather than a .org domain
because of the near transfer of .org to an organization that appeared to
plan to milk the .org domain for profits.

This is basically a volunteer effort to make WebRTC broadcasting
as quick and simple as possible for individuals.


Reason for PSL Inclusion
====

Individuals can register their own <xxx>.ddns5.com host names via an API
just like duckdns.org, and dozens of other dynamic DNS providers.

A user with foo.ddns5.com is separate and distinct 
from a different user with bar.ddns5.com
Thus it seems correct to have ddns5.com in the PSL

Registration Date Feb 20, 2021
Renewal Date Feb 20, 2027


DNS Verification via dig
=======


```
dig +short TXT _psl.ddns5.com
"https://github.com/publicsuffix/list/pull/1353"
```


make test
=========

I did manage to get the test running to the end on macOS!
It passed 5 of 5 tests.


