### PR TITLE
Add etn.zone

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13807,4 +13807,8 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// HostFly : https://hostfly.com.ua
+// Submitted by Bohdan Dub <support@hostfly.com.ua>
+etn.zone
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12220,6 +12220,10 @@ edu.scot
 sch.so
 org.yt
 
+// HostFly : https://hostfly.com.ua
+// Submitted by Bohdan Dub <support@hostfly.com.ua>
+etn.zone
+
 // HostyHosting (hostyhosting.com)
 hostyhosting.io
 
@@ -13806,9 +13810,5 @@ bss.design
 basicserver.io
 virtualserver.io
 enterprisecloud.nu
-
-// HostFly : https://hostfly.com.ua
-// Submitted by Bohdan Dub <support@hostfly.com.ua>
-etn.zone
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Our website (hostfly.com.ua) was created in 2013 year and extended until October 2031. (DATAFLY) is an official TM of our company in Ukraine.

Is planned to register clients in the (ETN.ZONE), but not everywhere is adequately recognized as a zone.

Zone extended for more than 2 years, _psl TXT record in (ETN.ZONE) is created.

Official E-mail (support@hostfly.com.ua) always works.

We have an ID in IANA (https://www.iana.org/assignments/epp-repository-ids/epp-repository-ids.xhtml)

Please, added (ETN.ZONE) in suffix list privates domains.

Best regards,
Bohdan Dub

// HostFly : https://hostfly.com.ua
// Submitted by Bohdan Dub <support@hostfly.com.ua>
etn.zone