### PR TITLE
Add `autocode.dev`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10859,6 +10859,10 @@ cdn.prod.atlassian-dev.net
 // Submitted by Lukas Reschke <lukas@authentick.net>
 translated.page
 
+// Autocode : https://autocode.com
+// Submitted by Jacob Lee <jacob@autocode.com>
+autocode.dev
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.net


### PR DESCRIPTION
### Checklist of required steps

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [X] This request was _not_ submitted with the objective of working around other third-party limits
  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Autocode is an API development, management, and hosting platform. We host projects for hundreds of thousands of developers, and have an online IDE that enables anyone to deploy live code in seconds without setup. We specialize in connecting ecosystems such as Discord, Stripe, and Airtable. Common use-cases include Discord bots, Slack alerts, webhooks, and, importantly for this request, static websites.

My name is Jacob Lee, and I'm the co-founder and CTO of Autocode.

Organization Website: https://autocode.com

Reason for PSL Inclusion
====

We currently host user code under the domain `api.stdlib.com` (which we previously added to the PSL under the name "Standard Library"). We rebranded the company to Autocode, and want to switch our primary domain to `autocode.dev` to match our new name.

Each user on our platform receives a unique hostname with the base domain where we host their deployed APIs. Though many APIs on the platform act as either JSON responses or webhook endpoints, a significant number of developers on the platform utilize our hosting capabilities to host static content (APIs can return any Content-Type, including `text/html`).

We would like cookie isolation at the subdomain level (user.autocode.dev). Inclusion of `autocode.dev` in the PSL would mitigate the risk of users setting and accessing cross site cookies that apply to other users' subdomains via the base api.stdlib.com domain.

As an example (and to verify success), I've created a page that attempts set a cookie named "xdomaincookie" for the base domain `autocode.dev`, and checks to see if the cookie was successfully set. It will return a success message once api.stdlib.com has been added to the Public Suffix List.
https://jacoblee.autocode.dev/psltest@autocodedev/

Number of users this request is being made to serve: Currently over 600,000


DNS Verification via dig
=======

```
dig +short TXT _psl.autocode.dev
"https://github.com/publicsuffix/list/pull/1617"
```

Results of Syntax Checker (`make test`)
=========

I ran the tests and they passed successfully.
