### PR TITLE
Remove `gwiddle.co.uk`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13841,10 +13841,6 @@ telebit.app
 telebit.io
 *.telebit.xyz
 
-// The Gwiddle Foundation : https://gwiddlefoundation.org.uk
-// Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
-gwiddle.co.uk
-
 // Thingdust AG : https://thingdust.com/
 // Submitted by Adrian Imboden <adi@thingdust.com>
 *.firenet.ch


### PR DESCRIPTION
I am not the original submitter, however it appears that the domain gwiddle.co.uk is now held by a malicious actor. Accordingly, I think it's better to remove this entry than for it to remain. [The Gwiddle Foundation has been removed from the UK's charity register](https://register-of-charities.charitycommission.gov.uk/charity-search/-/charity-details/5099459/charity-overview) and no longer exists.

The tests are passing:

```
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
[...]
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

See also #1637.