### PR TITLE
add support for scaleway subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13230,6 +13230,40 @@ sandcats.io
 logoip.de
 logoip.com
 
+// Scaleway : https://www.scaleway.com/
+// Submitted by Rémy Léone <rleone@scaleway.com>
+baremetal.scw.cloud
+fr-par-1.baremetal.scw.cloud
+fr-par-2.baremetal.scw.cloud
+fr-par2.baremetal.scw.cloud
+nl-ams1.baremetal.scw.cloud
+fnc.fr-par.scw.cloud
+functions.fnc.fr-par.scw.cloud
+k8s.fr-par.scw.cloud
+nodes.k8s.fr-par.scw.cloud
+lb.fr-par.scw.cloud
+s3.fr-par.scw.cloud
+s3-website.fr-par.scw.cloud
+whm.fr-par.scw.cloud
+priv.instances.scw.cloud
+pub.instances.scw.cloud
+k8s.scw.cloud
+k8s.nl-ams.scw.cloud
+nodes.k8s.nl-ams.scw.cloud
+lb.nl-ams.scw.cloud
+s3.nl-ams.scw.cloud
+s3-website.nl-ams.scw.cloud
+whm.nl-ams.scw.cloud
+k8s.pl-waw.scw.cloud
+nodes.k8s.pl-waw.scw.cloud
+lb.pl-waw.scw.cloud
+s3.pl-waw.scw.cloud
+s3-website.pl-waw.scw.cloud
+scalebook.scw.cloud
+smartlabeling.scw.cloud
+dedibox.fr
+mutu.online.net
+
 // schokokeks.org GbR : https://schokokeks.org/
 // Submitted by Hanno Böck <hanno@schokokeks.org>
 schokokeks.net

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13239,7 +13239,6 @@ fnc.fr-par.scw.cloud
 functions.fnc.fr-par.scw.cloud
 k8s.fr-par.scw.cloud
 nodes.k8s.fr-par.scw.cloud
-lb.fr-par.scw.cloud
 s3.fr-par.scw.cloud
 s3-website.fr-par.scw.cloud
 whm.fr-par.scw.cloud
@@ -13248,13 +13247,11 @@ pub.instances.scw.cloud
 k8s.scw.cloud
 k8s.nl-ams.scw.cloud
 nodes.k8s.nl-ams.scw.cloud
-lb.nl-ams.scw.cloud
 s3.nl-ams.scw.cloud
 s3-website.nl-ams.scw.cloud
 whm.nl-ams.scw.cloud
 k8s.pl-waw.scw.cloud
 nodes.k8s.pl-waw.scw.cloud
-lb.pl-waw.scw.cloud
 s3.pl-waw.scw.cloud
 s3-website.pl-waw.scw.cloud
 scalebook.scw.cloud

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13232,7 +13232,9 @@ logoip.com
 
 // Scaleway : https://www.scaleway.com/
 // Submitted by Rémy Léone <rleone@scaleway.com>
-*.baremetal.scw.cloud
+fr-par-1.baremetal.scw.cloud
+fr-par-2.baremetal.scw.cloud
+nl-ams-1.baremetal.scw.cloud
 fnc.fr-par.scw.cloud
 functions.fnc.fr-par.scw.cloud
 k8s.fr-par.scw.cloud

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13258,7 +13258,6 @@ s3-website.pl-waw.scw.cloud
 scalebook.scw.cloud
 smartlabeling.scw.cloud
 dedibox.fr
-mutu.online.net
 
 // schokokeks.org GbR : https://schokokeks.org/
 // Submitted by Hanno Böck <hanno@schokokeks.org>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13232,11 +13232,7 @@ logoip.com
 
 // Scaleway : https://www.scaleway.com/
 // Submitted by Rémy Léone <rleone@scaleway.com>
-baremetal.scw.cloud
-fr-par-1.baremetal.scw.cloud
-fr-par-2.baremetal.scw.cloud
-fr-par2.baremetal.scw.cloud
-nl-ams1.baremetal.scw.cloud
+*.baremetal.scw.cloud
 fnc.fr-par.scw.cloud
 functions.fnc.fr-par.scw.cloud
 k8s.fr-par.scw.cloud


### PR DESCRIPTION
- [x] Description of Organization
- [x] Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

# Reason for this Pull Request

