### PR TITLE
Remove uwu.nu

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13590,7 +13590,6 @@ at.md
 de.md
 jp.md
 to.md
-uwu.nu
 indie.porn
 vxl.sh
 ch.tc


### PR DESCRIPTION
* [x] Reason for PSL Exclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


Reason for PSL Exclusion
====

I purchased the domain uwu.nu on 2021-07-07 with the intention of using it for a website. At the time of purchase I was unaware of it being a part of this list.

The previous owner added it to the list in pull request #1014, and their project seems to be mostly abandoned at this point.

I have no intentions of making subdomains available/for sale and would therefore like uwu.nu removed.

DNS Verification via dig
=======

I will edit the dns records once the pull request has been submitted **(Edit: done)**

```
dig +short TXT _psl.uwu.nu
"https://github.com/publicsuffix/list/pull/1377"
```

