### PR TITLE
Add `translated.page`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10837,6 +10837,10 @@ myasustor.com
 // Submitted by Sam Smyth <devloop@atlassian.com>
 cdn.prod.atlassian-dev.net
 
+// Authentick UG (haftungsbeschränkt) : https://authentick.net
+// Submitted by Lukas Reschke <lukas@authentick.net>
+translated.page
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---



Description of Organization
====

Organization Website: https://dilingual.com/

I am the Managing Director of Authentick GmbH, we have developed a SaaS platform ("Dilingual") for translating existing websites into other languages.

The platform works as a reverse proxy for the original website and automatically extracts all relevant strings and allows the customer to change any translation using a web interface.

The workflow here is:

1. Page admin creates project for `example.com`
2. The platform provisions `example-com.translated.page` and populates it with the content from `example.com`
3. Optional: Admins can use bring their own domain (e.g. `example.fr` instead of `example-com.translated.page`)
4. Users can visit the translated website by visiting either the domain from step 2 or step 3.


Reason for PSL Inclusion
====

We would like to be included in the PSL for cookie security. The translated.page subdomains are serving content by different users. Note that we do not request inclusion due to any third-party issues. We are for example serving all requests using a wildcard certificate.

We confirm that we hold registration for this domain for longer than 2 years. The current registration is expiring in 2025, and we have processes and tooling in place to ensure this domain keeps being under our control.


DNS Verification via dig
=======


```
dig +short TXT _psl.translated.page
"https://github.com/publicsuffix/list/pull/1478"
```


make test
=========

I have ran the tests and everything was passing.