### PR TITLE
Add atmeta.com to PSL and consolidate Meta entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11371,10 +11371,6 @@ url.tw
 // Submitted by Eric Jiang <eric@fabrica.dev>
 onfabrica.com
 
-// Facebook, Inc.
-// Submitted by Peter Ruibal <public-suffix@fb.com>
-apps.fbsbx.com
-
 // FAITID : https://faitid.org/
 // Submitted by Maxim Alzoba <tech.contact@faitid.org>
 // https://www.flexireg.net/stat_info
@@ -12408,6 +12404,11 @@ memset.net
 // Messerli Informatik AG : https://www.messerli.ch/
 // Submitted by Ruben Schmidmeister <psl-maintainers@messerli.ch>
 messerli.app
+
+// Meta Platforms, Inc. : https://meta.com/
+// Submitted by Jacob Cordero <public-suffix@meta.com>
+atmeta.com
+apps.fbsbx.com
 
 // MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
 // Submitted by Zdeněk Šustr <zdenek.sustr@cesnet.cz>


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting


---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Meta builds technologies that help people connect, find communities, and grow businesses. When Facebook launched in 2004, it changed the way people connect. Apps like Messenger, Instagram and WhatsApp further empowered billions around the world. Now, Meta is moving beyond 2D screens toward immersive experiences like augmented and virtual reality to help build the next evolution in social technology.

Organization Website: http://about.meta.com/

I am a Software Engineer on the Security Foundations team at Meta.

Reason for PSL Inclusion
====

`atmeta.com` will be used to host third-party marketing sites that market different products in the Meta portfolio of solutions on different subdomains, and we’d like to isolate the various third parties from each other, particularly as it relates to setting cookies and cookie consent. 

Different subdomains of “atmeta.com” will be operated by different marketing companies and agencies, so while the overall ownership of “atmeta.com” resides with Meta, it is undesirable to have shared cookies or storage across these subdomains as it could open up security issues for visitors to more than one of these marketing sites. For example, `connect.atmeta.com` might point to a third party’s event platform for hosting an in-person event while `news.atmeta.com` may point to another third party’s hosted wordpress platform that hosts news and blog content.

While we will be endeavoring to secure these subdomains and vetting our marketing subdomain owners thoroughly, we would like to proceed to place “atmeta.com” on the Public Suffix List as well, as a cue to browser vendors to treat these sites independently.

We are aware of the time propagation delays, as well as the difficulties of later removing something from the Public Suffix List.

Number of users this request is being made to serve: We expect ~30-50 subdomains of atmeta.com over the next 24 months, with more continuously in the future. Based on current traffic to similar sites, we expect on the order of millions of viewers per month to these sites.

NOTE: I have also consolidated the existing "Facebook, Inc." record for "apps.fbsbx.com" (#110) under the "Meta Platforms, Inc." section to keep things tidy, and will update the DNS verification there as well. If we'd prefer to keep these changes separate, let me know, and I'd be happy to split them up.


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

```
$ dig +short TXT _psl.apps.fbsbx.com
"https://github.com/publicsuffix/list/pull/1736"

$ dig +short TXT _psl.atmeta.com
"https://github.com/publicsuffix/list/pull/1736"
```

Results of Syntax Checker (`make test`)
=========

All tests passed 👍


