### PR TITLE
Add `lolipopmc.jp`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12160,6 +12160,7 @@ weblike.jp
 whitesnow.jp
 zombie.jp
 heteml.net
+lolipopmc.jp
 
 // GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
 // Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12054,6 +12054,7 @@ shop.ro
 
 // GMO Pepabo, Inc. : https://pepabo.com/
 // Submitted by Hosting Div <admin@pepabo.com>
+lolipop.io
 angry.jp
 babyblue.jp
 babymilk.jp
@@ -12098,7 +12099,6 @@ greater.jp
 hacca.jp
 heavy.jp
 her.jp
-heteml.net
 hiho.jp
 hippy.jp
 holy.jp
@@ -12111,8 +12111,6 @@ kill.jp
 kilo.jp
 kuron.jp
 littlestar.jp
-lolipop.io
-lolipopmc.jp
 lolitapunk.jp
 lomo.jp
 lovepop.jp
@@ -12161,6 +12159,8 @@ watson.jp
 weblike.jp
 whitesnow.jp
 zombie.jp
+heteml.net
+lolipopmc.jp
 
 // GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
 // Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12111,6 +12111,7 @@ kill.jp
 kilo.jp
 kuron.jp
 littlestar.jp
+lolipopmc.jp
 lolitapunk.jp
 lomo.jp
 lovepop.jp
@@ -12160,7 +12161,6 @@ weblike.jp
 whitesnow.jp
 zombie.jp
 heteml.net
-lolipopmc.jp
 
 // GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
 // Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12054,7 +12054,6 @@ shop.ro
 
 // GMO Pepabo, Inc. : https://pepabo.com/
 // Submitted by Hosting Div <admin@pepabo.com>
-lolipop.io
 angry.jp
 babyblue.jp
 babymilk.jp
@@ -12099,6 +12098,7 @@ greater.jp
 hacca.jp
 heavy.jp
 her.jp
+heteml.net
 hiho.jp
 hippy.jp
 holy.jp
@@ -12111,6 +12111,8 @@ kill.jp
 kilo.jp
 kuron.jp
 littlestar.jp
+lolipop.io
+lolipopmc.jp
 lolitapunk.jp
 lomo.jp
 lovepop.jp
@@ -12159,8 +12161,6 @@ watson.jp
 weblike.jp
 whitesnow.jp
 zombie.jp
-heteml.net
-lolipopmc.jp
 
 // GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
 // Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://pepabo.com, https://mc.lolipop.jp

`LOLIPOP! Managed Cloud` is a Web Hosting service, provides by GMO Pepabo, inc.
For more information about `LOLIPOP! Managed Cloud` head over to [our website](https://mc.lolipop.jp/)


Reason for PSL Inclusion
====

We provide every app/website on LOLIPOP! Managed Cloud with its own `lolipopmc.jp` subdomain.
We'd like to be included in the list to improve our cookie security.

GMO Pepabo, Inc. has previously added domains for hosting services.

[Add 105 lolipop.io # 881] (https://github.com/publicsuffix/list/pull/881), [Add 105 lolipop and heteml domains to private section for GMO # 1522] (https://github.com/ publicsuffix / list / pull / 1522)

The purpose of this PR is because the `lolipopmc.jp` domain has also been added to the` LOLIPOP! Managed Cloud`, our hosting service.

DNS Verification via dig
=======

```
dig +short TXT _psl.lolipop.jp
"https://github.com/publicsuffix/list/pull/1522"
```

make test
=========

```
% make test-syntax
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC:
OK
-n test_allowedchars:
OK
-n test_dots:
OK
-n test_duplicate:
OK
-n test_exception:
OK
-n test_punycode:
OK
-n test_section1:
OK
-n test_section2:
OK
-n test_section3:
OK
-n test_section4:
OK
-n test_spaces:
OK
-n test_wildcard:
OK
```
