### PR TITLE
Add `iservschule.de`, `schulplattform.de`, update IServ GmbH contact information

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12458,9 +12458,11 @@ iopsys.se
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
 
-// IServ GmbH : https://iserv.eu
-// Submitted by Kim-Alexander Brodowski <info@iserv.eu>
+// IServ GmbH : https://iserv.de
+// Submitted by Mario Hoberg <info@iserv.de>
+iservschule.de
 mein-iserv.de
+schulplattform.de
 schulserver.de
 test-iserv.de
 iserv.dev


### PR DESCRIPTION
### Checklist of required steps

  * [x] Description of Organization
  * [x] Reason for PSL Inclusion
  * [x] DNS verification via dig
  * [x] Run Syntax Checker (make test)
  * [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting
 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.


Description of Organization
====

IServ GmbH is a German company providing IT solutions for the educational sector. Our main product is also called IServ. IServ, sometimes referred to as IServ school platform, is an all-in-one solution for the pedagogical side of a school's network. It provides basic functionality like e-mail, file sharing, instant messaging, calendars, a collaborative text editor etc., but also software deployment and an Active Directory domain controller as well as more education oriented features such as special examination modes for local computers and an exercise module.

IServ is currently used by over 5,200 schools primarily in German-speaking regions and manages about 350,000 computers and almost 2,900.000 user accounts.

Organization Website: https://iserv.de/


Reason for PSL Inclusion
====

We deploy IServ on-premise and cloud hosted under unique customer domains. Some IServ installations are hosted on cloud servers, but most of them, except for trial and development servers, have unique domains as well.

For the cloud hosted version of our software, instances may be hosted on subdomains of iservschule.de or schulplattform.de instead of unique domains to reduce cost and management overhead.

To improve (e.g. cookie) security of these installations we seek inclusion of this domain in the public suffix list.
We also use Let's Encrypt and may benefit from inclusion, but we also maintain explicit rate limit exemption with Let's Encrypt directly for that purpose.

Number of users this request is being made to serve: 250,000 - estimate based on current users and users that will stay on a hosted domain instead of registering a custom domain name.

Previous requests:
https://github.com/publicsuffix/list/pull/552
https://github.com/publicsuffix/list/pull/826
https://github.com/publicsuffix/list/pull/996


DNS Verification via dig
=======

```
# dig +short TXT _psl.iservschule.de
"https://github.com/publicsuffix/list/pull/1580"

# dig +short TXT _psl.schulplattform.de
"https://github.com/publicsuffix/list/pull/1580"
```

Results of Syntax Checker (`make test`)
=========

~~~
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
~~~
