### PR TITLE
Add `musician.io` - updates Staclar entry from #1331

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13499,6 +13499,8 @@ stackhero-network.com
 // Staclar : https://staclar.com
 // Submitted by Matthias Merkel <matthias.merkel@staclar.com>
 novecore.site
+// Submitted by Q Misell <q@staclar.com>
+musician.io
 
 // staticland : https://static.land
 // Submitted by Seth Vincent <sethvincent@gmail.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13497,10 +13497,10 @@ srht.site
 stackhero-network.com
 
 // Staclar : https://staclar.com
-// Submitted by Matthias Merkel <matthias.merkel@staclar.com>
-novecore.site
 // Submitted by Q Misell <q@staclar.com>
 musician.io
+// Submitted by Matthias Merkel <matthias.merkel@staclar.com>
+novecore.site
 
 // staticland : https://static.land
 // Submitted by Seth Vincent <sethvincent@gmail.com>


### PR DESCRIPTION
__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Organization Website: https://staclar.com/

Staclar provides a variety of services to digital music companies, record labels and independent artists.

Reason for PSL Inclusion
====

For the same reasons as #1331. This will be hosting sites for third party artists under it, and will be an additional option to users in addition to the already included novecore.site. The main reason for inclusion is cookie security. We confirm we'll maintain the required registration term for this domain.

DNS Verification via dig
=======

<TODO>

```
dig TXT _psl.musician.io
_psl.musician.io.       600     IN      TXT     "https://github.com/publicsuffix/list/pull/1532"
```

make test
=========

✅ Test was sucessful

