### PR TITLE
Add Supabase domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13385,6 +13385,8 @@ temp-dns.com
 // Submitted by Inian Parameshwaran <security@supabase.io>
 supabase.co
 supabase.net
+supabase.in
+su.paba.se
 
 // Symfony, SAS : https://symfony.com/
 // Submitted by Fabien Potencier <fabien@symfony.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13381,6 +13381,11 @@ user.srcf.net
 // Submitted by Dan Miller <dm@sub6.com>
 temp-dns.com
 
+// Supabase : https://supabase.io
+// Submitted by Inian Parameshwaran <security@supabase.io>
+supabase.co
+supabase.net
+
 // Symfony, SAS : https://symfony.com/
 // Submitted by Fabien Potencier <fabien@symfony.com>
 *.s5y.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13384,8 +13384,8 @@ temp-dns.com
 // Supabase : https://supabase.io
 // Submitted by Inian Parameshwaran <security@supabase.io>
 supabase.co
-supabase.net
 supabase.in
+supabase.net
 su.paba.se
 
 // Symfony, SAS : https://symfony.com/


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---

Description of Organization
====
Organization Website: https://supabase.co
Supabase is a hosted platform where users get a Postgres database with realtime capabilities, Authentication and Storage. Each user on the platform gets a domain like *.supabase.co.  

<!--
Please tell us who you are and represent (i.e. individual, 
non-profit volunteer, engineer at a business) and what you 
do (i.e. DynDNS, Hosting, etc)

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->
Reason for PSL inclusion is for cookie security. We let users upload assets via [Supabase Storage](https://supabase.io/storage). Some users have been using this to host websites and we want to ensure that websites hosted at user's subdomains have cookies properly segregated. 

Both the domains have more than 2 years left in the registration. 

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.supabase.co
"https://github.com/publicsuffix/list/pull/1363"
```

```
dig +short TXT _psl.supabase.net
"https://github.com/publicsuffix/list/pull/1363"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

```
dig +short TXT _psl.supabase.co
"https://github.com/publicsuffix/list/pull/1363"
```

```
dig +short TXT _psl.supabase.net
"https://github.com/publicsuffix/list/pull/1363"
```

```
dig +short TXT _psl.supabase.in
"https://github.com/publicsuffix/list/pull/1363"
```

```
dig +short TXT _psl.su.paba.se
"https://github.com/publicsuffix/list/pull/1363"
```
make test
=========
I ran the tests and all the 5 test suites pass
<details>
 <summary>Test output</summary>

```
make test
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_NFKC: OK
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up to date.
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:36: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:36: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:36: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
configure.ac:11: installing 'build-aux/compile'
configure.ac:5: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/home/ubuntu/list/public_suffix_list.dat --with-psl-testfile=/home/ubuntu/list/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```
</details>
