### PR TITLE
Add `cloudscale.ch` domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11075,6 +11075,12 @@ pages.dev
 trycloudflare.com
 workers.dev
 
+// cloudscale.ch AG : https://www.cloudscale.ch/
+// Submitted by Gaudenz Steinlin <support@cloudscale.ch>
+cust.cloudscale.ch
+objects.lpg.cloudscale.ch
+objects.rma.cloudscale.ch
+
 // Clovyr : https://clovyr.io
 // Submitted by Patrick Nielsen <patrick@clovyr.io>
 wnext.app


### PR DESCRIPTION
### Checklist of required steps

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [X] This request was _not_ submitted with the objective of working around other third-party limits

  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting
  * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  

Description of Organization
====
cloudscale.ch AG is a Swiss based cloud hosting (IaaS) provider. We offer cloud VMs, an S3-compatible Object Storage and other related services to customers.

Organization Website: https://www.cloudscale.ch/

I'm a System Engineering team lead at cloudscale.ch. 

Reason for PSL Inclusion
====

cust.cloudscale.ch
----

DNS records in this domain are provided as a convenience to our customers for each virtual machine.

I have read the guidelines, and did want to note that we plan to have the format of 1-2-3-4.cust.cloudscale.ch for a virtual machine with an IP address of 1.2.3.4. I understand the guideline prohibiting this as a type of wildcard domain, but I would like to assure the reviewer that we will only be serving these records for public IP addresses within ranges under our ownership, and that each IP is reserved for a customer's virtual machine.

I believe the intent of this entry in the guidelines is to prohibit hosting a DNS service for IP addresses which are not under our control, and therefore may be shared among multiple untrusted parties -- this is not the case here. Please correct me if I have misinterpreted this guideline.

objects.lpg.cloudscale.ch / objects.rma.cloudscale.ch
----

These are the primary domain names for our S3-compatible object storage. We support virtual-host style bucket addressing. This means customers can access their bucket under the name `<bucket_name>.objects.(lpg|rma).cloudscale.ch`. This is a common addressing scheme for S3-compatible object storage systems. Other such services are already listed in the PSL, including `s3.amazonaws.com`, `s3.teckids.org` and Scaleway's object storage (multiple domains). 

DNS Verification via dig
=======

```
dig +short TXT _psl.cust.cloudscale.ch
"https://github.com/publicsuffix/list/pull/1589"
```

```
dig +short TXT _psl.objects.lpg.cloudscale.ch
"https://github.com/publicsuffix/list/pull/1589"
```
```
dig +short TXT _psl.objects.rma.cloudscale.ch
"https://github.com/publicsuffix/list/pull/1589"
```

Results of Syntax Checker (`make test`)
=========

All tests passed