### PR TITLE
Names.of.London is no longer operating the service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12975,25 +12975,6 @@ cust.retrosnub.co.uk
 // Submitted by Paulus Schoutsen <infra@nabucasa.com>
 ui.nabu.casa
 
-// Names.of.London : https://names.of.london/
-// Submitted by James Stevens <registry[at]names.of.london> or <publiclist[at]jrcs.net>
-pony.club
-of.fashion
-in.london
-of.london
-from.marketing
-with.marketing
-for.men
-repair.men
-and.mom
-for.mom
-for.one
-under.one
-for.sale
-that.win
-from.work
-to.work
-
 // Net at Work Gmbh : https://www.netatwork.de
 // Submitted by Jan Jaeschke <jan.jaeschke@netatwork.de>
 cloud.nospamproxy.com


### PR DESCRIPTION
# Names.of.London is no longer operating a sub-domain service on the domains previously registered - all have been removed

Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowlegements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps

* [ X ] Description of Organization
* [ X ] Robust Reason for PSL Inclusion
* [ X ] DNS verification via dig
* [ X ] Run Syntax Checker (make test)

* [ N/A ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [ X ] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [ X ] This request was _not_ submitted with the objective of working around other third-party limits

  * [ X ] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [ X ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

 * [ X ] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====
Names.of.London is no longer trading

Organization Website: 
Names.of.London is no longer trading

Reason for PSL Exclusion
====
Names.of.London is no longer trading

Number of users this request is being made to serve:
N/A

DNS Verification via dig
=======
Most of these domains no longer resolve or are sent to parking services.

Results of Syntax Checker (`make test`)
=========
lines removed, not added - test passed
