### PR TITLE
Add AWS App Runner to PSL.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10694,6 +10694,10 @@ altervista.org
 // Submitted by Cyril <admin@alwaysdata.com>
 alwaysdata.net
 
+// Amazon App Runner : https://aws.amazon.com/apprunner/
+// Submitted by Eric Hays <psl-maintainers@amazon.com>
+*.awsapprunner.com
+
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com>
 cloudfront.net


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [x] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


Description of Organization
====
AWS App Runner is a fully managed service that makes it easy for developers to quickly deploy containerized web applications and APIs.

Organization Website: https://aws.amazon.com/apprunner/

I am a Sr. Security Engineer on the AWS App Runner team.

Reason for PSL Inclusion
====

AWS App Runner provides customers with a hostname in a regional suffix. As such, we would like to add PSL protections to these regional suffixes. For security reasons, AWS wants to prevent applications running on subdomains of <region>.awsapprunner.com from setting and sharing cookies on such domains.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.awsapprunner.com
"https://github.com/publicsuffix/list/pull/XXXX"
```


We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

make test
=========

https://pastebin.com/TTCwbuTN

