### PR TITLE
Add encoway domain: eu.encoway.cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11677,8 +11677,8 @@ mytuleap.com
 tuleap-partners.com
 
 // encoway GmbH : https://www.encoway.de
-// Submitted by Marcel Daus <marcel.daus@encoway.de>
-*.eu.encoway.cloud
+// Submitted by Marcel Daus <cloudops@encoway.de>
+eu.encoway.cloud
 
 // ECG Robotics, Inc: https://ecgrobotics.org
 // Submitted by <frc1533@ecgrobotics.org>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11676,14 +11676,14 @@ en-root.fr
 mytuleap.com
 tuleap-partners.com
 
-// encoway GmbH : https://www.encoway.de
-// Submitted by Marcel Daus <cloudops@encoway.de>
-eu.encoway.cloud
-
 // ECG Robotics, Inc: https://ecgrobotics.org
 // Submitted by <frc1533@ecgrobotics.org>
 onred.one
 staging.onred.one
+
+// encoway GmbH : https://www.encoway.de
+// Submitted by Marcel Daus <cloudops@encoway.de>
+eu.encoway.cloud
 
 // One.com: https://www.one.com/
 // Submitted by Jacob Bunk Nielsen <jbn@one.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11676,6 +11676,10 @@ en-root.fr
 mytuleap.com
 tuleap-partners.com
 
+// encoway GmbH : https://www.encoway.de
+// Submitted by Marcel Daus <marcel.daus@encoway.de>
+*.eu.encoway.cloud
+
 // ECG Robotics, Inc: https://ecgrobotics.org
 // Submitted by <frc1533@ecgrobotics.org>
 onred.one


### PR DESCRIPTION
Description of Organization
====

Organization Website: https://www.encoway.de/en/
encoway GmbH provides companies from the manufacturing industry with CPQ software.


Reason for PSL Inclusion
====

For each installation our clients get a subdomain of eu.encoway.cloud so they can access their system via web without having to incure additional fees for domains, static IP address or dyndns as this is handled by our system. Since each installation belongs to a separated legal entity and deals with that entity valuable information, security is top concern for us and our clients. It has proven that having the subdomains recognized by the browsers as separate domains and not share cookies or other vital information is a good working practice.

DNS Verification via dig
=======

```
dig +short TXT _psl.eu.encoway.cloud
"https://github.com/publicsuffix/list/pull/1430"
```

 
* [x]  Description of Organization
* [x]  Reason for PSL Inclusion
* [x]  DNS verification via dig
* [x]  Run Syntax Checker (make test)
* [x]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place
 
**Submitter affirms the following:**
 
* [x]  We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
* [x]  This request was _not_ submitted with the objective of working around other third party limits
* [x]  The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
* [x]  The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

**For Private section requests that are submitting entries for domains that match their organization website's primary domain:**

```
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```

(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [x]  Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.

