### PR TITLE
Remove no.com from PSL due to new owner/different use than subdomain registry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10973,7 +10973,6 @@ za.com
 ar.com
 hu.com
 kr.com
-no.com
 qc.com
 uy.com
 


### PR DESCRIPTION
#1533 