### PR TITLE
Remove WapBlog Suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13694,15 +13694,6 @@ v.ua
 // Submitted by Masayuki Note <masa@blade.wafflecell.com>
 wafflecell.com
 
-// WapBlog.ID : https://www.wapblog.id
-// Submitted by Fajar Sodik <official@wapblog.id>
-idnblogger.com
-indowapblog.com
-bloger.id
-wblog.id
-wbq.me
-fastblog.net
-
 // WebHare bv: https://www.webhare.com/
 // Submitted by Arnold Hendriks <info@webhare.com>
 *.webhare.dev


### PR DESCRIPTION
Citing an announcement from the official WapBlog.ID blog, WapBlog will stop providing services on February 23, 2022.

Closing full link:
https://official.wapblog.id/pengumuman-wapblog-id.xhtml

Previous PR:
#1111 