### PR TITLE
Update `.cy` per request from nic.cy in Issue 1516

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -865,6 +865,7 @@ gov.cx
 
 // cy : http://www.nic.cy/
 // Submitted by registry Panayiotou Fotia <cydns@ucy.ac.cy>
+// namespace policies URL https://www.nic.cy/portal//sites/default/files/symfonia_gia_eggrafi.pdf
 cy
 ac.cy
 biz.cy
@@ -872,10 +873,9 @@ com.cy
 ekloges.cy
 gov.cy
 ltd.cy
-name.cy
+mil.cy
 net.cy
 org.cy
-parliament.cy
 press.cy
 pro.cy
 tm.cy


### PR DESCRIPTION
This adds link to URL of reg policies that articulates the TLD structure within .cy
https://www.nic.cy/portal//sites/default/files/symfonia_gia_eggrafi.pdf

Further detail is present in #1516 sunmitted by @panayiotou

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig `(request from NIC works around this, see below)`
* [X] Run Syntax Checker (make test) `passed`

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 

  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third-party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---

Description of Organization
====

Organization Website: [https://nic.cy](https://nic.cy)

Reason for PSL Inclusion
====

This is being submitted to address the request in Issue #1516 to reflect the updated .cy namespace.

@weppos or @sleevi I won't be able to approve, would you please peek at this and approve?  
See Issue #1516 as it has documented some of the approval tests and validation steps typically included with approving requests.  I articulate them below, but it may contain any additional dialog with the submitting party.

DNS Verification via dig
=======

The NIC has not placed DNS records in the zones.

*Instead of DNS Verification*, the validation review was:

- Go to the IANA.org db, 
- Locate the respective TLD (`.cy`) and open that reference page on [IANA.org](https://www.iana.org/domains/root/db/cy.html)
- Click on the 'Registration Services' link on that page, listed as [https://nic.cy](https://nic.cy)
- Click on the Registration Policies link on that page, listed as [https://www.nic.cy/portal//sites/default/files/symfonia_gia_eggrafi.pdf](https://www.nic.cy/portal//sites/default/files/symfonia_gia_eggrafi.pdf)
- Page 1 of that document, sourced via full chain, top down, is the list of namespace within .cy
