### PR TITLE
Add etlds for KV GmbH

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6690,13 +6690,13 @@ washtenaw.mi.us
 
 // KV-GmbH : https://subdomain.com
 // Submitted by Martin Steinkamp <steinkamp@kv-gmbh.de>
-24.eu
+shop.co
 co.de
+ev.de
+24.eu
 co.gp
 co.nu
-ev.de
 info.tm
-shop.co
 
 // uy : http://www.nic.org.uy/
 uy

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6688,6 +6688,16 @@ mus.mi.us
 tec.mi.us
 washtenaw.mi.us
 
+// KV-GmbH : https://subdomain.com
+// Submitted by Martin Steinkamp <steinkamp@kv-gmbh.de>
+24.eu
+co.de
+co.gp
+co.nu
+ev.de
+info.tm
+shop.co
+
 // uy : http://www.nic.org.uy/
 uy
 com.uy


### PR DESCRIPTION
KV GmbH
Martinistr. 3
49080 Osnabrück
Deutschland
Register: Handelsregister
Registernummer: HRB 205536
Registergericht: Amtsgericht Osnabrück
Tel.: 0541-95224925
E-Mail: technik@kv-gmbh.de
Vertretungsberechtigter Geschäftsführer:
Dipl. Kaufm. Martin Steinkamp
USt.-Id.-Nr.: DE278925301

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Organization Website: https://subdomain.com

KV-Gmbh is a small internet company from Osnabrück, Germany. Besides all kinds of smaller projects, we run a registry for subdomains. On the one hand we use our subdomains for our own projects, but mainly we want to sell them through other registrars.
In addition, we also offer web hosting, for which these subdomains can also be used as domains.

Reason for PSL Inclusion
====

While we were not familiar with the list until now, we were pointed to it by an employee of a registrar and asked to join the list. Mainly it is important for us that our domains are considered as legit TLDs.

DNS Verification via dig
=======

dig +short TXT _psl.shop.co
"https://github.com/publicsuffix/list/pull/1465"

dig +short TXT _psl.co.de
"https://github.com/publicsuffix/list/pull/1465"

dig +short TXT _psl.ev.de
"https://github.com/publicsuffix/list/pull/1465"

dig +short TXT _psl.24.eu
"https://github.com/publicsuffix/list/pull/1465"

dig +short TXT _psl.co.gp
"https://github.com/publicsuffix/list/pull/1465"

dig +short TXT _psl.co.nu
"https://github.com/publicsuffix/list/pull/1465"

dig +short TXT _psl.info.tm
"https://github.com/publicsuffix/list/pull/1465"


make test
=========

cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Bereits aktuell.
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:36: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:36: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:36: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
configure.ac:11: installing 'build-aux/compile'
configure.ac:5: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/home/user/Schreibtisch/list-master/list/public_suffix_list.dat --with-psl-testfile=/home/user/Schreibtisch/list-master/list/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer

Testsuite summary for libpsl 0.21.1

TOTAL: 3
PASS:  3
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0

Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all

Testsuite summary for libpsl 0.21.1

TOTAL: 5
PASS:  5
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0

Making check in msvc
