### PR TITLE
Add activetrail.biz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10658,6 +10658,10 @@ graphox.us
 // Submitted by Craig Jellick <domains@acorn.io>
 *.on-acorn.io
 
+// ActiveTrail: https://www.activetrail.biz/
+// Submitted by Ofer Kalaora <postmaster@activetrail.com>
+activetrail.biz
+
 // Adobe : https://www.adobe.com/
 // Submitted by Ian Boston <boston@adobe.com> and Lars Trieloff <trieloff@adobe.com>
 adobeaemcloud.com


### PR DESCRIPTION
Adding activetrail.biz

 
Description of Organization
====
* [X] Description of Organization
ActiveTrail (https://www.activetrail.com/) provides marketing solutions for business owners for the past 18 years.
The platforms allows you to communicate with your customers using various channels such as Email, SMS, WhatsApp, Popups etc'.
As part of the platform, we provide a web page builder solution (hosting and publishing) for our customers using the https://activetrail.biz/ domain.

Reason for PSL Inclusion
====
* [X] Reason for PSL Inclusion
Each subdomain is dedicated to a separate customer, each customer is a separate business with his own pixels and events.
The customers wish to configure pixel conversion events on the eTLD+1 assigned to them, they cannon verify the eTLD as it belongs to us and cannot be verified by more than one account.

DNS Verification via dig
=======
* [X] DNS verification via dig

make test
=========
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

* [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  
* [X] This request was _not_ submitted with the objective of working around other third-party limits

* [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms

* [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting

* [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  

*reference PR:  https://github.com/publicsuffix/list/pull/1541