### PR TITLE
Updating .ve (Venezuela) entries and contact info

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6714,9 +6714,10 @@ mil.vc
 edu.vc
 
 // ve : https://registro.nic.ve/
-// Submitted by registry
+// Submitted by registry nic@nic.ve and nicve@conatel.gob.ve
 ve
 arts.ve
+bib.ve
 co.ve
 com.ve
 e12.ve
@@ -6728,7 +6729,9 @@ info.ve
 int.ve
 mil.ve
 net.ve
+nom.ve
 org.ve
+rar.ve
 rec.ve
 store.ve
 tec.ve


### PR DESCRIPTION
I was emailed these changes and will open a PR that will await them adding the PR text record matching the pull request number with a _psl text record in the .ve zone directly to validate before merging the change into the PSL

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
Nic.ve are the authoritative administrators of the Venezuelan ccTLD, .ve


Organization Website: https://nic.ve

This change was provided by email to one of the core PSL maintainers and a PR was arranged in order to update the .ve section in the PSL.  

Reason for PSL Inclusion
====

This updates the .ve section in the iCANN portion of the PSL and adds both contact information as well as three namespaces from the registry directly that should operate as etld.

DNS Verification via dig
=======

```
dig +short TXT _psl.nic.ve
"https://github.com/publicsuffix/list/pull/1397"
```

```
dig +short TXT _psl.bib.ve
"https://github.com/publicsuffix/list/pull/1397"
```

```
dig +short TXT _psl.nom.ve
"https://github.com/publicsuffix/list/pull/1397"
```

```
dig +short TXT _psl.rar.ve
"https://github.com/publicsuffix/list/pull/1397"
```


