### PR TITLE
Please add koobin.events to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12459,6 +12459,10 @@ uni5.net
 // Submitted by Roy Keene <rkeene@knightpoint.com>
 knightpoint.systems
 
+// KoobinEvent, SL: https://www.koobin.com
+// Submitted by Iván Oliva <ivan.oliva@koobin.com>
+koobin.events
+
 // KUROKU LTD : https://kuroku.ltd/
 // Submitted by DisposaBoy <security@oya.to>
 oya.to


### PR DESCRIPTION
This is a pull request in response to the Apple iOS 14.5 change that affected Facebook Pixel tracking functionality for the domain(s) in the change, and we seek to resolve the impacts to the best of our ability to do so. Both Apple and Facebook support Public Suffix List for Private Click Measurement and Aggregated Event Measurement respectively.

* We have reviewed the wiki here outlining the PSL and understand what it is and is not.
* We have reviewed this matter with the team at Facebook, we are now fully aware about the consequences to the change we are requesting as it relates to cookies or other services, and choose to proceed in submitting this PR. We understand that despite reviewing the matter with Facebook, Facebook cannot control which use cases get accepted to the PSL
* We understand that there is not any urgency and should this PR be merged to include our requested change, that there is no control over the timing of this change being updated downstream in browsers, libraries, certificate authorities or other systems or processes that incorporate the PSL.
* We understand that if we later want to back out this change, there is also no guarantee that this will occur in a rapid fashion due to the same lack of control over browser, library, certificate authority, or other system or process changes.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: <!-- https://example.com -->https://www.koobin.com

<!--
Please tell us who you are and represent (i.e. individual, 
non-profit volunteer, engineer at a business) and what you 
do (i.e. DynDNS, Hosting, etc)

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.

Provide at least three sentences, the more the better, but
avoid the promotional stuff about how wonderful it is.
-->
I'm Iván Oliva, developer at KoobinEvent, SL. We provide a ticketing platform for third parties, as SaaS. These third parties can be theaters, sports clubs, operas, concert halls and so on.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->
Our clients ticketing sites are currently published on subdomains of one of our domains (koobin.cat, koobin.com, koobin.es). However, some of our clients have expressed interest on proper Facebook pixel tracking with iOS 14.5 and above. That's why, after reviewing your guidelines and consulting with Facebook, we have reserved a new koobin.events domain, where we will migrate those clients to. By the way, our clients' website run independently, so they must not share cookies between them.

Besides, we will not run any website directly on koobin.events, since our corporate website runs under www.koobin.com.

I hereby confirm that our koobin.events domain, although reserved last July,  maintain more than 4 years registration term at the time of this PR (until 6/29/2026).

I will be glad to further clarify my petition if there is still any doubt about it.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->
DNS verification added:

```
dig +short TXT _psl.koobin.events
"https://github.com/publicsuffix/list/pull/1462"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
Test ran.


Thanks a lot in advance.