### PR TITLE
Adding ravendb.cloud domain to allow separation between users

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12197,6 +12197,7 @@ herokussl.com
 // Submitted by Oren Eini <oren@ravendb.net>
 myravendb.com
 ravendb.community
+ravendb.cloud
 ravendb.me
 development.run
 ravendb.run

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12195,8 +12195,8 @@ herokussl.com
 
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
-myravendb.com
 ravendb.cloud
+myravendb.com
 ravendb.community
 ravendb.me
 development.run

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12196,8 +12196,8 @@ herokussl.com
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
 myravendb.com
-ravendb.community
 ravendb.cloud
+ravendb.community
 ravendb.me
 development.run
 ravendb.run


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place


I'm not sure if the above 👆 is intended for the reviewers or me to fill. Left it empty, but all the items here are checked.

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website - company - https://hibernatingrhinos.com/ - product - https://ravendb.net

Hibernating Rhinos produces the RavenDB database, a NoSQL Document Database that can run on premise or in the cloud.

We provide our users with clusters that are running on `ravendb.cloud` subdomains. Each customer has each own independent subdomain and they are completely isolated from one another.

Those database clusters are offered from https://cloud.ravendb.net and the actual clusters are hosted on `ravendb.cloud` subdomains.


Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

We want to ensure that there is a proper separation at the domain level as well, so a cookie on one user won't be accessible from another. We also user certificate authentication and it would be very useful in the browser understood that there is a security boundary between those domains for this reason.

We already have other domains on this list (`ravendb.run`, for example) for the same purpose and want to extend the same behavior to our cloud users.

We previously included domains in the following PR: https://github.com/publicsuffix/list/pull/535
This PR is an extension of this to a new domain that we are started user using after that PR was accepted.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```


Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->


```
$  dig +short TXT _psl.ravendb.cloud
"https://github.com/publicsuffix/list/pull/1468"
```

make test
=========

I run this, output of that is here:

https://gist.github.com/ayende/fa98c80fd486658a6ac2f567b4cde445

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->


