### PR TITLE
Add `builder.code.com`, `stg-builder.code.com`, and `dev-builder.code.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13389,6 +13389,12 @@ rocky.page
 спб.рус
 я.рус
 
+// Salesforce.com, Inc. https://salesforce.com/
+// Submitted by Michael Biven <mbiven@salesforce.com>
+builder.code.com
+dev-builder.code.com
+stg-builder.code.com
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowlegements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale responsse below.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains 
that match their organization website's primary domain, please 
understand that this can have impacts that may not match the 
desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure 
that you read the affectation and propagation expectations, 
that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable 
to control when or if browsers or other parties using the 
PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Organization Website: https://engineering.salesforce.com/

Code Builder is a web-based IDE available to Salesforce customers. With the engineering team owning the development and management of the platform serving the Code Builder product. 

Further details: https://developer.salesforce.com/blogs/2020/12/an-update-on-code-builder-and-the-future-of-tooling-at-salesforce

The following domain(s), submitted for inclusion on the public suffix list, are within our control:
- builder.code.com
- dev-builder.code.com
- stg-builder.code.com

I am Michael Biven, Software Engineering PMTS, representative of the engineering team that owns the Code Builder platform.

Reason for PSL Inclusion
====

Each of these domains will have subdomains specific to a unique web-based IDE created for a specific person working who is associated with a specific Salesforce customer. We require cookie isolation between each subdomain, providing isolation between all of the IDEs. 

I can confirm we'll maintain the required registration term for the domain. Which is renewed for two years automatically.

DNS Verification via dig
=======

```
$ dig +short TXT _psl.builder.code.com
"https://github.com/publicsuffix/list/pull/1566"

$ dig +short TXT _psl.dev-builder.code.com
"https://github.com/publicsuffix/list/pull/1566"

$ dig +short TXT _psl.stg-builder.code.com
"https://github.com/publicsuffix/list/pull/1566"
```


Results of Syntax Checker (`make test`)
=========

The tests were ran and passed successfully. 
