### PR TITLE
Add `discordsays.com` and `discordsez.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11254,6 +11254,11 @@ dedyn.io
 *.rss.my.id
 *.diher.solutions
 
+// Discord Inc : https://discord.com
+// Submitted by Sahn Lam <slam@discordapp.com>
+discordsays.com
+discordsez.com
+
 // DNS Africa Ltd https://dns.business
 // Submitted by Calvin Browne <calvin@dns.business>
 jozi.biz


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Organization Website: https://discord.com

Discord is a voice, video and text communication service used by hundreds of millions of people to hang out and talk with their friends and communities.

I am an engineer at Discord.

Reason for PSL Inclusion
====

Discord provides a platform for 3rd parties to host activities like games within the Discord application. These activities run inside an iframe hosted on `discordsays.com` and `discordsez.com`. Each activity is a subdomain of either `discordsays.com` or `discordsez.com`.

We are seeking inclusion in the PSL for cookie security. We would like to allow individual activities to set cookies freely within
their subdomains while preventing them from setting cookies on `discordsays.com` or `discordsez.com` as those cookies would leak across activities.

DNS Verification via dig
=======

```
❯ dig +short TXT _psl.discordsays.com
"https://github.com/publicsuffix/list/pull/1474"
```

```
❯ dig +short TXT _psl.discordsez.com
"https://github.com/publicsuffix/list/pull/1474"
```

make test
=========

```
❯ make test
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_NFKC: OK
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up to date.
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:36: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:36: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:36: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
configure.ac:11: installing 'build-aux/compile'
configure.ac:5: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/home/slam/src/github.com/slam/list/public_suffix_list.dat --with-psl-testfile=/home/slam/src/github.com/slam/list/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
❯ echo $?
0
```