### PR TITLE
Update AWS Elastic Beanstalk domain suffixes.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10710,6 +10710,8 @@ us-east-1.amazonaws.com
 cn-north-1.eb.amazonaws.com.cn
 cn-northwest-1.eb.amazonaws.com.cn
 elasticbeanstalk.com
+af-south-1.elasticbeanstalk.com
+ap-east-1.elasticbeanstalk.com
 ap-northeast-1.elasticbeanstalk.com
 ap-northeast-2.elasticbeanstalk.com
 ap-northeast-3.elasticbeanstalk.com
@@ -10718,13 +10720,17 @@ ap-southeast-1.elasticbeanstalk.com
 ap-southeast-2.elasticbeanstalk.com
 ca-central-1.elasticbeanstalk.com
 eu-central-1.elasticbeanstalk.com
+eu-north-1.elasticbeanstalk.com
+eu-south-1.elasticbeanstalk.com
 eu-west-1.elasticbeanstalk.com
 eu-west-2.elasticbeanstalk.com
 eu-west-3.elasticbeanstalk.com
+me-south-1.elasticbeanstalk.com
 sa-east-1.elasticbeanstalk.com
 us-east-1.elasticbeanstalk.com
 us-east-2.elasticbeanstalk.com
 us-gov-west-1.elasticbeanstalk.com
+us-gov-east-1.elasticbeanstalk.com
 us-west-1.elasticbeanstalk.com
 us-west-2.elasticbeanstalk.com
 


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [X] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


Description of Organization
====
AWS Elastic Beanstalk is an easy-to-use service for deploying and scaling web applications and services.

Organization Website: https://aws.amazon.com/elasticbeanstalk/

I am a Sr. Security Engineer on the AWS Elastic Beanstalk team.


Reason for PSL Inclusion
====

AWS Elastic Beanstalk domains have been on the public suffix list since 2013. This pull request adds new regional suffixes to the list.

Domain Name: elasticbeanstalk.com
Updated Date: 2019-08-26T19:19:56+0000
Creation Date: 2011-01-04T23:11:58+0000
Registrar Registration Expiration Date: 2024-01-04T08:00:00+0000

Related Commits and Pull Requests:
```
https://github.com/publicsuffix/list/commit/86848d24d25d408f4b68fd9b053279d41c06d2f0
https://github.com/publicsuffix/list/commit/bb0be1b211e3620360d3ed91bcf13fda8d1378de
https://github.com/publicsuffix/list/pull/484
https://github.com/publicsuffix/list/pull/579
https://github.com/publicsuffix/list/pull/597
https://github.com/publicsuffix/list/pull/628
```

DNS Verification via dig
=======

```
$ dig +short TXT _psl.elasticbeanstalk.com
"https://github.com/publicsuffix/list/pull/1422"
```

make test
=========

make test results: https://pastebin.com/nxH2eCpV


