### PR TITLE
add `com.in`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1356,6 +1356,7 @@ edu.in
 res.in
 gov.in
 mil.in
+com.in
 
 // info : https://en.wikipedia.org/wiki/.info
 info

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1344,19 +1344,19 @@ tv.im
 // Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
 in
-co.in
-firm.in
-net.in
-org.in
-gen.in
-ind.in
-nic.in
 ac.in
-edu.in
-res.in
-gov.in
-mil.in
+co.in
 com.in
+edu.in
+firm.in
+gen.in
+gov.in
+ind.in
+mil.in
+net.in
+nic.in
+org.in
+res.in
 
 // info : https://en.wikipedia.org/wiki/.info
 info


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] Results of Syntax Checker (`make test`)

Description of Organization
====

NIXI is a not for profit Organization under section 8 of the Companies Act 2013, and was registered on 19th June, 2003. NIXI was set up for peering of ISP's among themselves for the purpose of routing the domestic traffic within the country, instead of taking it all the way to US/Abroad, thereby resulting in better quality of service (reduced latency) and reduced bandwidth charges for ISP's by saving on International Bandwidth. NIXI is managed and operated on a Neutral basis, in line with the best practices for such initiatives globally.

Organization Website: https://registry.in

Reason for PSL Inclusion
====

Official info from organization's website. Adding just because parsers in different languages can't pick it up properly.

Results of Syntax Checker (`make test`)
=========

```
PASS: test-is-public
PASS: test-is-public-all
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
