### PR TITLE
Add `f5.si`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10897,6 +10897,10 @@ appudo.net
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
+// Aquapal : https://aquapal.net/
+// Submitted by Aki Ueno <admin@aquapal.net>
+f5.si
+
 // ASEINet : https://www.aseinet.com/
 // Submitted by Asei SEKIGUCHI <mail@aseinet.com>
 user.aseinet.ne.jp


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Aquapal hosts "[DDNS Now](https://f5.si/)", a free dynamic DNS service.
Users can obtain a subdomain "*.f5.si" and host websites, game servers, etc. on that subdomain.

My name is Aki Ueno, and I'm the founder and CTO of Aquapal.

Organization Website: https://aquapal.net/

Reason for PSL Inclusion
====

Our dynamic DNS service is designed to allow registration on a subdomain basis.
This means that each website on a subdomain is independent.
For security, cookies must be separated between independent sites.

"f5.si" domain has been managed by Aquapal since 2013 and will be managed similarly for the next 2+ years.
The domain currently has a registration expiration date of 2030-06-28.

Number of users this request is being made to serve: Currently over 40,000


DNS Verification via dig
=======

```
dig +short TXT _psl.f5.si
"https://github.com/publicsuffix/list/pull/1664"
```

Results of Syntax Checker (`make test`)
=========
All tests are passing.
