### PR TITLE
Remove nodum domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12884,11 +12884,6 @@ zapto.org
 // Submitted by Konstantin Nosov <Nosov@nodeart.io>
 stage.nodeart.io
 
-// Nodum B.V. : https://nodum.io/
-// Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
-nodum.co
-nodum.io
-
 // Nucleos Inc. : https://nucleos.com
 // Submitted by Piotr Zduniak <piotr@nucleos.com>
 pcloud.host


### PR DESCRIPTION
Undoing: 
https://github.com/publicsuffix/list/pull/431

Removing `nodum.co` / `nodum.io`.

_psl DNS entry already removed.

Reference to this PR in DNS:
`_psl_remove.nodum.io	text = "https://github.com/publicsuffix/list/pull/1444"`