### PR TITLE
add eero ddns domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11609,8 +11609,8 @@ e4.cz
 
 // eero : https://eero.com/
 // Submitted by Yue Kang <eero-dynamic-dns@amazon.com>
-*.eero-stage.online
-*.eero.online
+eero-stage.online
+eero.online
 
 // En root‽ : https://en-root.org
 // Submitted by Emmanuel Raviart <emmanuel@raviart.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11609,8 +11609,8 @@ e4.cz
 
 // eero : https://eero.com/
 // Submitted by Yue Kang <eero-dynamic-dns@amazon.com>
-eero-stage.online
 eero.online
+eero-stage.online
 
 // En root‽ : https://en-root.org
 // Submitted by Emmanuel Raviart <emmanuel@raviart.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11607,6 +11607,11 @@ dynv6.net
 // Submitted by Vladimir Dudr <info@e4you.cz>
 e4.cz
 
+// eero : https://eero.com/
+// Submitted by Yue Kang <eero-dynamic-dns@amazon.com>
+*.eero-stage.online
+*.eero.online
+
 // En root‽ : https://en-root.org
 // Submitted by Emmanuel Raviart <emmanuel@raviart.com>
 en-root.fr


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


### Description of Organization
eero is a provider of a home WiFi system. It is owned by Amazon.com, Inc.
Organization Website: https://eero.com/

### Reason for PSL Inclusion
eero will soon release a feature that allows user-controlled content to exist on .eero.online. We are submitting these domains to the list to ensure they are correctly treated by browsers.


### DNS Verification via dig
=======
~ $ dig +short TXT _psl.eero-stage.online
"https://github.com/publicsuffix/list/pull/1359"
~ $ dig +short TXT _psl.eero.online
"https://github.com/publicsuffix/list/pull/1359"

### make test
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer

PASS: test-is-public
PASS: test-is-public-all
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain


