### PR TITLE
Add `*.c.ts.net.`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13754,6 +13754,7 @@ taifun-dns.de
 // Submitted by David Anderson <danderson@tailscale.com>
 beta.tailscale.net
 ts.net
+*.c.ts.net
 
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting
  * [x] (note) The affirmation regarding entries that match an organization website's primary domain is N/A here, as Tailscale's primary domain is tailscale.com and isn't being submitted for inclusion. Nonetheless, we understand and accept the documented downstream propagation and rollback properties of the PSL.

Description of Organization
====

Organization Website: https://www.tailscale.com

Tailscale is software that creates a private overlay mesh network between users' devices, secured by the WireGuard VPN protocol.

Among other features, Tailscale gives users a subdomain within a shared DNS namespace. This is primarily to enable obtaining TLS certificates from Let's Encrypt, to appease browser insistence on TLS connections even over our VPN (understandably since the browser doesn't know or care about the security properties of the IP transport).

I'm an engineer at Tailscale, and am making this submission on behalf of my employer. "We" throughout this PR refers to Tailscale as a whole, with me affirming things on the company's behalf.

Reason for PSL Inclusion
====

Expansion of #1453. In working on getting our DNS/TLS features out of beta, we realized that we need multiple namespace silos, rather than just the single one that the existing `ts.net` entry describes. This is because we have multiple independent instances of the Tailscale service, and each of those instances needs its own namespace to assign to end-users.

As in #1453, the purpose of PSL inclusion is purely browser cookie security. Each of our entries describes a namespace of user-controlled subdomains, across which cookies should not propagate. We have no other purpose for PSL inclusion. In particular, we already have custom issuance limits with Let's Encrypt directly, this PR is not aimed at circumventing their rate limits.

Currently, we have 3 additional namespace silos that need cookie isolation, with 3 more in the works. To minimize the burden on the PSL, these and all future silos will exist under `<silo name>.c.ts.net`, with user-controlled domains being `<name>.<silo name>.c.ts.net`, e.g. `danderson.eu.c.ts.net` or `site19.scp.c.ts.net`.

As in #1453, we understand and reaffirm that `ts.net` will maintain a registration term longer than 2 years to remain in the PSL. Domain expiration review and renewal is part of our quarterly compliance process. As of this submission, ts.net expires in 2028. Likewise, we'll maintain `_psl` DNS records for all our PSL entries.

Number of users this request is being made to serve: 20,000-100,000. This is an estimate since we aren't using these new DNS names yet. When we start using them, they'll cover ~20,000 users immediately, growing over time as we add more silos of interest to users (e.g. silos with data locality guarantees). 100k is my guess of what we might see in the next year or so, not an upper bound.

DNS Verification via dig
=======

```
dig +short TXT _psl.c.ts.net
"https://github.com/publicsuffix/list/pull/1618"
```

Results of Syntax Checker (`make test`)
=========

`make test` reports all test passing happily.