### PR TITLE
Add Akamai third-level domains to the PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10699,6 +10699,8 @@ aivencloud.com
 // Akamai : https://www.akamai.com/
 // Submitted by Akamai Team <publicsuffixlist@akamai.com>
 akadns.net
+com.akadns.net
+net.akadns.net
 akamai.net
 akamai-staging.net
 akamaiedge.net
@@ -10708,11 +10710,27 @@ akamaihd-staging.net
 akamaiorigin.net
 akamaiorigin-staging.net
 akamaized.net
+com.akamaized.net
+mdc.akamaized.net
+net.akamaized.net
 akamaized-staging.net
+com.akamaized-staging.net
+mdc.akamaized-staging.net
+net.akamaized-staging.net
 edgekey.net
+com.edgekey.net
+test.edgekey.net
 edgekey-staging.net
+com.edgekey-staging.net
+test.edgekey-staging.net
 edgesuite.net
+com.edgesuite.net
+mdc.edgesuite.net
+net.edgesuite.net
 edgesuite-staging.net
+com.edgesuite-staging.net
+mdc.edgesuite-staging.net
+net.edgesuite-staging.net
 
 // alboto.ca : http://alboto.ca
 // Submitted by Anton Avramov <avramov@alboto.ca>


### PR DESCRIPTION
*This reopens PR #1640 as requested  (after a subset of it was incorporated in PR #1701)*

### Checklist of required steps

* [X] Description of Organization
* [X] Reason for PSL Inclusion
* [ ] DNS verification via dig --- _(not possible, see below)_
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL in order to work around those limits or 
restrictions.
-->
  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale responsse below.
-->

  * [X] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predicatable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Akamai started as one of the largest Content Delivery Networks (CDNs)
in the world.  Today we provide a wide range of security, performance,
compute, and content delivery services for many of the world's largest
companies.

This PR is being submitted by a Fellow and Chief Architect at Akamai
who has been at Akamai for over 20 years.  The addition of these
domains to the Public Suffix List has been reviewed through our
Architecture Review and Change Management processes and has
received executive-level approval.


<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Organization Website:
https://www.akamai.com/
<!-- 
Provide the website address of 
the Org as a full URL ie https://example.com 
-->

Reason for PSL Inclusion
====

The domains included in this change are primarily associated with
content delivery and/or load balancing services.  They are domains
where multiple independent customers/tenants are serving content with
a shared public suffix, and thus where cross-hostname cookie sharing
is not desirable from a security or end-user privacy perspective.
Some of these domains are covered by Akamai-managed wildcard TLS
certificates.

For example, some of these are common patterns where
"foo" and "bar" are hostnames from unrelated customers:

* "foo.mdc.akamaized.net" and "bar.mdc.akamaized.net"
* "example.foo.com.edgesuite.net" and "example.bar.com.edgesuite.net"
* "foo.com.akadns.net" and "bar.com.akadns.net"
* "foo.test.edgekey.net" and "bar.test.edgekey.net"

We published a customer-facing public blog post explaining
to our customers why we are adding these domains to the PSL:

https://www.akamai.com/blog/developers/adding-akamai-shared-domains-to-the-public-suffix-list

Note that the "-staging" and "test.edgekey.net" domains are
all customer-facing environments which have the same
properties of multiple customers sharing a suffix.

These domains are also used as CNAME targets.  For example,
customers may CNAME "www.example.com" 
to "www.example.com.edgekey.net".  

While we would structure these differently today, these domains
have hundreds of thousands of production entries widely
in-use and have many entries in the top few hundred domains
on the Tranco top-1M list.

All of these domains are mission-critical production domains
and we do not intend to ever let their registrations lapse.

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the mannner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Number of users this request is being made to serve:
Altogether, these hostnames are involved in serving many
trillions of HTTP(S) requests per day.
<!--
Identify if this is current or an estimate.
-->


DNS Verification via dig
=======

Adding the _psl text records is not possible for many of these domains
due to the DNS load balancer implementations.
Please instead verify by contacting publicsuffixlist@akamai.com
and security@akamai.com, and/or by seeing details in our
public blog post:

https://www.akamai.com/blog/developers/adding-akamai-shared-domains-to-the-public-suffix-list


<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

Results of Syntax Checker (`make test`)
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.2
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
[...]
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc

```

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->


