### PR TITLE
Add ts.net and beta.tailscale.net domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13466,6 +13466,11 @@ tabitorder.co.il
 // Submitted by Bjoern Henke <dev-server@taifun-software.de>
 taifun-dns.de
 
+// Tailscale Inc. : https://www.tailscale.com
+// Submitted by David Anderson <danderson@tailscale.com>
+beta.tailscale.net
+ts.net
+
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl
 gdansk.pl


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig **(waiting on PR number to set records)**
* [x] Run Syntax Checker (make test)

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting
  * [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

  * (note) The affirmation regarding entries that match an organization website's primary domain is N/A here, as Tailscale's primary domain is tailscale.com and isn't being submitted for inclusion. Nonetheless, I understand and accept the documented downstream propagation and rollback properties of the PSL.

Description of Organization
====

Organization Website: https://www.tailscale.com

Tailscale is software that creates a private overlay mesh network between users' devices, secured by the WireGuard VPN protocol.

Among other features, Tailscale lets users provision TLS certificates for the devices on their networks, via Let's Encrypt. The resulting certs are provisioned on shared domains operated by Tailscale, and follow the form `<device name>.<network name>.beta.tailscale.net` and `<device name>.<network name>.ts.net`.

TLS certificates may seem superfluous given that there's already an L3 VPN securing and authenticating communications, but browsers disagree: increasingly non-TLS connections result in scary warnings to users, and some newer features of the web platform are hard-disabled in "insecure contexts" - which browsers take to mean "no TLS". To avoid a downgraded web experience, Tailscale facilitates the issuance of TLS certificates by plumbing the ACME dns-01 challenge through the ts.net and beta.tailscale.net domains on behalf of user devices.

In future, we also plan to use these TLS certificates to provide "ingress" functionality, allowing controlled exposure of private devices to the internet while preserving e2e privacy of connections (since only the user device has the TLS private key, Tailscale merely facilitates issuance and L4 packet forwarding).

I'm an engineer at Tailscale, and am making this submission on behalf of my employer. "We" throughout this PR refers to Tailscale as a whole, with me affirming things on the company's behalf.

Reason for PSL Inclusion
====

We are seeking inclusion in the PSL for cookie security. Tailscale's TLS certificates are issued in two domains shared among all Tailscale users, with each user getting a distinct subdomain. As a result, `foo.ts.net` and `bar.ts.net` are owned by different users, similar to how various web host subdomains work.

We want to allow users to set cookies freely within their subdomain "container" on our domains, but prevent setting cookies on `ts.net` and `beta.tailscale.net`, as those cookies would leak between different users.

We have no purpose for PSL inclusion other than cookie security. In particular, we've already been granted an increased issuance rate limit with Let's Encrypt directly, and this submission is not aiming to circumvent those limits.

We understand that ts.net and tailscale.net will have to keep registration terms longer than 2 years to remain in the PSL. As of this submission, ts.net and tailscale.net expire in 2028 and 2029 respectively, and checking+renewing their registrations is included as an item in Tailscale's quarterly review of policy documents and compliance commitments.

While the "beta" in beta.tailscale.net may suggest a non-production or internal domain (which wouldn't be eligible for PSL inclusion), it is in fact being used for production purposes. It predates Tailscale's acquisition of the ts.net domain, and "beta" was included in the name to avoid burning the entire tailscale.net domain if we made some kind of terrible mistake in how we structured user-owned subdomains. Users are currently transitioning to the ts.net domain, so in the long term I expect to be able to remove beta.tailscale.net from the PSL. However, that transition is limited by uptake of new versions of Tailscale software, and empirically, our long tail is >2 years long.

There are no past issues or PRs relating to these PSL entries, or to Tailscale more generally.

DNS Verification via dig
=======

(I've created placeholder records at _psl.ts.net and _psl.tailscale.net, and will update them with the PR number as soon as I hit the create button - the PR number may show as XXXX for a few minutes while the update propagates)

```
dig +short TXT _psl.ts.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.tailscale.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

make test
=========

I've run `make test`, and it reports that all tests pass.
