### PR TITLE
Remove clic2000.net from Private Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11051,10 +11051,6 @@ clerkstage.app
 *.stg.dev
 *.stgstage.dev
 
-// Clic2000 : https://clic2000.fr
-// Submitted by Mathilde Blanchemanche <mathilde@clic2000.fr>
-clic2000.net
-
 // ClickRising : https://clickrising.com/
 // Submitted by Umut Gumeli <infrastructure-publicsuffixlist@clickrising.com>
 clickrising.net


### PR DESCRIPTION
Hi,

We are letting go an unused domain name on October 22th and would like to clean up before.
This PR simply removes the entry I made in the first time to the list. I already removed the `_psl` TXT entry from the zone file.

Thanks in advance.
Best,