### PR TITLE
Revises policy links for `.ac` `.io` `.sh` to address issue #1527

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9,7 +9,7 @@
 
 // ===BEGIN ICANN DOMAINS===
 
-// ac : https://en.wikipedia.org/wiki/.ac
+// ac : http://nic.ac/rules.htm
 ac
 com.ac
 edu.ac
@@ -1366,7 +1366,7 @@ info
 int
 eu.int
 
-// io : http://www.nic.io/rules.html
+// io : http://www.nic.io/rules.htm
 // list of other 2nd level tlds ?
 io
 com.io
@@ -6036,7 +6036,7 @@ gov.sg
 edu.sg
 per.sg
 
-// sh : http://www.nic.sh/registrar.html
+// sh : http://nic.sh/rules.htm
 sh
 com.sh
 net.sh


### PR DESCRIPTION
This corrects the registration rules links (commented) for .ac, .io and .sh as the BERO has changed (Back End Registry Operator) to address the issue reported in #1527 

