### PR TITLE
Update .ck -- adding sld records to instantiate wildcard, no policy change

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -323,7 +323,6 @@ net.bd
 org.bd
 sw.bd
 tv.bd
-judiciary.org.bd
 
 // be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -732,7 +732,15 @@ md.ci
 gouv.ci
 
 // ck : https://en.wikipedia.org/wiki/.ck
+// ck : https://www.vodafone.co.ck/domain-admin-policy
+// Enumerating SLDs for convenience.
 *.ck
+biz.ck
+co.ck
+edu.ck
+gen.ck
+net.ck
+org.ck
 !www.ck
 
 // cl : https://www.nic.cl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -310,19 +310,7 @@ store.bb
 tv.bb
 
 // bd : https://en.wikipedia.org/wiki/.bd
-// Enumerating SLDs and one 3LD entry for convenience.
 *.bd
-ac.bd
-co.bd
-com.bd
-edu.bd
-gov.bd
-info.bd
-mil.bd
-net.bd
-org.bd
-sw.bd
-tv.bd
 
 // be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -310,7 +310,20 @@ store.bb
 tv.bb
 
 // bd : https://en.wikipedia.org/wiki/.bd
+// Enumerating SLDs and one 3LD entry for convenience.
 *.bd
+ac.bd
+co.bd
+com.bd
+edu.bd
+gov.bd
+info.bd
+mil.bd
+net.bd
+org.bd
+sw.bd
+tv.bd
+judiciary.org.bd
 
 // be : https://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


__Submitter affirms the following:__ 
  * [X] We are listing any third party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the guidelines.
Your request could very likely alter the cookie and certificate (as well as other) behaviours on your 
core domain name in ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate the PSL do what they do, and when.
It is not within the PSL volunteers' control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest priority, so if something gets broken 
it will stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [ ] Yes, I understand.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  Proceed.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: <!-- https://example.com -->

<!--
Please tell us who you are and represent (i.e. individual, 
non-profit volunteer, engineer at a business) and what you 
do (i.e. DynDNS, Hosting, etc)

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->
Individual, not acting on behalf of employer.
DNS architect at GoDaddy, member of DNS-OARC, IETF contributor.
No connection to request per se.
Improving entry by instantiating second level domains covered by the wildcard.
No change in policy.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.
-->
Not my domain(s), but I am submitting a list of entries for the CCTLD 'ck' at the second level, to enumerate entries that would otherwise be covered by the single wildcard entry '*.ck'.
The purpose is to enable anyone using the PSL to generate accurate RPZ zone files.
RPZ (response policy zone) files are ordinary zone files, and as such, do not support wildcard interior labels like 'foo.*.example.com'. Enumerating the matching actual entries allows this to instead be 'foo.bar.example.com', if the only actual wildcard match was 'bar'.

No policy change results from this PR. The existing matching of wildcard vs literal SLD has the same level rules.

This is one of several similar submissions, for other CCTLDs which currently have only wildcard SLDs listed.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->
Not responsible for the domain, so cannot add these TXT records.
However, here is dig output demonstrating that the specific second level domains exist (as ENTs):

> 
; <<>> DiG 9.16.13 <<>> @downstage.mcs.vuw.ac.nz biz.ck. NS
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25520
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;biz.ck.				IN	NS

;; AUTHORITY SECTION:
ck.			86400	IN	SOA	parau.oyster.net.ck. soa.oyster.net.ck. 2021083000 14400 900 1728000 86400

;; Query time: 180 msec
;; SERVER: 130.195.6.10#53(130.195.6.10)
;; WHEN: Tue Sep 28 00:25:07 PDT 2021
;; MSG SIZE  rcvd: 92


; <<>> DiG 9.16.13 <<>> @downstage.mcs.vuw.ac.nz co.ck. NS
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44284
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;co.ck.				IN	NS

;; AUTHORITY SECTION:
ck.			86400	IN	SOA	parau.oyster.net.ck. soa.oyster.net.ck. 2021083000 14400 900 1728000 86400

;; Query time: 181 msec
;; SERVER: 130.195.6.10#53(130.195.6.10)
;; WHEN: Tue Sep 28 00:25:07 PDT 2021
;; MSG SIZE  rcvd: 91


; <<>> DiG 9.16.13 <<>> @downstage.mcs.vuw.ac.nz edu.ck. NS
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24238
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;edu.ck.				IN	NS

;; AUTHORITY SECTION:
ck.			86400	IN	SOA	parau.oyster.net.ck. soa.oyster.net.ck. 2021083000 14400 900 1728000 86400

;; Query time: 189 msec
;; SERVER: 130.195.6.10#53(130.195.6.10)
;; WHEN: Tue Sep 28 00:25:07 PDT 2021
;; MSG SIZE  rcvd: 92


; <<>> DiG 9.16.13 <<>> @downstage.mcs.vuw.ac.nz gen.ck. NS
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 36797
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;gen.ck.				IN	NS

;; AUTHORITY SECTION:
ck.			86400	IN	SOA	parau.oyster.net.ck. soa.oyster.net.ck. 2021083000 14400 900 1728000 86400

;; Query time: 183 msec
;; SERVER: 130.195.6.10#53(130.195.6.10)
;; WHEN: Tue Sep 28 00:25:08 PDT 2021
;; MSG SIZE  rcvd: 92


; <<>> DiG 9.16.13 <<>> @downstage.mcs.vuw.ac.nz net.ck. NS
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49411
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;net.ck.				IN	NS

;; AUTHORITY SECTION:
ck.			86400	IN	SOA	parau.oyster.net.ck. soa.oyster.net.ck. 2021083000 14400 900 1728000 86400

;; Query time: 180 msec
;; SERVER: 130.195.6.10#53(130.195.6.10)
;; WHEN: Tue Sep 28 00:25:08 PDT 2021
;; MSG SIZE  rcvd: 88


; <<>> DiG 9.16.13 <<>> @downstage.mcs.vuw.ac.nz org.ck. NS
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 35504
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;org.ck.				IN	NS

;; AUTHORITY SECTION:
ck.			86400	IN	SOA	parau.oyster.net.ck. soa.oyster.net.ck. 2021083000 14400 900 1728000 86400

;; Query time: 181 msec
;; SERVER: 130.195.6.10#53(130.195.6.10)
;; WHEN: Tue Sep 28 00:25:08 PDT 2021
;; MSG SIZE  rcvd: 92



make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
Test has been run, all results are "pass".

