### PR TITLE
Add 9 BASE, Inc. domains to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10885,6 +10885,18 @@ rs.ba
 app.banzaicloud.io
 *.backyards.banzaicloud.io
 
+// BASE, Inc. : https://binc.jp
+// Submitted by Yuya NAGASAWA <public-suffix-list@binc.jp>
+base.ec
+official.ec
+buyshop.jp
+fashionstore.jp
+handcrafted.jp
+kawaiishop.jp
+supersale.jp
+theshop.jp
+shopselect.net
+base.shop
 
 // BetaInABox
 // Submitted by Adrian <adrian@betainabox.com>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---

Description of Organization
====

Organization Website: https://binc.jp/

My name is Yuya NAGASAWA, I'm SRE at BASE.

BASE, Inc. is based on the mission "Payment to the People, Power to the People."　Our goal is to democratize payment, by various means including providing access to various payment methods and financing methods, as well as through our e-commerce platform, "BASE". Our focus is to empower individuals and small teams and enable them transform their abilities into value.

Reason for PSL Inclusion
====

Our e-commerce platform, "BASE", enables merchants to use subdomains such as "base.ec" and "buyshop.jp", at no cost. Many of our merchants use these subdomains instead of acquiring their own domains. However, due to the impact of Apple iOS 14.5, shops using our subdomains are currently unable to obtain conversion data from their Instagram Ads (in other words, they are unable to monitor the performance of their ads). We would like to solve this issue through registering to the PSL.

This is a pull request in response to the Apple iOS 14.5 change that affected Facebook Pixel tracking functionality for the domain(s) in the change, and we seek to resolve the impacts to the best of our ability to do so. Both Apple and Facebook support Public Suffix List for Private Click Measurement and Aggregated Event Measurement respectively.

* We have reviewed the wiki here outlining the PSL and understand what it is and is not.
* We have reviewed this matter with the team at Facebook, we are now fully aware about the consequences to the change we are requesting as it relates to cookies or other services, and choose to proceed in submitting this PR. We understand that despite reviewing the matter with Facebook, Facebook cannot control which use cases get accepted to the PSL
* We understand that there is not any urgency and should this PR be merged to include our requested change, that there is no control over the timing of this change being updated downstream in browsers, libraries, certificate authorities or other systems or processes that incorporate the PSL.
* We understand that if we later want to back out this change, there is also no guarantee that this will occur in a rapid fashion due to the same lack of control over browser, library, certificate authority, or other system or process changes.

DNS Verification via dig
=======

~*Setting in progress. Please wait.*~

```
echo 'base.ec
official.ec
buyshop.jp
fashionstore.jp
handcrafted.jp
kawaiishop.jp
supersale.jp
theshop.jp
shopselect.net
base.shop' | while read domain
do
  echo "_psl.${domain}\t$(dig +short TXT _psl.${domain} @1.1.1.1)"
done | column -t
```

```
_psl.base.ec          "https://github.com/publicsuffix/list/pull/1420"
_psl.official.ec      "https://github.com/publicsuffix/list/pull/1420"
_psl.buyshop.jp       "https://github.com/publicsuffix/list/pull/1420"
_psl.fashionstore.jp  "https://github.com/publicsuffix/list/pull/1420"
_psl.handcrafted.jp   "https://github.com/publicsuffix/list/pull/1420"
_psl.kawaiishop.jp    "https://github.com/publicsuffix/list/pull/1420"
_psl.supersale.jp     "https://github.com/publicsuffix/list/pull/1420"
_psl.theshop.jp       "https://github.com/publicsuffix/list/pull/1420"
_psl.shopselect.net   "https://github.com/publicsuffix/list/pull/1420"
_psl.base.shop        "https://github.com/publicsuffix/list/pull/1420"
```

make test
=========

```
(……snip……)
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-public-all
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

https://gist.github.com/ngsw/c05d04d68ec8bc7dd824bd42dedec26f


