### PR TITLE
Fix spelling errors in PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10823,7 +10823,7 @@ onavstack.net
 *.advisor.ws
 
 // AZ.pl sp. z.o.o: https://az.pl
-// Submited by Krzysztof Wolski <krzysztof.wolski@home.eu>
+// Submitted by Krzysztof Wolski <krzysztof.wolski@home.eu>
 ecommerce-shop.pl
 
 // b-data GmbH : https://www.b-data.io
@@ -12168,7 +12168,7 @@ günstigbestellen.de
 günstigliefern.de
 
 // Hakaran group: http://hakaran.cz
-// Submited by Arseniy Sokolov <security@hakaran.cz>
+// Submitted by Arseniy Sokolov <security@hakaran.cz>
 fin.ci
 free.hr
 caa.li
@@ -12211,7 +12211,7 @@ development.run
 ravendb.run
 
 // home.pl S.A.: https://home.pl
-// Submited by Krzysztof Wolski <krzysztof.wolski@home.eu>
+// Submitted by Krzysztof Wolski <krzysztof.wolski@home.eu>
 homesklep.pl
 
 // Hong Kong Productivity Council: https://www.hkpc.org/
@@ -12321,7 +12321,7 @@ to.leg.br
 pixolino.com
 
 // Internet-Pro, LLP: https://netangels.ru/
-// Submited by Vasiliy Sheredeko <piphon@gmail.com>
+// Submitted by Vasiliy Sheredeko <piphon@gmail.com>
 na4u.ru
 
 // iopsys software solutions AB : https://iopsys.eu/
@@ -12344,7 +12344,7 @@ iserv.dev
 iobb.net
 
 // Jelastic, Inc. : https://jelastic.com/
-// Submited by Ihor Kolodyuk <ik@jelastic.com>
+// Submitted by Ihor Kolodyuk <ik@jelastic.com>
 mel.cloudlets.com.au
 cloud.interhostsolutions.be
 users.scale.virtualcloud.com.br
@@ -12960,7 +12960,7 @@ orsites.com
 operaunite.com
 
 // Oursky Limited : https://authgear.com/, https://skygear.io/
-// Submited by Authgear Team <hello@authgear.com>, Skygear Developer <hello@skygear.io>
+// Submitted by Authgear Team <hello@authgear.com>, Skygear Developer <hello@skygear.io>
 authgear-staging.com
 authgearapps.com
 skygearapp.com


### PR DESCRIPTION
This pr fixes 6 spelling mistakes in the PSL, allowing for better automatic parsing.

Fixes #1529 

Guidelines
=========
* [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting


make test
=========

- [X] Run on wsl2/Ubuntu


