### PR TITLE
Add `SoftEther.net` Dynamic DNS Service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13715,6 +13715,12 @@ atl.jelastic.vps-host.net
 njs.jelastic.vps-host.net
 ric.jelastic.vps-host.net
 
+// SoftEther.net Dynamic DNS Service: https://www.softether.net/
+// Submitted by Daiyuu Nobori <softether-ddns-admin@softether.net>
+softether.net
+v4.softether.net
+v6.softether.net
+
 // Sony Interactive Entertainment LLC : https://sie.com/
 // Submitted by David Coles <david.coles@sony.com>
 playstation-cloud.com


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---



Description of Organization
====

Organization Website: 
https://www.softether.net/
https://www.softether.org/

Hello. We provide the SoftEther DDNS service for free of charge to any registered users worldwide since 2013. As described on the [softether.net](https://www.softether.net/) web page this service allows anyone to register a unique hostname (subdomain) under the `softether.net` domain with associated IPv4 and IPv6 address. Some users use this their DDNS subdomains to operate VPN servers, and other users use it to run original web servers. We have three parent domains: (1) `softether.net`, (2) `v4.softether.net` and (3) `v6.softether.net`. (1) allows both IPv4 hosts (A and AAAA records). (2) allows only IPv4 hosts (A records). (3) allow only IPv6 hosts (AAAA records).


Reason for PSL Inclusion
====

Since many users operate individual and independent VPN servers and web servers in this DDNS service under the `softether.net` domain, it is important that web browsers recognize DDNS parent domains correctly as public domains for security reasons (e.g. prevent sharing cookies).

[https://www.google.com/search?q=site%3Asoftether.net](https://www.google.com/search?q=site%3Asoftether.net)

Number of users this request is being made to serve:
6,863,193 registered hosts on December 18, 2022.
The history of growing number of hosts is published in the following URL:
[https://www.softether.net/](https://www.softether.net/)


DNS Verification via dig
=======

```
$ dig +short TXT _psl.softether.net
"https://github.com/publicsuffix/list/pull/100"
$ dig +short TXT _psl.v4.softether.net
"https://github.com/publicsuffix/list/pull/100"
$ dig +short TXT _psl.v6.softether.net
"https://github.com/publicsuffix/list/pull/100"
```


Results of Syntax Checker (`make test`)
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.1
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```


