### PR TITLE
Add nog.community

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11975,6 +11975,10 @@ gitpage.si
 // Submitted by Mads Hartmann <mads@glitch.com>
 glitch.me
 
+// Global NOG Alliance : https://nogalliance.org/
+// Submitted by Sander Steffann <sander@nogalliance.org>
+nog.community
+
 // Globe Hosting SRL : https://www.globehosting.com/
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 co.ro


### PR DESCRIPTION
Add nog.community, where we host websites for 3rd party NOGs

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
  * [X] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

Description of Organization
====

Organization Website: https://nogalliance.org/

The full name of our organisation is Stichting Global NOG Alliance. Stichting is just the Dutch word for Foundation, and NOG stands for Network Operator Group. Network Operator Groups are often run by volunteers and often not registered as a legal entity. they are places where network operators and engineers meet to share experiences and learn from each other. We provide free services to NOGs like web and email hosting, online conferencing tools, file sharing tools etc. so that they can concentrate on helping their community without having to worry about maintaining their own servers and tools.

Reason for PSL Inclusion
====

We use the domain `nog.community` exclusively to host websites for NOGs that don't have their own domain. Therefore we think it is prudent to list nog.community as a public suffix as each subdomain under it is used by a different entity. They should not set/see cookies for other NOGs.

The nog.community domain is on a 3-year renewal and currently registered until 2024-10-11.

DNS Verification via dig
=======

```
dig +short TXT _psl.nog.community
"https://github.com/publicsuffix/list/pull/1381"
```

The test has passed.

make test
=========

The test has passed.
