### PR TITLE
Add GitHub Action to deploy site on list update

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,16 @@
+---
+name: deploy website
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  upload-website:
+    uses: publicsuffix/publicsuffix.org/.github/workflows/deploy-site.yaml@master
+    secrets: inherit


### PR DESCRIPTION
This PR adds a GitHub Action that uses the workflow from `publicsuffix/publicsuffix.org` and deploys the list and website if commits are pushed to `master` or if triggered manually.

Signed-off-by: Robert Müller <rmuller@mozilla.com>
