### PR TITLE
Add instances.spawn.cc

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13112,6 +13112,10 @@ qbuser.com
 // Submitted by Scott Claeys <s.claeys@radwebhosting.com>
 cloudsite.builders
 
+// Redgate Software: https://red-gate.com
+// Submitted by Andrew Farries <andrew.farries@red-gate.com>
+instances.spawn.cc
+
 // Redstar Consultants : https://www.redstarconsultants.com/
 // Submitted by Jons Slemmer <jons@redstarconsultants.com>
 instantcloud.cn


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---

Description of Organization
====

Organization Website: https://red-gate.com

I'm an engineer on Redgate's [Spawn](https://spawn.cc) project - a SaaS product offering hosted, ephemeral databases for development and CI purposes. 

Reason for PSL Inclusion
====

Every time one of our users creates a new database server on our service, they receive a connection string with which to access the server. The host portion of the connection string contains a randomly generated user-specific subdomain prefix, eg `77hszmhf.instances.spawn.cc`. 

A user's subdomain is assigned when they onboard with the service and these subdomains are all independent and mutually untrusting, and as such `instances.spawn.cc` should be considered a public suffix. This would also help us with certificate generation for these subdomains, but our usage currently falls within LetsEncrypt's rate limits so this isn't the primary motivation for seeking the addition.

The domain is registered for 2 years and will maintain more than 1 year term thereafter.

DNS Verification via dig
=======

```
dig +short TXT _psl.instances.spawn.cc
"https://github.com/publicsuffix/list/pull/1411"
```

make test
=========

Ran and passed `make test`.

