### PR TITLE
Add siiites.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10803,6 +10803,10 @@ tele.amune.org
 // Submitted by Apigee Security Team <security@apigee.com>
 apigee.io
 
+// Apphud : https://apphud.com
+// Submitted by Alexander Selivanov <alex@apphud.com>
+siiites.com
+
 // Appspace : https://www.appspace.com
 // Submitted by Appspace Security Team <security@appspace.com>
 appspacehosted.com
@@ -13804,9 +13808,5 @@ bss.design
 basicserver.io
 virtualserver.io
 enterprisecloud.nu
-
-// Apphud : https://apphud.com
-// Submitted by Alexander Selivanov <alex@apphud.com>
-siiites.com
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13805,4 +13805,9 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// Apphud : https://apphud.com
+// Submitted by Alexander Selivanov <alex@apphud.com>
+apphud.com
+siiites.com
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13807,7 +13807,6 @@ enterprisecloud.nu
 
 // Apphud : https://apphud.com
 // Submitted by Alexander Selivanov <alex@apphud.com>
-apphud.com
 siiites.com
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
- [x] Description of Organization
- [x] Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Run Syntax Checker (make test)
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place

**Submitter affirms the following:**

- [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
- [x] This request was _not_ submitted with the objective of working around other third party limits
- [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
- [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---

**For Private section requests that are submitting entries for domains that match their organization website's primary domain:**

```
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken
it will stay that way for an indefinitely long while.
```

(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

- [x] Yes, I understand. I could break my organization's website cookies etc. and the rollback timing, etc is acceptable. Proceed.

---

# Description of Organization

Organization Website: https://apphud.com

I'm a CTO at Apphud - a smarter way to build and grow mobile apps with in-app subscriptions. By making development simpler, providing real-time data and tools to increase revenue.

# Reason for PSL Inclusion

Apphud is a b2b service for managing in-app purchases in mobile apps.

Our clients are mobile app developers. Within our online web editor, each developer can create an HTML paywall, just like Wix or Squarespace, and assign a unique randomly generated URL to it, (for example, 48bbb359.siiites.com). More details here: https://apphud.com/product

The domain "siiites.com" belongs to Apphud Inc., and should be considered a public suffix, since all subdomains are independent and fully controlled by our clients - mobile app developers.

The domain is registered for 3 years and will maintain more than 1 year term thereafter.

# DNS Verification via dig

```
dig +short TXT _psl.siiites.com
"https://github.com/publicsuffix/list/pull/1416"
```

# make test

Ran tests `make test`
All passed
