### PR TITLE
Add Spreadshop hosting domains: myspreadshop.com plus country-specific

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13360,6 +13360,28 @@ spacekit.io
 // Submitted by Stefan Neufeind <info@speedpartner.de>
 customer.speedpartner.de
 
+// Spreadshop (sprd.net AG) : https://www.spreadshop.com/
+// Submitted by Martin Breest <security@spreadshop.com>
+myspreadshop.at
+myspreadshop.com.au
+myspreadshop.be
+myspreadshop.ca
+myspreadshop.ch
+myspreadshop.com
+myspreadshop.de
+myspreadshop.dk
+myspreadshop.es
+myspreadshop.fi
+myspreadshop.fr
+myspreadshop.ie
+myspreadshop.it
+myspreadshop.net
+myspreadshop.nl
+myspreadshop.no
+myspreadshop.pl
+myspreadshop.se
+myspreadshop.co.uk
+
 // Standard Library : https://stdlib.com
 // Submitted by Jacob Lee <jacob@stdlib.com>
 api.stdlib.com


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---

Description of Organization
====

Organization Website: https://www.spreadshop.com (group: https://www.spreadgroup.com/our-brands/, brand: Spreadshop, company: sprd.net AG)

Spreadshop is the shop hosting business of Spreadgroup (formerly known as Spreadshirt/ sprd.net AG) and exists since more than 15 years. We run more than 1.5 Mio shops and 40000 active shops on a couple of country-specific myspreadshop domains. Spreadshop provides shops similar to Shopify for the print-on-demand niche.

Some example shops for testing are:

* https://reclaimyourpower.myspreadshop.com
* https://h3h3productions.myspreadshop.ca
* https://pittsburghclothingcompany.myspreadshop.com.au
* https://ephshop.myspreadshop.co.uk
* https://earth-day-store.myspreadshop.net
* https://littleadventures.myspreadshop.de

Reason for PSL Inclusion
====

Indicate every subdomain as an independent business, which includes benefits for better security (no cookie sharing by accident across subdomains). 
Improve SEM and SEO capabilities for our independent shop partners.
Enable end-to-end tracking per subdomain with Facebook and other social media channels. 

We extended our domains to >2 years expiry time where it was possible (myspreadshop.com, myspreadshop.co.uk, myspreadshop.fr). All other domains are on auto renewal and we will extend the expiry time to >2 years on the next renewal. At the moment, it is for the remaining domains technically not possible to extend them to 2 or more years or it will not be reflected in the registries until the next renewal in some cases. However, all domains are on auto renewal and we do not sell or abandon any domains anyway (see track record for sprd.net AG domains).

DNS Verification via dig
=======

```
dig +short TXT _psl.myspreadshop.at
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.be
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.ca
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.ch
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.co.uk
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.com
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.com.au
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.de
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.dk
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.es
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.fi
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.fr
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.ie
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.it
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.net
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.nl
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.no
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.pl
"https://github.com/publicsuffix/list/pull/1368"
```

```
dig +short TXT _psl.myspreadshop.se
"https://github.com/publicsuffix/list/pull/1368"
```

make test
=========

```
make test
```

```
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up to date.
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/tmp/list/public_suffix_list.dat --with-psl-testfile=/tmp/list/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_dafsa_fuzzer.o
  CC       libpsl_load_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
  CCLD     libpsl_icu_load_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```