### PR TITLE
Removing myravendb.com domain that expired and is not used

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12447,7 +12447,6 @@ herokussl.com
 // Hibernating Rhinos
 // Submitted by Oren Eini <oren@ravendb.net>
 ravendb.cloud
-myravendb.com
 ravendb.community
 ravendb.me
 development.run


### PR DESCRIPTION
The `myravendb.com` domain is no longer used by us and should probably be removed from this list.
I'm the person who original asked to add this domain.

Previous PR that added that is: https://github.com/publicsuffix/list/pull/535

```
$ dig myravendb.com

; <<>> DiG 9.16.1-Ubuntu <<>> myravendb.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 9421
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
```