### PR TITLE
Roll back diher.solutions PR #1393

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11258,13 +11258,6 @@ deno-staging.dev
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
-// Diher Solutions : https://diher.solutions
-// Submitted by Didi Hermawan <mail@diher.solutions>
-rss.my.id
-*.rss.my.id
-diher.solutions
-*.diher.solutions
-
 // DNS Africa Ltd https://dns.business
 // Submitted by Calvin Browne <calvin@dns.business>
 jozi.biz

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11258,6 +11258,11 @@ deno-staging.dev
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
+// Diher Solutions : https://diher.solutions
+// Submitted by Didi Hermawan <mail@diher.solutions>
+*.rss.my.id
+*.diher.solutions
+
 // DNS Africa Ltd https://dns.business
 // Submitted by Calvin Browne <calvin@dns.business>
 jozi.biz


### PR DESCRIPTION
foo.bar and *.foo.bar can't both be added, and I let #1393 through, where the linter typically catches and fails them.

It subsequently causes failed imports on some browser inclusions, so this must be backed out.

@pereceh you must re-sumbit and choose only one of each, please reference #1393 in the new PR - leaving the prior _psl txt record is fine when you re-submit 

// Diher Solutions : https://diher.solutions
// Submitted by Didi Hermawan <mail@diher.solutions>
rss.my.id
*.rss.my.id
diher.solutions
*.diher.solutions


