### PR TITLE
Add `vultrobjects.com` and future regional subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13682,7 +13682,7 @@ me.vu
 // Submitted by Serhii Rostilo <sergey@rostilo.kiev.ua>
 v.ua
 
-// Vultr Object Storage : https://www.vultr.com/products/object-storage/
+// Vultr Objects : https://www.vultr.com/products/object-storage/
 // Submitted by Niels Maumenee <storage@vultr.com>
 *.vultrobjects.com
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13682,6 +13682,10 @@ me.vu
 // Submitted by Serhii Rostilo <sergey@rostilo.kiev.ua>
 v.ua
 
+// Vultr Object Storage : https://www.vultr.com/products/object-storage/
+// Submitted by Niels Maumenee <storage@vultr.com>
+*.vultrobjects.com
+
 // Waffle Computer Inc., Ltd. : https://docs.waffleinfo.com
 // Submitted by Masayuki Note <masa@blade.wafflecell.com>
 wafflecell.com


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__
  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the
order of commented org placement, order of sorting of entries.
(hint: TLD then SLD, Ascending sort)
-->
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

```
Seriously, carefully read the downline flow of the PSL and the
guidelines. Your request could very likely alter the cookie and
certificate (as well as other) behaviors on your core domain name in
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate
the PSL do what they do, and when. It is not within the PSL volunteers'
control to do anything about that.

The volunteers are busy with new requests, and rollbacks are lowest
priority, so if something gets broken by your PR, it will potentially
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---
Description of Organization
====

Organization Website: https://www.vultr.com/

<!--
Please tell us who you are and represent (i.e. individual,
non-profit volunteer, engineer at a business) and what you
do (i.e. DynDNS, Hosting, etc)

For the org description, there is less interest in the
promotional / marketing information about the org and more
a focus on having concise description of the core focus of
the submitting org, specifically with context/connection
to this request.

Provide at least three sentences, the more the better, but
avoid the promotional stuff about how wonderful it is.
-->
My name is Niels Maumenee. I am a Cloud Storage Engineer and Product Manager of
Vultr Objects, a highly available S3 compatible object storage product at
Constant (the parent company of Vultr). Vultr, founded in 2014, is on a mission
to empower developers and businesses by simplifying the deployment of infrastructure
via its advanced cloud platform. Vultr is strategically located in 19 datacenters
around the globe and provides frictionless provisioning of public cloud, storage
and single-tenant bare metal compute resources.


Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook,
Cloudflare etc) and clearly confirm that any private section
names hold registration term longer than 2 years and shall
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR #
specifically related to this submission or section.

Three or more sentences here that describe the purpose for
which your PR should be included in the PSL.  There is no
upper limit, but six paragraphs seems like a rational stop.
-->

Submitting *.vultrobjects.com would have security benefits with regards to
cookies or potential cross-site scripting attacks for users of vultrobjects products
and services. In addition, having Vultr Objects in the public suffix list may help
Internet Service Providers identify potential phishing and/or spoofing attacks by
individual users of Vultr Objects as opposed to service as a whole.

We also have plans to expand the Vultr Objects S3 service to additional points
of presence and therefore would like to extend the same functionality to all
content that utilizes the same top level domain of *.vultrobjects.com.

This request is for our object storage sites only at this point and no previous
requests have been made to include any Vultr products or services at this time.

Finally, it is worth noting that vultrobjects.com expires before the criteria:
Lack of proper domain ownership or expiry dates less than 2Y away
We have owned vultrobjects.com since February 15, 2019 and intend to renew our
registration with Godaddy before the Registry Expiry Date: 2023-02-15T16:17:41Z

```
$ whois vultrobjects.com | grep Date
   Updated Date: 2021-02-16T12:59:32Z
   Creation Date: 2019-02-15T16:17:41Z
   Registry Expiry Date: 2023-02-15T16:17:41Z
Updated Date: 2019-05-16T00:51:12Z
Creation Date: 2019-02-15T11:17:41Z
Registrar Registration Expiration Date: 2023-02-15T11:17:41Z
```


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want
your entry to remain in the PSL, so that future (TBD)
automation can remove entries where the record is not present.

-->

dig +short TXT _psl.vultrobjects.com
"https://github.com/publicsuffix/list/pull/1470"

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

test ran and passed
