### PR TITLE
Replace edugit.org with edugit.io and add s3.teckids.org for Teckids

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13491,7 +13491,9 @@ sopot.pl
 
 // Teckids e.V. : https://www.teckids.org
 // Submitted by Dominik George <dominik.george@teckids.org>
+edugit.io
 edugit.org
+s3.teckids.org
 
 // Telebit : https://telebit.cloud
 // Submitted by AJ ONeal <aj@telebit.cloud>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13492,7 +13492,6 @@ sopot.pl
 // Teckids e.V. : https://www.teckids.org
 // Submitted by Dominik George <dominik.george@teckids.org>
 edugit.io
-edugit.org
 s3.teckids.org
 
 // Telebit : https://telebit.cloud


### PR DESCRIPTION
* [x] Description of organisation
* [x] Reason for PSL inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

# Description of organisation

Teckids e.V. is an organisation that works on everything around young people, educaiton, and free software. It provides a large set of services to bring free software and open education to everyone.

# Reason for PSL inclusion

* `edugit.io` should be added to replace to `edugit.org` (see #736, #972)
* `s3.teckids.org` is the base domain for Teckids' new objcet storage platform, which will host buckets under sub-domains, with buckets potentially including web assets that might be able to set cross-origin cookies

# DNS verification via `dig`

```plain
❯ dig +short _psl.edugit.org. TXT
"https://github.com/publicsuffix/list/pull/736"
"https://github.com/publicsuffix/list/pull/1463"
❯ dig +short _psl.edugit.io. TXT
"https://github.com/publicsuffix/list/pull/1463"
❯ dig +short _psl.s3.teckids.org. TXT
"https://github.com/publicsuffix/list/pull/1463"
```

# Run Syntax Checker

`make test` seems happy!

---

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->
