### PR TITLE
these domains are being deprecated, we wish to clean up after ourselves

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11676,11 +11676,6 @@ staging.onred.one
 // Submitted by Jacob Bunk Nielsen <jbn@one.com>
 service.one
 
-// Enonic : http://enonic.com/
-// Submitted by Erik Kaareng-Sunde <esu@enonic.com>
-enonic.io
-customer.enonic.io
-
 // EU.org https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>
 eu.org


### PR DESCRIPTION
### Info ### 
Years ago we needed these addresses for our customers. We have moved away from these domains and are able to what we need with a new setup and new domain.

We are trying to clean all up so we don't leave anything in a broken state.

### Question ### 

Do I need to remove the TXT entry on our end first? 
```
dig +short TXT _psl.customer.enonic.io. 
"https://github.com/publicsuffix/list/pull/330"
```
