### PR TITLE
Add digitaloceanspaces.com & regional subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11619,6 +11619,34 @@ definima.io
 // Submitted by Braxton Huggins <bhuggins@digitalocean.com>
 ondigitalocean.app
 
+// DigitalOcean Spaces : https://www.digitalocean.com/products/spaces/
+// Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
+digitaloceanspaces.com
+ams3.digitaloceanspaces.com
+fra1.digitaloceanspaces.com
+nyc3.digitaloceanspaces.com
+sfo2.digitaloceanspaces.com
+sfo3.digitaloceanspaces.com
+sgp1.digitaloceanspaces.com
+
+// DigitalOcean Spaces - Static Sites : https://www.digitalocean.com/products/spaces/
+// Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
+ams3-static.digitaloceanspaces.com
+fra1-static.digitaloceanspaces.com
+nyc3-static.digitaloceanspaces.com
+sfo2-static.digitaloceanspaces.com
+sfo3-static.digitaloceanspaces.com
+sgp1-static.digitaloceanspaces.com
+
+// DigitalOcean Spaces - CDN : https://www.digitalocean.com/products/spaces/
+// Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
+ams3.cdn.digitaloceanspaces.com
+fra1.cdn.digitaloceanspaces.com
+nyc3.cdn.digitaloceanspaces.com
+sfo2.cdn.digitaloceanspaces.com
+sfo3.cdn.digitaloceanspaces.com
+sgp1.cdn.digitaloceanspaces.com
+
 // dnstrace.pro : https://dnstrace.pro/
 // Submitted by Chris Partridge <chris@partridge.tech>
 bci.dnstrace.pro

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11621,31 +11621,7 @@ ondigitalocean.app
 
 // DigitalOcean Spaces : https://www.digitalocean.com/products/spaces/
 // Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
-digitaloceanspaces.com
-ams3.digitaloceanspaces.com
-fra1.digitaloceanspaces.com
-nyc3.digitaloceanspaces.com
-sfo2.digitaloceanspaces.com
-sfo3.digitaloceanspaces.com
-sgp1.digitaloceanspaces.com
-
-// DigitalOcean Spaces - Static Sites : https://www.digitalocean.com/products/spaces/
-// Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
-ams3-static.digitaloceanspaces.com
-fra1-static.digitaloceanspaces.com
-nyc3-static.digitaloceanspaces.com
-sfo2-static.digitaloceanspaces.com
-sfo3-static.digitaloceanspaces.com
-sgp1-static.digitaloceanspaces.com
-
-// DigitalOcean Spaces - CDN : https://www.digitalocean.com/products/spaces/
-// Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
-ams3.cdn.digitaloceanspaces.com
-fra1.cdn.digitaloceanspaces.com
-nyc3.cdn.digitaloceanspaces.com
-sfo2.cdn.digitaloceanspaces.com
-sfo3.cdn.digitaloceanspaces.com
-sgp1.cdn.digitaloceanspaces.com
+*.digitaloceanspaces.com
 
 // dnstrace.pro : https://dnstrace.pro/
 // Submitted by Chris Partridge <chris@partridge.tech>


### PR DESCRIPTION
Add all regions of DigitalOcean Spaces to the PSL, to deliniate the
names which can be registered by users. This mirrors the inclusion of
Amazon S3.

Please note the contact email address goes to a superset of the domain
registration group, suitable for reaching all critical points of contact
regarding DigitalOcean's PSL entries.

Signed-off-by: Robin H. Johnson <rjohnson@digitalocean.com>


* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [ ] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---



Description of Organization
====

Organization Website: https://www.digitalocean.com/

I am Robin H. Johnson. I work for DigitalOcean. DigitalOcean offers many cloud services including virtualized servers, managed databases, managed kubernetes clusters, storage services, and an application platform.

Reason for PSL Inclusion
====

DigitalOcean's Object Storage Service: "Spaces" creates permits users to have subdomains for their services, within various scopes of the `digitaloceanspaces.com.` domain: 3rd & 4th level subdomains, with further subdomains within those (periods are permitted within the user-controlled portion of the FQDN). 

- We would like to be included in the list to provide cookie security for our end users.
- We would like to make it clear that separate customer-controlled content is hosted on each subdomain, and that inclusion/exclusion on blocking lists, such as the UK's web blocking system [who claim to use PSL to make some determinations].

This reflects similar entries listed for AWS S3: https://github.com/publicsuffix/list/blob/428efccbe95f13dc6d6399bef8aa274bdb588e86/public_suffix_list.dat#L10740

The domains are registered through 2028:
```
$ whois digitaloceanspaces.com |grep Date
Updated Date: 2021-06-09T20:23:10Z
Creation Date: 2017-02-23T21:30:06Z
Registry Expiry Date: 2028-02-23T21:30:06Z
Updated Date: 2021-06-21T20:50:33Z
Creation Date: 2017-02-23T21:30:06Z
Registrar Registration Expiration Date: 2028-02-23T21:30:06Z
```

DNS Verification via dig
=======

```
_psl.digitaloceanspaces.com. 600 IN	TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.ams3.digitaloceanspaces.com. 600 IN TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.fra1.digitaloceanspaces.com. 600 IN TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.nyc3.digitaloceanspaces.com. 600 IN TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.sfo2.digitaloceanspaces.com. 600 IN TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.sfo3.digitaloceanspaces.com. 600 IN TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.sgp1.digitaloceanspaces.com. 600 IN TXT	"https://github.com/publicsuffix/list/pull/1421"
_psl.ams3-static.digitaloceanspaces.com. 600 IN	TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.fra1-static.digitaloceanspaces.com. 600 IN	TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.nyc3-static.digitaloceanspaces.com. 600 IN	TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.sfo2-static.digitaloceanspaces.com. 600 IN	TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.sfo3-static.digitaloceanspaces.com. 600 IN	TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.sgp1-static.digitaloceanspaces.com. 600 IN	TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.ams3.cdn.digitaloceanspaces.com. 600 IN TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.fra1.cdn.digitaloceanspaces.com. 600 IN TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.nyc3.cdn.digitaloceanspaces.com. 600 IN TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.sfo2.cdn.digitaloceanspaces.com. 600 IN TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.sfo3.cdn.digitaloceanspaces.com. 600 IN TXT "https://github.com/publicsuffix/list/pull/1421"
_psl.sgp1.cdn.digitaloceanspaces.com. 600 IN TXT "https://github.com/publicsuffix/list/pull/1421"
```


make test
=========
Tests ran & passed.


