### PR TITLE
Revert "Add amsw.nl private domain to PSL (#929)"

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10782,10 +10782,6 @@ s3-website.eu-west-2.amazonaws.com
 s3-website.eu-west-3.amazonaws.com
 s3-website.us-east-2.amazonaws.com
 
-// Amsterdam Wireless: https://www.amsterdamwireless.nl/
-// Submitted by Imre Jonk <hostmaster@amsterdamwireless.nl>
-amsw.nl
-
 // Amune : https://amune.org/
 // Submitted by Team Amune <cert@amune.org>
 t3l3p0rt.net


### PR DESCRIPTION
This reverts commit 1e3d816c08debd4474b1c192b3660b4c331f8a85.
The domain amsw.nl is no longer in use and now belongs to a party that
is not affiliated with Amsterdam Wireless.

The original PR that was used for PSL inclusion can be found here: https://github.com/publicsuffix/list/pull/929