### PR TITLE
addition of kn com.kn sld; update authority link

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3690,8 +3690,9 @@ veterinaire.km
 gouv.km
 
 // kn : https://en.wikipedia.org/wiki/.kn
-// http://www.dot.kn/domainRules.html
+// https://www.nic.kn/procedure-polices/
 kn
+com.kn
 net.kn
 org.kn
 edu.kn


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
  * Submitter unaffiliated with domain cc-tld
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place
  * No PRIVATE domains listed

__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

Description of Organization
====

Organization Website: https://censys.io/

Using the publicsuffixlist to group hostnames under their logical root; prior to this addition, x.y.com.kn names are being grouped under com.kn as opposed to under y.com.kn.

Reason for PSL Inclusion
====

I am not affiliated with the *.kn authority -- this requested addition is based on public information:

 * the Wikipedia article linked in the original commit for .kn from 2008 [was updated in 2016](https://en.wikipedia.org/w/index.php?title=.kn&diff=709888093&oldid=694123699) to include com.kn
 * the www.dot.kn link in the original commit from 2008 seems to have been [down since 2009](https://web.archive.org/web/2009*/http://www.dot.kn/domainRules.html), but [the more recent, active site on nic.kn](https://www.nic.kn/procedure-polices/) does explicitly call out .com.kn  


DNS Verification via dig
=======

N/A -- I have no affiliation or control over .kn or com.kn; addition pulled from public documents listed above.


make test
=========

`make test` passed
