### PR TITLE
Added Lokalized domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12512,6 +12512,10 @@ loginline.io
 loginline.services
 loginline.site
 
+// Lokalized : https://lokalized.nl
+// Submitted by Noah Taheij <noah@lokalized.nl>
+servers.run
+
 // Lõhmus Family, The
 // Submitted by Heiki Lõhmus <hostmaster at lohmus dot me>
 lohmus.me


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---

Description of Organization
====

Organization Website: https://lokalized.nl

Providing hosting for websites and servers. We are working on a platform that can host websites and provide a secure environment for testing and deployment. We also strive to make an option to proxy to your own server (like ngrok.io). Use cases are: proxying, hosting your static content and deploy scalable apps with for example multiple nodes.

Reason for PSL Inclusion
====

Needed for Cookie Security due to the different websites (with "subdomains") on the hosting. Due to having multiple websites hosted by different people, we want to make it as secure as possible, therefore needing the PSL which will make the sites less vulnerable for same-site attacks.

DNS Verification via dig
=======

```
dig +short TXT _psl.servers.run
"https://github.com/publicsuffix/list/pull/1390"
```

make test
=========
Done.


