### PR TITLE
Add `rocky.page`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13207,6 +13207,10 @@ itcouldbewor.se
 // Submitted by Jennifer Herting <jchits@rit.edu>
 git-pages.rit.edu
 
+// Rocky Enterprise Software Foundation : https://resf.org
+// Submitted by Neil Hanlon <neil@resf.org>
+rocky.page
+
 // Rusnames Limited: http://rusnames.ru/
 // Submitted by Sergey Zotov <admin@rusnames.ru>
 биз.рус


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Organization Website: https://resf.org | https://rockylinux.org

The Rocky Enterprise Software Foundation is a not-for-profit Software Foundation, whose primary project is Rocky Linux, a free community distribution downstream of Red Hat Enterprise Linux. I am a Team Lead for Infrastructure and a member of the Core Special Interest Group within Rocky Linux.

Reason for PSL Inclusion
====

The RESF project Rocky Linux intends to host an instance of Gitlab Pages from our installation at https://git.rockylinux.org - with the `rocky.page` domain as the mask URL for all projects. There will be no public access to use these domains, except by contributors to the project who have signed agreements on the proper use of the services, so they will not be abused. The primary purpose of the gitlab pages installation will be to provide a static content hosting location for contributors to Special Interest groups such that they may host wikis and landing pages for themselves.

The domain rocky.page is registered for at least two years, and we confirm intent to continue to have the domain registered for greater than one year, subsequent to our addition to the PSL.

DNS Verification via dig
=======

```
dig +short TXT @liv.ns.cloudflare.com _psl.rocky.page
"https://github.com/publicsuffix/list/pull/1491"
```

make test
=========

Tests ran and completed successfully.


