### PR TITLE
DEL whole nymnom section due to mass atrophy

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12875,60 +12875,6 @@ pcloud.host
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn
 
-// NymNom : https://nymnom.com/
-// Submitted by NymNom <psl@nymnom.com>
-nom.ae
-nom.af
-nom.ai
-nom.al
-nym.by
-nom.bz
-nym.bz
-nom.cl
-nym.ec
-nom.gd
-nom.ge
-nom.gl
-nym.gr
-nom.gt
-nym.gy
-nym.hk
-nom.hn
-nym.ie
-nom.im
-nom.ke
-nym.kz
-nym.la
-nym.lc
-nom.li
-nym.li
-nym.lt
-nym.lu
-nom.lv
-nym.me
-nom.mk
-nym.mn
-nym.mx
-nom.nu
-nym.nz
-nym.pe
-nym.pt
-nom.pw
-nom.qa
-nym.ro
-nom.rs
-nom.si
-nym.sk
-nom.st
-nym.su
-nym.sx
-nom.tj
-nym.tw
-nom.ug
-nom.uy
-nom.vc
-nom.vg
-
 // Observable, Inc. : https://observablehq.com
 // Submitted by Mike Bostock <dns@observablehq.com>
 static.observableusercontent.com


### PR DESCRIPTION
Proactively extends DELETIONS on inactive nymnom names that ocurred in #1383 to whole section - Please read issue #1354

Reason for PSL Exclusion
====

NymNom, the organization that submitted and managed this section, has allowed registration to lapse on the majority of the domains that they had submitted as eTLD+1 - which they should be maintaining / removing or updating the PSL section for.  Names being removed manually due to security concerns raised in #1354 has already ocurred in #1388, which was a very time-consuming process for the volunteers here on PSL maintainence. 

While it is typical that entities have a 'set and forget' approach to their entries in the PSL, the fact is that there is a requirement to remove entries when domains expire or are no longer needed.  We may revise the submisison intake form to make this more clear in the future if it is not.

Because the PSL is volunteer-based, upkeep of entries should be on the nameholders or companies that submitted entries and not the volunteers.  This is not intended as punative, but rather efficient.  Given the substantial volume of domains that were not renewed, and the current state of the hosting and accessibility of the company website as reported to us in #1354, it is not clear that this company will renew other domains, which has a number of concerns listed in #1354 that removing this section will address in a manner that has a modest impact on the volunteer maintainers with the highest degree of safety and integrity for browsers, users etc that rely on the PSL.

NymNom is not blacklisted and this is not a statement on that company.  The opportunity exists for NymNom to re-list domain names which they might seek to continue to operate and renew shall be available to them, if they opt to do so.



