### PR TITLE
Remove .nc.tr

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6261,10 +6261,6 @@ tel.tr
 tsk.tr
 tv.tr
 web.tr
-// Used by Northern Cyprus
-nc.tr
-// Used by government agencies of Northern Cyprus
-gov.nc.tr
 
 // tt : http://www.nic.tt/
 tt


### PR DESCRIPTION
As sleevi has pointed out we should follow the official policies https://github.com/publicsuffix/list/pull/832#issuecomment-507376281

The document https://www.nic.tr/forms/eng/policies.pdf shows that there is no reserve for .nc.tr and thus .nc.tr should be removed.