### PR TITLE
Set and forget debris -cleanup of nymnom  expired names (see #1354)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12859,27 +12859,10 @@ nyc.mn
 
 // NymNom : https://nymnom.com/
 // Submitted by NymNom <psl@nymnom.com>
-nom.ae
-nom.af
-nom.ai
-nom.al
-nym.by
 nom.bz
 nym.bz
-nom.cl
-nym.ec
-nom.gd
 nom.ge
-nom.gl
-nym.gr
-nom.gt
-nym.gy
-nym.hk
-nom.hn
-nym.ie
 nom.im
-nom.ke
-nym.kz
 nym.la
 nym.lc
 nom.li
@@ -12887,27 +12870,15 @@ nym.li
 nym.lt
 nym.lu
 nom.lv
-nym.me
-nom.mk
 nym.mn
-nym.mx
 nom.nu
 nym.nz
-nym.pe
-nym.pt
-nom.pw
-nom.qa
-nym.ro
 nom.rs
 nom.si
 nym.sk
 nom.st
-nym.su
 nym.sx
-nom.tj
 nym.tw
-nom.ug
-nom.uy
 nom.vc
 nom.vg
 


### PR DESCRIPTION
This PSL Maintainer Volunteer submitted patch addresses some of (but not all of) #1354 

[ Seeking other volunteer (@sleevi) to review and approve this PR so I can merge it ]

NymNom appears to have gone kablooey, or at least they have not renewed a very significant quantity of the domains in their section.

I am removing names that were non-resolvable, and this may set a precedent to just pull entire sections where a majority of names within it are abandoned to expire like this without pulling PSL entries.

The entire list in the section was not entirely lost, and rather than be punative and remove the entire section due to the high level of extra work the situation

Non-exhaustive list of fail; appears that folks have picked up other nymnom names and have re-purposed them.

This PR removed the following domoains that had hard DNS errors:

nom.ae SOA : ** server can't find nom.ae: SERVFAIL
nom.af SOA : ** server can't find nom.af: NXDOMAIN
nom.ai : ;; connection timed out; no servers could be reached
nom.al : *** Can't find nom.al: No answer
nym.by SOA : ** server can't find nym.by: NXDOMAIN
nom.cl : ;; connection timed out; no servers could be reached
nym.ec SOA : ** server can't find nym.ec: NXDOMAIN
nom.gd : ;; connection timed out; no servers could be reached
nom.gl SOA : ** server can't find nom.gl: NXDOMAIN
nym.gr : ;; connection timed out; no servers could be reached
nom.gt : ;; connection timed out; no servers could be reached
nym.gy SOA : ** server can't find nym.gy: NXDOMAIN
nom.hn SOA : ** server can't find nom.hn: NXDOMAIN
nym.hk : ;; connection timed out; no servers could be reached
nym.ie : ;; connection timed out; no servers could be reached
nom.ke SOA : ** server can't find nom.ke: NXDOMAIN
nym.kz SOA : ** server can't find nym.kz: SERVFAIL
nym.me SOA : ** server can't find nym.me: SERVFAIL
nom.mk SOA : ** server can't find nom.mk: NXDOMAIN
nym.mx : *** Can't find nym.mx: No answer
nym.pe : *** Can't find nym.pe: No answer
nym.pt SOA : ** server can't find nym.pt: NXDOMAIN
nom.pw SOA : ** server can't find nom.pw: SERVFAIL
nom.qa SOA : ** server can't find nom.qa: SERVFAIL
nym.ro : ;; connection timed out; no servers could be reached
nym.su : ;; connection timed out; no servers could be reached
nom.tj SOA : ** server can't find nom.tj: SERVFAIL
nom.ug SOA : ** server can't find nom.ug: NXDOMAIN
nom.uy SOA : ** server can't find nom.uy: NXDOMAIN


