### PR TITLE
Add rs.ba suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -292,6 +292,9 @@ mil.ba
 net.ba
 org.ba
 
+// rs.ba : http://urc.rs/index.php/page/301
+rs.ba
+
 // bb : https://en.wikipedia.org/wiki/.bb
 bb
 biz.bb


### PR DESCRIPTION
Subdomain rs.ba, is domain for Republic of Srpska entity (part of Bosnia and Herzegovina). Applications for domain registrations are submitted through [form](http://urc.rs/index.php/domen) on  web site of Computer Center of University of Banja Luka, or by writing email to domeni@unibl.org (which belongs to University's official site).

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Description of Organization
====

Organization Website: https://unibl.org and also http://urc.rs/index.php/page/301.
Please see **Extra info** and **Reason for PSL Inclusion** for more information.


Reason for PSL Inclusion
====

Different sites, ranging from government to private companies, use .rs.ba domain, which refers to Republic of Srpska, authonomous region of Bosnia and Hercegovina. This affects cookie policy, and how browsers treat these domains in general.

DNS Verification via dig
=======
```
$ dig +short TXT _psl.rs.ba
"https://github.com/publicsuffix/list/pull/1289"
```

make test
=========

I ran the test, and got:
```
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

Extra info
====

More info on university's computer center web site: http://urc.rs/index.php/page/301 (in Serbian language).

Political background:
Banja Luka is the capital of Republic of Srpska. Biggest university in the entity is University of Banja Luka.
Republic of Srpska is part of Bosnia and Hercegovina, with certain authonomy and close relations with Serbia (thus Computer Center of University of Banja Luka has .rs domain).

