### PR TITLE
Update #1385: add `mytabit.co.il` & `mytabit.com` for IOS PCM / FB solution

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13466,6 +13466,8 @@ direct.quickconnect.to
 // Tabit Technologies Ltd. : https://tabit.cloud/
 // Submitted by Oren Agiv <oren@tabit.cloud>
 tabitorder.co.il
+mytabit.co.il
+mytabit.com
 
 // TAIFUN Software AG : http://taifun-software.de
 // Submitted by Bjoern Henke <dev-server@taifun-software.de>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

**Note**
This request is similar to our previous PR, with 2 new additional domains - mytabit.co.il and mytabit.com (that intend to replace original tabitorder.co.il sub-domains system of ours in the future): https://github.com/publicsuffix/list/pull/1385

Description of Organization
====
Organization Website: https://tabit.cloud/

Tabit is a restaurant ordering system as well as a point-of-sale that streamlines restaurant operations and extends sales opportunities.
Our 360 degree integrated ecosystem connects every aspect of the customer experience: from guest management, customer ordering and kitchen productivity to tableside payment, bringing efficiencies to every interaction point.

Reason for PSL Inclusion
====
This is a pull request in response to the Apple iOS 14.5 change that affected Facebook Pixel tracking functionality for the domain(s) in the change, and we seek to resolve the impacts to the best of our ability to do so.  Both Apple and Facebook support Public Suffix List for Private Click Measurement and Aggregated Event Measurement respectively.
- We have reviewed the wiki here outlining the PSL and understand what it is and is not.
- We have reviewed this matter with the team at Facebook, we are now fully aware about the consequences to the change we are requesting as it relates to cookies or other services, and choose to proceed in submitting this PR. We understand that despite reviewing the matter with Facebook, Facebook cannot control which use cases get accepted to the PSL
- We understand that there is not any urgency and should this PR be merged to include our requested change, that there is no control over the timing of this change being updated downstream in browsers, libraries, certificate authorities or other systems or processes that incorporate the PSL.
- We understand that if we later want to back out this change, there is also no guarantee that this will occur in a rapid fashion due to the same lack of control over browser, library, certificate authority, or other system or process changes. 

Our clients (restaurants) are attempting to set up conversion tracking, and therefore inclusion in the public suffix list is required for the cookie security with changes in iOS 14.5 per https://www.facebook.com/business/help/331612538028890?id=428636648170202

Our restaurants online ordering websites are sub-domains in https://*.mytabit.co.il/ as well as https://*.mytabit.com/

DNS Verification via dig
====
```
dig +short TXT _psl.mytabit.co.il
"https://github.com/publicsuffix/list/pull/1499"

dig +short TXT _psl.mytabit.com
"https://github.com/publicsuffix/list/pull/1499"
```

make test
====
Tests have been executed successfully.



