### PR TITLE
Add YunoHost DynDns domains: ynh.fr

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13717,6 +13717,7 @@ ybo.trade
 
 // Yunohost : https://yunohost.org
 // Submitted by Valentin Grimaud <security@yunohost.org>
+ynh.fr
 nohost.me
 noho.st
 


### PR DESCRIPTION
 * [x]  Description of Organization
 * [x]  Reason for PSL Inclusion
 * [x]  DNS verification via dig
 * [x]  Run Syntax Checker (make test)
 * [x]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

# Description of Organization
https://yunohost.org
YunoHost is a server operating system aiming to make self-hosting accessible to everyone.

# Reason of this Pull Request
We have added a new subdomain `ynh.fr` in more of the 2 `noho.st`, `nohost.me`. Those domain allows our user to self-host some services without the need of buying a personal domain and with the advantage to bypass some ISPs dynamic IP and to configure DNS entries automatically.

It could be very usefull, if browser could correctly manage this new subdomains (cookies, highlighting the subdomain, sorting by subdomain and not all the domain ). We want these services to be recognized as a known public suffix and dyndns services too.

# Dig request output

```
dig +short TXT _psl.ynh.fr
"https://github.com/publicsuffix/list/pull/1380"
```

# Make test
Here are the validated `make test`
https://paste.yunohost.org/ukolakaxaf

# `ynh.fr` birthdate
This new domain has been added in 2018. A lot of users use subdomains in ynh.fr now, we need to protect them. It's a security review that found this one was not in the publicsuffixlist like the 2 others `noho.st` and `nohost.me`...

# Extra info
I am a member of the yunohost council (the decision-making body of the Yunohost project). I have been mandated by the YunoHost Council the 27th february 2018 during a meeting to open this PR with the "submitted by Valentin GRIMAUD" instead of "submitted by YunoHost" as you requested it. I have put the security [at] yunohost.org mailing list as email contact (more appropriate) but if you want insist I can edit this PR with the personnal valentin.grimaud [at] yunohost.org instead.

I am also known as ljf inside the YunoHost community. I have made the PR directly from a fork hosted on our official organization on github.

# Previous PR made by our organization
https://github.com/publicsuffix/list/pull/615 [MERGED]
https://github.com/publicsuffix/list/pull/250 [REFUSED]


__Submitter affirms the following:__ 
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting
 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---