### PR TITLE
Remove `couk.me` and `ukco.me` from private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11860,8 +11860,6 @@ app.os.stg.fedoraproject.org
 
 // FearWorks Media Ltd. : https://fearworksmedia.co.uk
 // submitted by Keith Fairley <domains@fearworksmedia.co.uk>
-couk.me
-ukco.me
 conn.uk
 copro.uk
 hosp.uk


### PR DESCRIPTION
We have decided to not renew the domains couk.me and ukco.me, and instead we are focusing on our .uk domains. I wanted to clean these two .me domains up so they aren't left on the list.

These two domains are currently in the expiration grace period, and we would appreciate their removal from the list.

Many thanks.