### PR TITLE
Add sandbox.usercontent.goog

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12083,6 +12083,8 @@ withyoutube.com
 *.gateway.dev
 cloud.goog
 translate.goog
+usercontent.goog
+sandbox.usercontent.goog
 cloudfunctions.net
 blogspot.ae
 blogspot.al

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12083,7 +12083,7 @@ withyoutube.com
 *.gateway.dev
 cloud.goog
 translate.goog
-sandbox.usercontent.goog
+*.usercontent.goog
 cloudfunctions.net
 blogspot.ae
 blogspot.al

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12083,7 +12083,6 @@ withyoutube.com
 *.gateway.dev
 cloud.goog
 translate.goog
-usercontent.goog
 sandbox.usercontent.goog
 cloudfunctions.net
 blogspot.ae


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [X] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


Description of Organization
====

Organization Website: https://www.google.com

Information Security Engineer at Google

Reason for PSL Inclusion
====

.sandbox.usercontent.goog will be serving 3rd party code separated by publisher. This is very similar to (but a different use case than) .translate.goog (https://github.com/publicsuffix/list/pull/1107). Currently there is no public usage, but since it takes a while to get into the PSL, we would like to have it available before wider use.

*Note: sandbox.usercontent.goog is not an internal/test-only service. In this case "sandbox" refers to code that is isolated akin to "CSP: sandbox".*

The domain is registered for 2 years and will maintain more than 1 year term thereafter.

```
Name: usercontent.goog
Registry Domain ID: 46D7EB740-GOOG
Domain Status:
clientDeleteProhibited
clientTransferProhibited
clientUpdateProhibited
Nameservers:
ns1.googledomains.com
ns2.googledomains.com
ns3.googledomains.com
ns4.googledomains.comDates
Registry Expiration: 2024-06-25 18:47:03 UTC
Updated: 2021-09-13 17:19:33 UTC
Created: 2021-06-25 18:47:03 UTC
```

DNS Verification via dig
=======
```
dig +short TXT _psl.usercontent.goog
"https://github.com/publicsuffix/list/pull/1417"
                                                             
dig +short TXT _psl.sandbox.usercontent.goog
"https://github.com/publicsuffix/list/pull/1417"
```

make test
=========

```
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public-all.o
  CC       test-is-public.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```


