### PR TITLE
add new domains for thingdust AG

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13463,13 +13463,17 @@ gwiddle.co.uk
 
 // Thingdust AG : https://thingdust.com/
 // Submitted by Adrian Imboden <adi@thingdust.com>
+*.firenet.ch
+*.svc.firenet.ch
+reservd.com
 thingdustdata.com
 cust.dev.thingdust.io
 cust.disrec.thingdust.io
 cust.prod.thingdust.io
 cust.testing.thingdust.io
-*.firenet.ch
-*.svc.firenet.ch
+reservd.dev.thingdust.io
+reservd.disrec.thingdust.io
+reservd.testing.thingdust.io
 
 // Tlon.io : https://tlon.io
 // Submitted by Mark Staarink <mark@tlon.io>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
Organization Website: https://thingdust.com

We are a small startup that provides a solution for measuring the occupancy of workplace environments (primarily shared desk and meeting rooms). Every customer gets his own instance with his own subdomain provided by us.

Reason for PSL Inclusion
====

A new product (reservd) is built in the same way (every customer has his own separate subdomain). We use these domains:
prod: customername.reservd.com
testing: customername.reservd.testing.thingdust.io
local dev: customername.reservd.dev.thingdust.io
disaster recovery test: customername.reservd.disrec.thingdust.io

We want as much isolation (Cookies Security, etc.) between the customers as possible, therefore we want to add the domains to the public suffix list.

We don't plan to cancel the registration. We confirm to hold the registration for longer than 2 years and will maintain the TXT section during that time.

Previous additions:
https://github.com/publicsuffix/list/pull/1031
https://github.com/publicsuffix/list/pull/767
https://github.com/publicsuffix/list/pull/419


DNS Verification via dig
=======
```
$ dig +short _psl.reservd.com TXT @8.8.8.8
"https://github.com/publicsuffix/list/pull/1361"
```

```
$ dig +short _psl.reservd.dev.thingdust.io TXT @8.8.8.8
"https://github.com/publicsuffix/list/pull/1361"
```

```
$ dig +short _psl.reservd.disrec.thingdust.io TXT @8.8.8.8
"https://github.com/publicsuffix/list/pull/1361"
```

```
$ dig +short _psl.reservd.testing.thingdust.io TXT @8.8.8.8
"https://github.com/publicsuffix/list/pull/1361"
```

make test
=========
Did run successfully

