### PR TITLE
Updates to NIXI `.in` subspace in ICANN section of PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1374,6 +1374,7 @@ io.in
 me.in
 mil.in
 net.in
+nic.in
 org.in
 pg.in
 post.in

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1346,6 +1346,7 @@ tv.im
 in
 5g.in
 6g.in
+ac.in
 ai.in
 am.in
 bihar.in
@@ -1359,9 +1360,11 @@ coop.in
 cs.in
 delhi.in
 dr.in
+edu.in
 er.in
 firm.in
 gen.in
+gov.in
 gujarat.in
 ind.in
 info.in
@@ -1369,11 +1372,13 @@ int.in
 internet.in
 io.in
 me.in
+mil.in
 net.in
 org.in
 pg.in
 post.in
 pro.in
+res.in
 travel.in
 tv.in
 uk.in

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1344,18 +1344,41 @@ tv.im
 // Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
 in
+5g.in
+6g.in
+ai.in
+am.in
+bihar.in
+biz.in
+business.in
+ca.in
+cn.in
 co.in
+com.in
+coop.in
+cs.in
+delhi.in
+dr.in
+er.in
 firm.in
+gen.in
+gujarat.in
+ind.in
+info.in
+int.in
+internet.in
+io.in
+me.in
 net.in
 org.in
-gen.in
-ind.in
-nic.in
-ac.in
-edu.in
-res.in
-gov.in
-mil.in
+pg.in
+post.in
+pro.in
+travel.in
+tv.in
+uk.in
+up.in
+us.in
 
 // info : https://en.wikipedia.org/wiki/.info
 info


### PR DESCRIPTION
### Checklist of required steps

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] Run Syntax Checker (make test)

**Description of Organization**
===
NIXI is a not for profit Organization under section 8 of the Companies Act 2013, and was registered on 19th June, 2003. NIXI was set up for peering of ISP's among themselves for the purpose of routing the domestic traffic within the country, instead of taking it all the way to US/Abroad, thereby resulting in better quality of service (reduced latency) and reduced bandwidth charges for ISP's by saving on International Bandwidth. NIXI is managed and operated on a Neutral basis, in line with the best practices for such initiatives globally.
Organization Website: https://registry.in/

**Reason for PSL Inclusion**
===
As per info available here - https://registry.in/policies 

Unlimited registrations are available in the following zones.
.in
co.in
net.in
org.in
firm.in
gen.in (general)
ind.in (individuals)
5g.in
6g.in
ai.in
am.in
bihar.in
biz.in
business.in
ca.in
cn.in
com.in
coop.in
cs.in
delhi.in
dr.in
er.in
gujarat.in
info.in
int.in
internet.in
io.in
me.in
pg.in
post.in
pro.in
travel.in
tv.in
uk.in
up.in
us.in
 

Results of Syntax Checker (`make test`)
===
Testsuite summary for libpsl 0.21.1
TOTAL: 5
PASS:  5
SKIP:  0
XFAIL: 0
FAIL:  0
XPASS: 0
ERROR: 0



