### PR TITLE
Remove `ac.ru`, `edu.ru`, `gov.ru`, `int.ru`, `mil.ru`, `test.ru` (revises #815, ref: #1395)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11124,15 +11124,6 @@ co.no
 webhosting.be
 hosting-cluster.nl
 
-// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
-// Submitted by George Georgievsky <gug@cctld.ru>
-ac.ru
-edu.ru
-gov.ru
-int.ru
-mil.ru
-test.ru
-
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
 dyn.cosidns.de


### PR DESCRIPTION
* [ ] Description of Organization

Coordination Center for TLD RU (CC for TLD RU) is administrator of national top level domains .RU and .РФ (national registry). Organization Website: https://cctld.ru/

* [ ] Reason for PSL Inclusion

Domains ac.ru, edu.ru, gov.ru, int.ru, mil.ru, test.ru need to be removed from Public section. There are no support directly registering third level domains by internet users.