### PR TITLE
Add affinitylottery.org.uk raffleentry.org.uk and weeklylottery.org.uk to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13615,6 +13615,10 @@ meinforum.net
 // Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
 raffleentry.org.uk
 weeklylottery.org.uk
+affinitylottery.org.uk
+test-raffleentry.org.uk
+test-weeklylottery.org.uk
+test-affinitylottery.org.uk
 
 // WP Engine : https://wpengine.com/
 // Submitted by Michael Smith <michael.smith@wpengine.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13613,12 +13613,12 @@ meinforum.net
 
 // Woods Valldata : https://www.woodsvalldata.co.uk/
 // Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
-raffleentry.org.uk
-weeklylottery.org.uk
 affinitylottery.org.uk
+raffleentry.org.uk
+test-affinitylottery.org.uk
 test-raffleentry.org.uk
 test-weeklylottery.org.uk
-test-affinitylottery.org.uk
+weeklylottery.org.uk
 
 // WP Engine : https://wpengine.com/
 // Submitted by Michael Smith <michael.smith@wpengine.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13612,7 +13612,7 @@ community-pro.net
 meinforum.net
 
 // Woods Valldata : https://www.woodsvalldata.co.uk/
-// Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
+// Submitted by Chris Whittle <chris.whittle@woodsvalldata.co.uk>
 affinitylottery.org.uk
 raffleentry.org.uk
 test-affinitylottery.org.uk

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13718,9 +13718,6 @@ meinforum.net
 // Submitted by Chris Whittle <chris.whittle@woodsvalldata.co.uk>
 affinitylottery.org.uk
 raffleentry.org.uk
-test-affinitylottery.org.uk
-test-raffleentry.org.uk
-test-weeklylottery.org.uk
 weeklylottery.org.uk
 
 // WP Engine : https://wpengine.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13611,6 +13611,11 @@ diskussionsbereich.de
 community-pro.net
 meinforum.net
 
+// Woods Valldata : https://www.woodsvalldata.co.uk/
+// Submitted by Dave Wiltshire <dave.wiltshire@woodsvalldata.co.uk>
+raffleentry.org.uk
+weeklylottery.org.uk
+
 // WP Engine : https://wpengine.com/
 // Submitted by Michael Smith <michael.smith@wpengine.com>
 // Submitted by Brandon DuRette <brandon.durette@wpengine.com>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organisation
====
Organisation Website: https://www.woodsvalldata.co.uk/
WoodsValldata is a charity fundraising service provider.
I am a software developer at WoodsValldata catering for the hosted raffle and lottery websites that we provide.

Reason for PSL Inclusion
====
This is a pull request in response to the Apple iOS 14.5 change that affected Facebook Pixel tracking functionality for the domain(s) in the change, and we seek to resolve the impacts to the best of our ability to do so.  Both Apple and Facebook support Public Suffix List for Private Click Measurement and Aggregated Event Measurement respectively.
We have reviewed the wiki here outlining the PSL and understand what it is and is not.
We have reviewed this matter with the team at Facebook, we are now fully aware about the consequences to the change we are requesting as it relates to cookies or other services, and choose to proceed in submitting this PR. We understand that despite reviewing the matter with Facebook, Facebook cannot control which use cases get accepted to the PSL We understand that there is not any urgency and should this PR be merged to include our requested change, that there is no control over the timing of this change being updated downstream in browsers, libraries, certificate authorities or other systems or processes that incorporate the PSL.
We understand that if we later want to back out this change, there is also no guarantee that this will occur in a rapid fashion due to the same lack of control over browser, library, certificate authority, or other system or process changes.


DNS Verification via dig
=======
```
>nslookup -type=txt _psl.affinitylottery.org.uk 1.1.1.1
Server:  one.one.one.one
Address:  1.1.1.1

Non-authoritative answer:
_psl.affinitylottery.org.uk     text =

        "https://github.com/publicsuffix/list/pull/1398"
```

```
>nslookup -type=txt _psl.raffleentry.org.uk 1.1.1.1
Server:  one.one.one.one
Address:  1.1.1.1

Non-authoritative answer:
_psl.raffleentry.org.uk text =

        "https://github.com/publicsuffix/list/pull/1398"    
```     
```        
>nslookup -type=txt _psl.weeklylottery.org.uk 1.1.1.1
Server:  one.one.one.one
Address:  1.1.1.1

Non-authoritative answer:
_psl.weeklylottery.org.uk       text =

        "https://github.com/publicsuffix/list/pull/1398"
```
make test
=========
I have followed the test as outlined in https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change
and the output hasn't come back with any errors.

Please note, a previous pull request was made at https://github.com/publicsuffix/list/pull/1329