### PR TITLE
Remove: gb.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10979,7 +10979,6 @@ za.com
 // No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 ar.com
-gb.com
 hu.com
 kr.com
 no.com


### PR DESCRIPTION
* [x] Reason for PSL Exclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

Reason for PSL Exclusion
====
gb.com is not owned or operated by CentralNic anymore, should be removed.

We're the current owner of this domain, would like it removed from the list.

DNS Verification via dig
=======
```
dig +short TXT _psl.gb.com
"https://github.com/publicsuffix/list/pull/1467"
```

make test
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
  CCLD     test-registrable-domain
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin19.6.0
libtool: warning: assuming '-no-fast-install' instead
PASS: test-is-public-all
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```