### PR TITLE
Add `ktistory.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12564,6 +12564,10 @@ js.org
 kaas.gg
 khplay.nl
 
+// Kakao : https://www.kakaocorp.com/
+// Submitted by JaeYoong Lee <cec@kakaocorp.com>
+ktistory.com
+
 // Kapsi : https://kapsi.fi
 // Submitted by Tomi Juntunen <erani@kapsi.fi>
 kapsi.fi


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place
* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
* [x] This request was _not_ submitted with the objective of working around other third-party limits
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
* [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting
---
* [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---
Description of Organization
====

Organization Website: https://www.kakaocorp.com/page/?lang=ENG&tab=all

We are Kakao who provides all online services such as mobile messenger, search, and blog in Korea.
(https://www.kakaocorp.com/page/service/service)
* Mobile messenger : kakaotalk
https://www.kakaocorp.com/page/service/service/KakaoTalk?lang=ENG&tab=all
* Search engine / News service
https://www.kakaocorp.com/page/service/service/Daum?lang=ENG&tab=all

Among them, this request is for the following blog service:
* Blog : tistory
https://www.kakaocorp.com/page/service/service/Tistory
(https://www.tistory.com/)
Users can use  a subdomain of tistory.com. For example, blog-a.tistory.com, blog-b.tistory.com, etc. can be used. 
Users can also alias their own domains for their blogs.

Reason for PSL Inclusion
====
Tistory provides individual blog services in the form of `https://{blog name}.tistory.com`.
And we use Adsense ads to provide revenue for our users. Recently, there is a warning that ads for all users of Tistory are blocked due to violation of the policy of [The Better Ads Standards] (https://www.betterads.org/standards/) on a specific blog.
The problem is that individual blogs are registered under `tistory.com`, and if any one of those blogs has a problem, the biggest problem is that it affects `tistory.com`.
So we apply psl to prevent individual blogs from affecting the whole blog of tistory.

ktistory.com is a domain to check the service impact before implementing the above. If there is no problem with the service through this verification, tistory.com will also be added.

Also, the expiry date of the domain is more than two years away, and I will also keep the domain and _psl. 
Domain Expiration Date: 2025-12-07

DNS Verification via dig
=======
dig +short TXT _psl.ktistory.com
"https://github.com/publicsuffix/list/pull/1493"

make test
=========
I've run make test and I can confirm everything passes.