### PR TITLE
Add `adoveo.com` to public suffix list Referring to pervious pull request #1495 

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10657,6 +10657,10 @@ adobeaemcloud.com
 adobeaemcloud.net
 *.dev.adobeaemcloud.com
 
+// Adoveo : https://adoveo.coom
+// submitted by Umapathi Tallapragada <umapathi@adoveo.com>
+adoveo.com
+
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl


### PR DESCRIPTION
<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.

If there are third party limits that the PR seeks to overcome, those
must be listed.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort) 
-->
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting


 * [x] * Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
Adoveo is a digital marketing company which provides the creation of interactive landing pages for high end brands in FMCG, Retail and charity.
Organization Website: https://adoveo.com
This request is related to our pervious pull request#1495 

Reason for PSL Inclusion
====
Adoveo platform helps users to create their own websites under subdomains.

Main reason we would like to be included in the list is to provide cookie security for our users. As well, our users need to be able to issue Let's Encrypt certificates for their subdomains.

We previously made pull request for solving FB issues, but it's not the case anymore.

DNS Verification via dig
=======
dig +short TXT adoveo.com
"https://github.com/publicsuffix/list/pull/1685"

make test
=========
Tests passed OK.
