### PR TITLE
Add Oliv'r free domains: cluster.ws & wip.la

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12913,6 +12913,11 @@ static.observableusercontent.com
 // Submitted by Andrew Sampson <andrew@ulterius.io>
 cya.gg
 
+// Oliv'r: https://github.com/Olivr/free-domain
+// Submitted by Romain Barissat <domains@olivr.com>
+wip.la
+cluster.ws
+
 // OMG.LOL : <https://omg.lol>
 // Submitted by Adam Newbold <adam@omg.lol>
 omg.lol


### PR DESCRIPTION
* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 

  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third-party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Oliv'r contributes to several open source projects. Some of them need to have a domain name at hand. Unfortunately, many developers don't; as a result, Oliv'r has put **cluster.ws** and **wip.la** at the disposition of the community under the repository https://github.com/Olivr/free-domain.

Organization Website: https://github.com/Olivr

Reason for PSL Inclusion
====

Currently a developer wanting to manage their DNS with Cloudflare cannot do so.
Moreover, these suffixes are to be used as TLD's. Including them in the PSL will ensure that they will be treated as such by as many services as possible (Cloudflare, browser cookies, let's encrypt, etc.)

DNS Verification via dig
=======

```
dig +short TXT _psl.cluster.ws
"https://github.com/publicsuffix/list/pull/1523"
```

```
dig +short TXT _psl.wip.la
"https://github.com/publicsuffix/list/pull/1523"
```

make test
=========

```sh
PASS: test-is-public-all
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```


