### PR TITLE
Add Hash Hackers TLDs under `telegram.ind.in`, `iii.ind.in` and `hashhackers.win`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12303,9 +12303,6 @@ conf.se
 hs.zone
 hs.run
 
-// Hashbang : https://hashbang.sh
-hashbang.sh
-
 // Hash Hackers : https://hashhackers.com
 // Submitted by TheFirstSpeedster <hostmaster@hashhackers.com>
 hashhackers.win
@@ -12317,6 +12314,9 @@ telegram.ind.in
 *.c.telegram.ind.in
 *.g.telegram.ind.in
 *.u.telegram.ind.in
+
+// Hashbang : https://hashbang.sh
+hashbang.sh
 
 // Hasura : https://hasura.io
 // Submitted by Shahidh K Muhammed <shahidh@hasura.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1197,18 +1197,6 @@ gov.gy
 net.gy
 org.gy
 
-// Hash Hackers : https://hashhackers.com
-// Submitted by TheFirstSpeedster <hostmaster@hashhackers.com>
-hashhackers.win
-*.app.hashhackers.win
-iii.ind.in
-*.app.iii.ind.in
-telegram.ind.in
-*.b.telegram.ind.in
-*.c.telegram.ind.in
-*.g.telegram.ind.in
-*.u.telegram.ind.in
-
 // hk : https://www.hkirc.hk
 // Submitted by registry <hk.tech@hkirc.hk>
 hk
@@ -12317,6 +12305,18 @@ hs.run
 
 // Hashbang : https://hashbang.sh
 hashbang.sh
+
+// Hash Hackers : https://hashhackers.com
+// Submitted by TheFirstSpeedster <hostmaster@hashhackers.com>
+hashhackers.win
+*.app.hashhackers.win
+iii.ind.in
+*.app.iii.ind.in
+telegram.ind.in
+*.b.telegram.ind.in
+*.c.telegram.ind.in
+*.g.telegram.ind.in
+*.u.telegram.ind.in
 
 // Hasura : https://hasura.io
 // Submitted by Shahidh K Muhammed <shahidh@hasura.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1197,6 +1197,18 @@ gov.gy
 net.gy
 org.gy
 
+// Hash Hackers : https://hashhackers.com
+// Submitted by TheFirstSpeedster <hostmaster@hashhackers.com>
+hashhackers.win
+*.app.hashhackers.win
+iii.ind.in
+*.app.iii.ind.in
+telegram.ind.in
+*.b.telegram.ind.in
+*.c.telegram.ind.in
+*.g.telegram.ind.in
+*.u.telegram.ind.in
+
 // hk : https://www.hkirc.hk
 // Submitted by registry <hk.tech@hkirc.hk>
 hk

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12305,8 +12305,6 @@ hs.run
 
 // Hash Hackers : https://hashhackers.com
 // Submitted by TheFirstSpeedster <hostmaster@hashhackers.com>
-hashhackers.win
-*.app.hashhackers.win
 iii.ind.in
 *.app.iii.ind.in
 telegram.ind.in
@@ -12314,6 +12312,8 @@ telegram.ind.in
 *.c.telegram.ind.in
 *.g.telegram.ind.in
 *.u.telegram.ind.in
+hashhackers.win
+*.app.hashhackers.win
 
 // Hashbang : https://hashbang.sh
 hashbang.sh


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->
====

Organization Website: https://hashhackers.com

<!--
Please tell us who you are and represent (i.e. individual, 
non-profit volunteer, engineer at a business) and what you 
do (i.e. DynDNS, Hosting, etc)

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.

Provide at least three sentences, the more the better, but
avoid the promotional stuff about how wonderful it is.
-->

Hash Hackers makes free service websites to make the internet better, we are a group of people who build open source software's, contribute to them, deploy free software's on Servers based on donations and free products of different organizations. We're building new products now which will require each user to have their own domain name (eg. Telegram Web).

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

* First Reason is Cloudflare and other DNS hosting providers like Netlify. Every user who will make app from our network will need to use services like Netlify, Cloudflare Workers, Cloudflare Pages, Vercel or Heroku. Their Free plan are enough to run our currently [available](https://gitlab.com/ParveenBhadooOfficial/Google-Drive-Index) and upcoming apps.
* For Telegram we are building an Application Network for users to have their own web version of Telegram, making it easier to use for every user at their own host privately. Also we are making it possible to each user to have their own domain which they can share in public to link their profile, channel or groups.
* Using different domains to deploy different project on different locations. eg. our Rapidleech Deployments. (Not Possible on sub-domains when there are large numbers of users and IP addresses of Rapidleech host providers change time to time.)
* These all should cover the Cookie Security, Let's Encrypt issuance, Cloudflare/Netlify Host issues.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

````
dig +short TXT _psl.hashhackers.win
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.*.app.hashhackers.win
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.iii.ind.in
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.*.app.iii.ind.in
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.telegram.ind.in
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.*.b.telegram.ind.in
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.*.c.telegram.ind.in
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.*.g.telegram.ind.in
"https://github.com/publicsuffix/list/pull/1562"
dig +short TXT _psl.*.u.telegram.ind.in
"https://github.com/publicsuffix/list/pull/1562"
````

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

I ran the test but couldn't understand much about it.
````
D:\test\list>D:\GnuWin32\bin\make.exe
cd linter;                                \
          ./pslint_selftest.sh;                     \
          ./pslint.py ../public_suffix_list.dat;
The system cannot find the path specified.
make: *** [test-syntax] Error 1
````