### PR TITLE
Add .tv.ni

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10950,6 +10950,10 @@ cafjs.com
 // Submitted by Marcus Popp <admin@callidomus.com>
 mycd.eu
 
+// canal6.com.ni : https://canal6.com.ni
+// Submitted by Canal6-Team <admin@canal6.com.ni>
+tv.ni
+
 // Carrd : https://carrd.co
 // Submitted by AJ <aj@carrd.co>
 drr.ac

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4693,6 +4693,7 @@ mil.ni
 net.ni
 nom.ni
 org.ni
+tv.ni
 web.ni
 
 // nl : https://en.wikipedia.org/wiki/.nl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4693,7 +4693,6 @@ mil.ni
 net.ni
 nom.ni
 org.ni
-tv.ni
 web.ni
 
 // nl : https://en.wikipedia.org/wiki/.nl


### PR DESCRIPTION
Cloudflare It is a free system that acts as a proxy (intermediary) between site visitors and the server. When I wanted to add my website educa6.tv.ni, there was an error, which I contacted support and they gave me the following answer:

Hello,

Thanks for contacting Cloudflare support. My name is Venkat and I will be looking into this ticket for you. We're sorry to read that you're experiencing difficulties.

I understand that you are seeing the following error: Please ensure you are providing the root domain and not any subdomains.

As per the following article: I cannot add my domain to Cloudflare

If you see this error, you need to make sure that the domain uses a verified TLD
You will find the verified TLD list here: https://publicsuffix.org/list/public_suffix_list.dat

As per above list, I do not see .tv.ni as a verified TLD. However, it does have .ni as a verified TLD. I believe this is why you are seeing the error.

I would suggest submitting an amendment to have .tv.ni added to the list of verified TLDs. Please refer: https://publicsuffix.org/submit/

Once this has been verified, you will be able to add the domain to Cloudflare.

Thank you for using Cloudflare. For now, I will mark this ticket as solved but please let us know if you have any further questions by replying back to this message.

Kind regards,

Venkat Chintha
Technical Support Engineer

Search the Cloudflare Community for advice and insight.



For this reason, I am making this request.
