### PR TITLE
Add `torun.pl`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13008,6 +13008,9 @@ netlify.app
 // Submitted by Alan Shreve <alan@ngrok.com>
 ngrok.io
 
+// Nicolaus Copernicus University in Torun - MSK TORMAN (https://www.man.torun.pl)
+torun.pl
+
 // Nimbus Hosting Ltd. : https://www.nimbushosting.co.uk/
 // Submitted by Nicholas Ford <nick@nimbushosting.co.uk>
 nh-serv.co.uk
@@ -13875,9 +13878,6 @@ tlon.network
 // Submitted by Antoine Beaupré <anarcat@torproject.org
 torproject.net
 pages.torproject.net
-
-// TORMAN geographical domain (https://www.man.torun.pl/oferta/domena/)
-torun.pl
 
 // TownNews.com : http://www.townnews.com
 // Submitted by Dustin Ward <dward@townnews.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13876,6 +13876,9 @@ tlon.network
 torproject.net
 pages.torproject.net
 
+// TORMAN geographical domain (https://www.man.torun.pl/oferta/domena/)
+torun.pl
+
 // TownNews.com : http://www.townnews.com
 // Submitted by Dustin Ward <dward@townnews.com>
 bloxcms.com


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

The Nicolaus Copernicus University in Toruń was established in 1945 and is one of Poland's largest universities. It is composed of 17 faculties, including 3 dedicated to medicine at the Collegium Medicum UMK in Bydgoszcz. It offers education in over 100 fields of study, is a research university and has state-of-the-art research infrastructure. The Metropolitan Area Network in Torun (MSK TORMAN) is governed by the university.
MSK TORMAN not only manages the university's network, but is also telecommunication operator who offers a range of services. One of them is the possibility of registering subdomains in the regional domain "torun.pl".

Organization Website: 
https://www.man.torun.pl

Reason for PSL Inclusion
====

The "torun.pl" is a regional domain for institutions, enterprises and people associated with the city of Toruń.
Subdomains (*.torun.pl) are registered by independent 3rd parties. Main reason for PSL inclusion is to increase the level of security (Cookie Security).


Number of users this request is being made to serve:
around 1000


DNS Verification via dig
=======

dig +short TXT _psl.torun.pl 
"https://github.com/publicsuffix/list/pull/1684"

Results of Syntax Checker (`make test`)
=========

> PASS: libpsl_icu_fuzzer
> PASS: libpsl_icu_load_dafsa_fuzzer
> PASS: libpsl_icu_load_fuzzer
> ============================================================================
> Testsuite summary for libpsl 0.21.2
> ============================================================================
> # TOTAL: 3
> # PASS:  3
> # SKIP:  0
> # XFAIL: 0
> # FAIL:  0
> # XPASS: 0
> # ERROR: 0
> ============================================================================
> Making check in tests
>   CC       test-is-public.o
>   CC       test-is-public-all.o
>   CC       test-is-cookie-domain-acceptable.o
>   CC       test-is-public-builtin.o
>   CC       test-registrable-domain.o
>   CCLD     test-is-cookie-domain-acceptable
>   CCLD     test-is-public-builtin
>   CCLD     test-is-public
>   CCLD     test-is-public-all
>   CCLD     test-registrable-domain
> PASS: test-is-public-builtin
> PASS: test-is-public
> PASS: test-is-cookie-domain-acceptable
> PASS: test-registrable-domain
> PASS: test-is-public-all
> ============================================================================
> Testsuite summary for libpsl 0.21.2
> ============================================================================
> # TOTAL: 5
> # PASS:  5
> # SKIP:  0
> # XFAIL: 0
> # FAIL:  0
> # XPASS: 0
> # ERROR: 0
> ============================================================================