(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: <https://www.scaleway.com>

I'm Rémy Léone, I work as an Engineering Manager and cloud developer advocate at Scaleway.
Scaleway is a cloud provider that offers different kinds of managed services for our customers.
Some of those services include DNS functionality: for instance, a DNS record will be added to a load balancer or an instance server.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Product | Sub-domains available for customers | Examples
-- | -- | -- 
baremetal | - `fr-par-1.baremetal.scw.cloud` <br/> - `fr-par-2.baremetal.scw.cloud` <br/> - `nl-ams1.baremetal.scw.cloud` <br/> - `dedibox.fr` | - `11111111-1111-1111-1111-111111111111.fr-par-2.baremetal.scw.cloud` </br> - `sd-167474.dedibox.fr` 
serverless | - `fnc.fr-par.scw.cloud` <br/> - `functions.fnc.fr-par.scw.cloud` | https://fdsfdsnhuqkasr-sdfsfsfsd.functions.fnc.fr-par.scw.cloud 
k8s | - `nodes.k8s.fr-par.scw.cloud` <br/> - `nodes.k8s.nl-ams.scw.cloud` <br/> - `nodes.k8s.pl-waw.scw.cloud` <br/> - `k8s.scw.cloud` <br/> - `k8s.fr-par.scw.cloud` <br/> - `k8s.nl-ams.scw.cloud` <br/> - `k8s.pl-waw.scw.cloud` | `11111111-1111-1111-1111-111111111111.api.k8s.fr-par.scw.cloud` <br/> - `*.11111111-1111-1111-1111-111111111111.nodes.k8s.fr-par.scw.cloud` 
Instance | - `priv.instances.scw.cloud` <br/> - `pub.instances.scw.cloud` | `11111111-1111-1111-1111-111111111111.pub.instances.scw.cloud` <br/> `11111111-1111-1111-1111-111111111111.priv.instances.scw.cloud` 
LB | - `lb.fr-par.scw.cloud` <br/> - `lb.nl-ams.scw.cloud` <br/> - `lb.pl-waw.scw.cloud` | `51-158-57-55.lb.fr-par.scw.cloud` 
AI | - `smartlabeling.scw.cloud` <br/> - `scalebook.scw.cloud` | `11111111-1111-1111-1111-111111111111.smartlabeling.scw.cloud` 
object storage | - `s3.fr-par.scw.cloud` <br/> - `s3.nl-ams.scw.cloud` <br/> - `s3.pl-waw.scw.cloud` <br/> - `s3-website.fr-par.scw.cloud` <br/> - `s3-website.nl-ams.scw.cloud` <br/> - `s3-website.pl-waw.scw.cloud` | - https://dumpremy.s3.fr-par.scw.cloud 
Webhosting | - `whm.fr-par.scw.cloud` <br/> - `whm.nl-ams.scw.cloud` | - `pf-1000.whm.fr-par.scw.cloud` <br/> - `pf-1001.whm.fr-par.scw.cloud` <br/> - `ns1.whm.fr-par.scw.cloud` <br/> - `ns2.whm.fr-par.scw.cloud`

We tried in the past to be included: https://github.com/publicsuffix/list/pull/684 

DNS Verification via dig
=======

```
dig +short TXT _psl.fr-par-1.baremetal.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.fr-par-2.baremetal.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.nl-ams-1.baremetal.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.fnc.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.functions.fnc.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.k8s.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.nodes.k8s.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.lb.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.s3.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.s3-website.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.whm.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.priv.instances.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.pub.instances.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.k8s.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.k8s.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.nodes.k8s.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.lb.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.s3.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.s3-website.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.whm.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.k8s.pl-waw.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.nodes.k8s.pl-waw.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.lb.pl-waw.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.s3.pl-waw.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.s3-website.pl-waw.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.scalebook.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.smartlabeling.scw.cloud
"https://github.com/publicsuffix/list/pull/1507"

dig +short TXT _psl.dedibox.fr
"https://github.com/publicsuffix/list/pull/1507"
```

make test
=========

I've run the test using:

```
brew install icu4c
echo 'export PATH="/usr/local/opt/icu4c/bin:$PATH"' >> ~/.zshrc
echo 'export PATH="/usr/local/opt/icu4c/sbin:$PATH"' >> ~/.zshrc
export LDFLAGS="-L/usr/local/opt/icu4c/lib"
export CPPFLAGS="-I/usr/local/opt/icu4c/include"
make test
```

The tests run fine.