### PR TITLE
Add `cloudil.com` domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11203,6 +11203,22 @@ cloudns.pro
 cloudns.pw
 cloudns.us
 
+// CloudIL: https://cloudil.co.il
+// Submitted by Igor Kravchenko <psl@cloudil.co.il>
+cloudil.com
+apigw.cloudil.com
+containers.cloudil.com
+docapi.serverless.cloudil.com
+functions.cloudil.com
+functions6.cloudil.com
+gitlab.cloudil.com
+logging.cloudil.com
+mdb.cloudil.com
+s3.cloudil.com
+storage.cloudil.com
+website.cloudil.com
+ydb.serverless.cloudil.com
+
 // CNPY : https://cnpy.gdn
 // Submitted by Angelo Gladding <angelo@lahacker.net>
 cnpy.gdn
@@ -14167,21 +14183,5 @@ bss.design
 basicserver.io
 virtualserver.io
 enterprisecloud.nu
-
-// CloudIL: https://cloudil.co.il
-// Submitted by Igor Kravchenko <psl@cloudil.co.il>
-cloudil.com
-apigw.cloudil.com
-containers.cloudil.com
-docapi.serverless.cloudil.com
-functions.cloudil.com
-functions6.cloudil.com
-gitlab.cloudil.com
-logging.cloudil.com
-mdb.cloudil.com
-s3.cloudil.com
-storage.cloudil.com
-website.cloudil.com
-ydb.serverless.cloudil.com
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14168,4 +14168,20 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// CloudIL: https://cloudil.co.il
+// Submitted by Igor Kravchenko <psl@cloudil.co.il>
+cloudil.com
+storage.cloudil.com
+website.cloudil.com
+s3.cloudil.com
+functions.cloudil.com
+functions6.cloudil.com
+containers.cloudil.com
+apigw.cloudil.com
+logging.cloudil.com
+docapi.serverless.cloudil.com
+ydb.serverless.cloudil.com
+mdb.cloudil.com
+gitlab.cloudil.com
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11208,16 +11208,16 @@ cloudns.us
 cloudil.com
 apigw.cloudil.com
 containers.cloudil.com
-docapi.serverless.cloudil.com
 functions.cloudil.com
 functions6.cloudil.com
 gitlab.cloudil.com
 logging.cloudil.com
 mdb.cloudil.com
 s3.cloudil.com
+docapi.serverless.cloudil.com
+ydb.serverless.cloudil.com
 storage.cloudil.com
 website.cloudil.com
-ydb.serverless.cloudil.com
 
 // CNPY : https://cnpy.gdn
 // Submitted by Angelo Gladding <angelo@lahacker.net>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14171,17 +14171,17 @@ enterprisecloud.nu
 // CloudIL: https://cloudil.co.il
 // Submitted by Igor Kravchenko <psl@cloudil.co.il>
 cloudil.com
-storage.cloudil.com
-website.cloudil.com
-s3.cloudil.com
+apigw.cloudil.com
+containers.cloudil.com
+docapi.serverless.cloudil.com
 functions.cloudil.com
 functions6.cloudil.com
-containers.cloudil.com
-apigw.cloudil.com
-logging.cloudil.com
-docapi.serverless.cloudil.com
-ydb.serverless.cloudil.com
-mdb.cloudil.com
 gitlab.cloudil.com
+logging.cloudil.com
+mdb.cloudil.com
+s3.cloudil.com
+storage.cloudil.com
+website.cloudil.com
+ydb.serverless.cloudil.com
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowlegements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale responsse below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->
CloudIL is an Israeli-based venture founded by Yandex — one of the leading tech companies in Europe — in collaboration with local partners. The mission of CloudIL is to deliver a high-performing cloud platform comparable to global hyperscalers in quality, and with unprecedented levels of security for full compliance with local laws and requirements for data privacy, access and control.

Organization Website: 
<!-- 
Provide the website address of 
the Org as a full URL ie https://example.com 
-->

https://cloudil.com

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the mannner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->
As a part of a service, we provide data storage for our customers, that can be used to deviler content and to host simple static websites (similar to AWS S3).

Here is the list of locations available for our customers to host there own content:

https://storage.cloudil.com/<bucket_name>/**
https://<bucket_name>.website.cloudil.com/**


Number of users this request is being made to serve:
<!--
Identify if this is current or an estimate.
-->
More 10000

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

dig +short TXT _psl.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.apigw.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.containers.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.docapi.serverless.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.functions.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.functions6.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.gitlab.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.logging.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.mdb.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.s3.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.storage.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.website.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

dig +short TXT _psl.ydb.serverless.cloudil.com
"https://github.com/publicsuffix/list/pull/1620"

Results of Syntax Checker (`make test`)
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->



```
make test
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:765: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:383: warning: file `version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/home/slipko/list/public_suffix_list.dat --with-psl-testfile=/home/slipko/list/tests/tests.txt && make -s clean && make -s check -j4
./configure: line 13519: gl_VISIBILITY: command not found
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

