### PR TITLE
Add tuleap-partners.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11614,6 +11614,7 @@ en-root.fr
 // Enalean SAS: https://www.enalean.com
 // Submitted by Thomas Cottier <thomas.cottier@enalean.com>
 mytuleap.com
+tuleap-partners.com
 
 // ECG Robotics, Inc: https://ecgrobotics.org
 // Submitted by <frc1533@ecgrobotics.org>


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [X] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---

Description of Organization
====

Organization Website: https://www.enalean.com

I am a sysadmin at Enalean, a software development company that makes Tuleap (https://www.tuleap.org)


Reason for PSL Inclusion
====

We will host our partners applications on the tuleap-partners.com domain and want them to be secure and fully contained.
We already did that for our customers some years ago for the mytuleap.com domain PR #453

DNS Verification via dig
=======

```bash
# dig +short TXT _psl.tuleap-partners.com 
"https://github.com/publicsuffix/list/pull/1360"
```

make test
=========

Test passed


