### PR TITLE
Add `ts.io` and others to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10889,8 +10889,9 @@ bitbucket.io
 
 // bitinflow GbR : https://bitinflow.com
 // Submitted by René Preuß <rene@bitinflow.com>
-ts.io
+bitinflow.space
 maid.build
+ts.io
 
 // Blackbaud, Inc. : https://www.blackbaud.com
 // Submitted by Paul Crowder <paul.crowder@blackbaud.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10887,6 +10887,11 @@ bnr.la
 // Submitted by Andy Ortlieb <aortlieb@atlassian.com>
 bitbucket.io
 
+// bitinflow GbR : https://bitinflow.com
+// Submitted by René Preuß <rene@bitinflow.com>
+ts.io
+maid.build
+
 // Blackbaud, Inc. : https://www.blackbaud.com
 // Submitted by Paul Crowder <paul.crowder@blackbaud.com>
 blackbaudcdn.net


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

---
__For Private section requests that are submitting entries for domains that match their organization website's primary domain:__

``` 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinitely long while.
```
(Link: [about propogation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

We bitinflow GbR offer various internet services for our customers. Customers have the possibility to use their own domains or use *.ts.io (get.ts.io), *.maid.build, *.bitinflow.space, therefore we would like to have these domains in the public suffix list and have it as eTLD.

.ts.io domain became available in 2015 as the original domain for fans of teamspeak, games, and all things of fun. Already 60,000 domains have been registered by 35,000 customers. Anyone can use a .ts.io to express themselves online.

Since 2022 we offer .maid.build domains for managed Kubernetes clusters who using our cli tool (https://github.com/ghostzero/maid), so that users can deploy their applications without the need of registering a custom domain.

Furthermore, we offer customers webspace using the domain .bitinflow.space with which customers can create their own website.

I'm the co-founder and CTO of bitinflow GbR. I administrate the ns1.bitinflow.com & ns2.bitinflow.com, which resolves all domains.

We have ensured that the domains have a sufficient expiration date:

- `.ts.io` expires on 2032-02-06
- `.bitinflow.space` expires on 2025-01-06
- `.maid.build` expires on 2024-05-05

Reason for PSL Inclusion
====

Preparing and securing a technical infrastructure for customer services on *.ts.io, *.maid.build & *.bitinflow.space domains. As we allow customers to host their websites on a shared domain there is a security risk if they can write and read cookies intended solely for other customers. 

We want services like Cloudflare & Let's Encrypt to accept our domains as eTLDs, so that restrictions are lifted. In other words, it should be allowed to register a domain like example.ts.io on Cloudflare and rate limits of aaa.ts.io should not affect bbb.ts.io on Let's Encrypt.

DNS Verification via dig
=======

```
dig +short TXT _psl.ts.io
"https://github.com/publicsuffix/list/pull/1565"
```

```
dig +short TXT _psl.maid.build
"https://github.com/publicsuffix/list/pull/1565"
```

```
dig +short TXT _psl.bitinflow.space
"https://github.com/publicsuffix/list/pull/1565"
```

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->

```
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```