### PR TITLE
AWS Submissions to the Public Suffix List - Month of 2022-07

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10804,6 +10804,52 @@ s3-website.eu-west-2.amazonaws.com
 s3-website.eu-west-3.amazonaws.com
 s3-website.us-east-2.amazonaws.com
 
+// AWS Cloud9 : https://aws.amazon.com/cloud9/
+// Submitted by: AWS Security <psl-maintainers@amazon.com>
+// Reference: 2b6dfa9a-3a7f-4367-b2e7-0321e77c0d59
+vfs.cloud9.af-south-1.amazonaws.com
+webview-assets.cloud9.af-south-1.amazonaws.com
+vfs.cloud9.ap-east-1.amazonaws.com
+webview-assets.cloud9.ap-east-1.amazonaws.com
+vfs.cloud9.ap-northeast-1.amazonaws.com
+webview-assets.cloud9.ap-northeast-1.amazonaws.com
+vfs.cloud9.ap-northeast-2.amazonaws.com
+webview-assets.cloud9.ap-northeast-2.amazonaws.com
+vfs.cloud9.ap-northeast-3.amazonaws.com
+webview-assets.cloud9.ap-northeast-3.amazonaws.com
+vfs.cloud9.ap-south-1.amazonaws.com
+webview-assets.cloud9.ap-south-1.amazonaws.com
+vfs.cloud9.ap-southeast-1.amazonaws.com
+webview-assets.cloud9.ap-southeast-1.amazonaws.com
+vfs.cloud9.ap-southeast-2.amazonaws.com
+webview-assets.cloud9.ap-southeast-2.amazonaws.com
+vfs.cloud9.ca-central-1.amazonaws.com
+webview-assets.cloud9.ca-central-1.amazonaws.com
+vfs.cloud9.eu-central-1.amazonaws.com
+webview-assets.cloud9.eu-central-1.amazonaws.com
+vfs.cloud9.eu-north-1.amazonaws.com
+webview-assets.cloud9.eu-north-1.amazonaws.com
+vfs.cloud9.eu-south-1.amazonaws.com
+webview-assets.cloud9.eu-south-1.amazonaws.com
+vfs.cloud9.eu-west-1.amazonaws.com
+webview-assets.cloud9.eu-west-1.amazonaws.com
+vfs.cloud9.eu-west-2.amazonaws.com
+webview-assets.cloud9.eu-west-2.amazonaws.com
+vfs.cloud9.eu-west-3.amazonaws.com
+webview-assets.cloud9.eu-west-3.amazonaws.com
+vfs.cloud9.me-south-1.amazonaws.com
+webview-assets.cloud9.me-south-1.amazonaws.com
+vfs.cloud9.sa-east-1.amazonaws.com
+webview-assets.cloud9.sa-east-1.amazonaws.com
+vfs.cloud9.us-east-1.amazonaws.com
+webview-assets.cloud9.us-east-1.amazonaws.com
+vfs.cloud9.us-east-2.amazonaws.com
+webview-assets.cloud9.us-east-2.amazonaws.com
+vfs.cloud9.us-west-1.amazonaws.com
+webview-assets.cloud9.us-west-1.amazonaws.com
+vfs.cloud9.us-west-2.amazonaws.com
+webview-assets.cloud9.us-west-2.amazonaws.com
+
 // Amune : https://amune.org/
 // Submitted by Team Amune <cert@amune.org>
 t3l3p0rt.net


### PR DESCRIPTION
Description of Organization
====

Amazon Web Services is an infrastructure-as-a-service cloud computing provider.
More information about AWS is availble on our website:
[What is AWS?](https://aws.amazon.com/what-is-aws/)

**Organization Website:**  
[AWS Homepage](https://aws.amazon.com)

Reason for PSL Inclusion
====

These features/services have been identified by AWS Security and AWS service
teams as supporting different distinct customers/resources across shared
DNS suffixes. Adding these suffixes to the PSL is expected to improve the
security posture of customers using our services.

**Number of users this request is being made to serve:**  
These changes are expected to impact all customers using these AWS services.
This includes both AWS-internal and external customers. Specific user counts
for these listed features/services are not publicly available.

Services/Features in PR:
====

- AWS Cloud9 - Application Preview, Webviews

DNS Verification via dig
=======

<details>
<summary>Click here</summary>

```
$> dig +short TXT _psl.vfs.cloud9.af-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.af-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-northeast-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-northeast-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-northeast-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-northeast-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-northeast-3.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-northeast-3.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-southeast-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-southeast-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ap-southeast-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ap-southeast-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.ca-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.ca-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.eu-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.eu-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.eu-north-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.eu-north-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.eu-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.eu-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.eu-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.eu-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.eu-west-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.eu-west-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.eu-west-3.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.eu-west-3.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.me-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.me-south-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.sa-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.sa-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.us-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.us-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.us-east-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.us-east-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.us-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.us-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.vfs.cloud9.us-west-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
$> dig +short TXT _psl.webview-assets.cloud9.us-west-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/1590"
```

</details>

Results of Syntax Checker (`make test`)
=========
<details>
<summary>Click here</summary>

```
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:763: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:763: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:763: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:763: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:381: warning: file `version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=[snip]/public_suffix_list.dat --with-psl-testfile=[snip]/tests/tests.txt && make -s clean && make -s check -j4
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc

```

</details>