### PR TITLE
Add: `campaign.gov.uk` (updates #1512)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11987,6 +11987,7 @@ independent-panel.uk
 independent-review.uk
 public-inquiry.uk
 royal-commission.uk
+campaign.gov.uk
 service.gov.uk
 
 // CDDO : https://www.gov.uk/guidance/get-an-api-domain-on-govuk


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting
 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---



Description of Organization
====

Organization Website: [GDS](https://www.gov.uk/government/organisations/government-digital-service)

The Government Digital Service is department of the Cabinet Office, we are responsible for the management and delegation for many of the core domains used within the UK Government.

Further details: https://www.gov.uk/service-manual/technology/managing-domain-names

The following domain(s), submitted for inclusion on the public suffix list, are within GDS' control:
- campaign.gov.uk

I am Stephen Ford, Tech Lead/Senior Site Reliability Engineer, technical representative of the team which manages these domains within GDS and the Cabinet Office.  Organisational approval for this request has been granted by the GDS Policy and Engagement Team, and senior technical engineers.


Reason for PSL Inclusion
====
We need these domains to be in the public suffix list as each subdomain is specific to one distinct UK Government related agency or group, meaning cookie isolation is required between all.

Some cloud providers also use the public suffix list to allow use of said domains on their platform.  As each user agency or group of one of the sub domains is free to chose their provider, inclusion on the list will allow them to have a free choice of provider.

All of these domains are registered for over 2 years, they will exist for perpetuity as they exist to convey information to the public on behalf of the UK Government.


DNS Verification via dig
=======
```
dig +short TXT _psl.campaign.gov.uk
"https://github.com/publicsuffix/list/pull/1536"
```


make test
=========

The test has run and passed.