### PR TITLE
Add cockpit.scw.cloud and obs.fr-par.scw.cloud in scaleway private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13676,6 +13676,7 @@ scalebook.scw.cloud
 smartlabeling.scw.cloud
 cockpit.scw.cloud
 obs.fr-par.scw.cloud
+mnq.fr-par.scw.cloud
 dedibox.fr
 
 // schokokeks.org GbR : https://schokokeks.org/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13649,6 +13649,7 @@ logoip.com
 
 // Scaleway : https://www.scaleway.com/
 // Submitted by Rémy Léone <rleone@scaleway.com>
+// Updated by Benjamin Lazarecki <blazarecki@scaleway.com>
 fr-par-1.baremetal.scw.cloud
 fr-par-2.baremetal.scw.cloud
 nl-ams-1.baremetal.scw.cloud
@@ -13673,6 +13674,8 @@ s3.pl-waw.scw.cloud
 s3-website.pl-waw.scw.cloud
 scalebook.scw.cloud
 smartlabeling.scw.cloud
+cockpit.scw.cloud
+obs.fr-par.scw.cloud
 dedibox.fr
 
 // schokokeks.org GbR : https://schokokeks.org/


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

Organization Website: [https://www.scaleway.com/](https://www.scaleway.com/)

I'm Benjamin Lazarecki, I work as an Engineer at Scaleway.
Scaleway is a cloud provider that offers different kinds of managed services for our customers.
Some of those services include DNS functionality: for instance, a DNS record will be added to a load balancer, an instance server, a grafana setup.

Reason for PSL Inclusion
====

We are seeking to get around limitations with let's encrypt issuance for the following domains:

- cockpit.scw.cloud
- obs.fr-par.scw.cloud
- mnq.fr-par.scw.cloud

Here the list of previous PR for scaleway domains: 

- [https://github.com/publicsuffix/list/pull/1507](https://github.com/publicsuffix/list/pull/1507)
- [https://github.com/publicsuffix/list/pull/684](https://github.com/publicsuffix/list/pull/684)

DNS Verification via dig
=======

```
dig +short TXT _psl.cockpit.scw.cloud
"https://github.com/publicsuffix/list/pull/1727"
```

```
dig +short TXT _psl.obs.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1727"
```

```
dig +short TXT _psl.mnq.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1727"
```


Results of Syntax Checker (`make test`)
=========

```
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC:
OK
-n test_allowedchars:
OK
-n test_dots:
OK
-n test_duplicate:
OK
-n test_exception:
OK
-n test_punycode:
OK
-n test_section1:
OK
-n test_section2:
OK
-n test_section3:
OK
-n test_section4:
OK
-n test_spaces:
OK
-n test_wildcard:
OK
```