### PR TITLE
Adding scoreapp.me domain name

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12234,6 +12234,10 @@ org.yt
 // HostyHosting (hostyhosting.com)
 hostyhosting.io
 
+// Hyper Targeted Marketing Limited : https://www.scoreapp.com
+// Submitted by Steven Oddy <info@scoreapp.com>
+scoreapp.me
+
 // Häkkinen.fi
 // Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
 häkkinen.fi


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting


Description of Organization
====

Organization Website: https://www.scoreapp.com
ScoreApp (owned by Hyper Targeting Marketing Limited) is a quiz / microsite builder. We issue scoreapp.me sub-domains to our users.

Reason for PSL Inclusion
====

This is a pull request in response to the Apple iOS 14.5 change that affected Facebook Pixel tracking functionality for the domain(s) in the change, and we seek to resolve the impacts to the best of our ability to do so.  Both Apple and Facebook support Public Suffix List for Private Click Measurement and Aggregated Event Measurement respectively.
                ○ We have reviewed the wiki here outlining the PSL and understand what it is and is not.
                ○ We have reviewed this matter with the team at Facebook, we are now fully aware about the consequences to the change we are requesting as it relates to cookies or other services, and choose to proceed in submitting this PR. We understand that despite reviewing the matter with Facebook, Facebook cannot control which use cases get accepted to the PSL
                ○ We understand that there is not any urgency and should this PR be merged to include our requested change, that there is no control over the timing of this change being updated downstream in browsers, libraries, certificate authorities or other systems or processes that incorporate the PSL.
                ○ We understand that if we later want to back out this change, there is also no guarantee that this will occur in a rapid fashion due to the same lack of control over browser, library, certificate authority, or other system or process changes.

○ We also confirm the domain listed holds a registration term longer than 2 years and shall 
maintain more than a 1 year term in order to remain listed

DNS Verification via dig
=======

```
dig +short TXT _psl.scoreapp.me
"https://github.com/publicsuffix/list/pull/1408"
```


make test
=========
[x]


