### PR TITLE
Added Amazon EMR Notebooks domain suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10717,6 +10717,27 @@ us-west-2.elasticbeanstalk.com
 *.elb.amazonaws.com
 *.elb.amazonaws.com.cn
 
+// Amazon EMR: https://aws.amazon.com/emr/
+// Submitted by Parag Chaudhari <psl-maintainers@amazon.com>
+emrnotebooks-prod.us-west-1.amazonaws.com
+emrnotebooks-prod.us-west-2.amazonaws.com
+emrnotebooks-prod.us-east-1.amazonaws.com
+emrnotebooks-prod.us-east-2.amazonaws.com
+emrnotebooks-prod.eu-west-1.amazonaws.com
+emrnotebooks-prod.eu-west-2.amazonaws.com
+emrnotebooks-prod.eu-west-3.amazonaws.com
+emrnotebooks-prod.eu-central-1.amazonaws.com
+emrnotebooks-prod.eu-north-1.amazonaws.com
+emrnotebooks-prod.ap-south-1.amazonaws.com
+emrnotebooks-prod.ap-northeast-1.amazonaws.com
+emrnotebooks-prod.ap-northeast-2.amazonaws.com
+emrnotebooks-prod.ap-southeast-1.amazonaws.com
+emrnotebooks-prod.ap-southeast-2.amazonaws.com
+emrnotebooks-prod.ca-central-1.amazonaws.com
+emrnotebooks-prod.sa-east-1.amazonaws.com
+emrnotebooks-prod.cn-north-1.amazonaws.com.cn
+emrnotebooks-prod.cn-northwest-1.amazonaws.com.cn
+
 // Amazon Global Accelerator : https://aws.amazon.com/global-accelerator/
 // Submitted by Daniel Massaguer <psl-maintainers@amazon.com>
 awsglobalaccelerator.com


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [x] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [ ] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviors on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---

Description of Organization
====
Amazon EMR is the industry-leading cloud big data platform for processing vast amounts of data using open source tools such as Apache Spark, Apache Hive, Apache HBase, Apache Flink, Apache Hudi, and Presto.

Organization Website: https://aws.amazon.com/emr/

I'm a Sr. Software Development Engineer working for Amazon Web Services in Amazon EMR team.

Reason for PSL Inclusion
====
Amazon provides EMR notebooks that are a "serverless" Jupyter notebooks that you can use to run queries and code. These EMR notebooks are associated with a fourth level subdomain (e.g. https://**notebook-id**.emrnotebooks-prod.us-west-1.amazonaws.com) and we expect these subdomains to provide security boundary to protect issues such as cookie tossing and setting cookies across customers or notebooks so that so that each notebook client is provided with an isolated context.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->
```
dig +short TXT _psl.emrnotebooks-prod.ap-northeast-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.ap-northeast-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.ap-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.ap-southeast-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.ap-southeast-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.ca-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.eu-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.eu-north-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.eu-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.eu-west-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.eu-west-3.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.sa-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.us-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.us-east-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.us-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.us-west-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.cn-north-1.amazonaws.com.cn
"https://github.com/publicsuffix/list/pull/1404"

dig +short TXT _psl.emrnotebooks-prod.cn-northwest-1.amazonaws.com.cn
"https://github.com/publicsuffix/list/pull/1404"
```


make test
=========
Ran the tests and all tests passed


