### PR TITLE
Fix comments delete space and deprecation of io/ioutil

### DIFF
--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -268,7 +267,7 @@ func (d datFile) String() string {
 // data is found within the dat file. An error is returned if the file can't be read
 // or if the gTLD data span can't be found or is invalid.
 func readDatFile(datFilePath string) (*datFile, error) {
-	pslDatBytes, err := ioutil.ReadFile(datFilePath)
+	pslDatBytes, err := os.ReadFile(datFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +338,7 @@ func getData(url string) ([]byte, error) {
 			url, http.StatusOK, resp.StatusCode)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -559,6 +558,6 @@ func main() {
 
 	// Otherwise print nothing to stdout and write the content over the exiting
 	// pslDatFile path we read earlier.
-	err = ioutil.WriteFile(*pslDatFile, []byte(content), 0644)
+	err = os.WriteFile(*pslDatFile, []byte(content), 0644)
 	ifErrQuit(err)
 }

--- a/tools/newgtlds_test.go
+++ b/tools/newgtlds_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -532,7 +531,7 @@ func TestDatFileString(t *testing.T) {
 
 func TestReadDatFile(t *testing.T) {
 	mustWriteTemp := func(t *testing.T, content string) string {
-		tmpfile, err := ioutil.TempFile("", "dat")
+		tmpfile, err := os.CreateTemp("", "dat")
 		if err != nil {
 			t.Fatalf("Failed to create temp file: %v", err)
 		}


### PR DESCRIPTION
Description
=========
I would like to contact you regarding modifications to the PSL creation script.

* fix comments
* delete space end of line
* deprecation of "io/ioutil"

This is not a feature that must be modified.
Please use this information for future revisions.

Thanks again for your community.

make test
=========

```
% pwd
/Users/makoto/github/list/tools
git remote -v
origin	https://github.com/gongqi-zhen/list.git (fetch)
origin	https://github.com/gongqi-zhen/list.git (push)
upstream	https://github.com/publicsuffix/list.git (fetch)
upstream	https://github.com/publicsuffix/list.git (push)
% go version
go version go1.18.1 darwin/amd64
% go test
PASS
ok  	github.com/publicsuffix/list/tools	0.483s%
```
![workflow-passed](https://user-images.githubusercontent.com/26854289/164408858-997d7c6b-c555-48bb-96fa-a4b3fccedf21.png)

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->


