### PR TITLE
Add `beagleboard.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10871,6 +10871,10 @@ theshop.jp
 shopselect.net
 base.shop
 
+// BeagleBoard.org Foundation : https://beagleboard.org
+// Submitted by Jason Kridner <jkridner@beagleboard.org>
+beagleboard.io
+
 // Beget Ltd
 // Submitted by Lev Nekrasov <lnekrasov@beget.com>
 *.beget.app


### PR DESCRIPTION
# Description of Organization

[BeagleBoard.org Foundation](https://beagleboard.org) is a United States 501(c)3 non-profit corporation supporting education in open source embedded systems. We primarily design open hardware single board computers for use in systems needing real-time capabilities, but are also just generally useful when you want to dedicate a computer to a function. By releasing our designs as open hardware, people are free to make variations and ultimately make real-world products out of their ideas. Our community is mostly made of Linux experts seeking to collaborate and educate in improving access and automation all around us.

# Reason for PSL Inclusion

We've setup a public `gitlab` instance for use by our community at `git.beagleboard.org` and are enabling community members to publish pages on `beagleboard.io` in an attempt to normalize some aspects of contributions. This includes providing places for community members to post project blogs and documentation. We expect 25-50 of our 100,000+ community members to take advantage of this setup, especially contributors to Google Summer of Code.

# DNS verification via dig

```
$ dig +short TXT _psl.beagleboard.io
"https://github.com/publicsuffix/list/pull/1573"
```

# Make test

```
$ make test 2>/dev/null | pastebinit
https://paste.ubuntu.com/p/WBhdzM9wrw/
$ make test 2>/dev/null | tail
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```
