### PR TITLE
Update public_suffix_list.dat for scw.cloud cockpit product subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13108,6 +13108,7 @@ logoip.com
 fr-par-1.baremetal.scw.cloud
 fr-par-2.baremetal.scw.cloud
 nl-ams-1.baremetal.scw.cloud
+cockpit.fr-par.scw.cloud
 fnc.fr-par.scw.cloud
 functions.fnc.fr-par.scw.cloud
 k8s.fr-par.scw.cloud
@@ -13118,11 +13119,13 @@ whm.fr-par.scw.cloud
 priv.instances.scw.cloud
 pub.instances.scw.cloud
 k8s.scw.cloud
+cockpit.nl-ams.scw.cloud
 k8s.nl-ams.scw.cloud
 nodes.k8s.nl-ams.scw.cloud
 s3.nl-ams.scw.cloud
 s3-website.nl-ams.scw.cloud
 whm.nl-ams.scw.cloud
+cockpit.pl-waw.scw.cloud
 k8s.pl-waw.scw.cloud
 nodes.k8s.pl-waw.scw.cloud
 s3.pl-waw.scw.cloud


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

Organization Website: [https://www.scaleway.com/](https://www.scaleway.com/)

I'm Benjamin Lazarecki, I work as an Engineer at Scaleway.
Scaleway is a cloud provider that offers different kinds of managed services for our customers.
Some of those services include DNS functionality: for instance, a DNS record will be added to a load balancer, an instance server, a grafana instance.

Reason for PSL Inclusion
====

We are releasing a new product, that allow client to have observability on their metrics and logs. 

Sub-domains available for customers
- cockpit.fr-par.scw.cloud
- cockpit.nl-ams.scw.cloud
- cockpit.pl-waw.scw.cloud

Example:
- 11111111-1111-1111-1111-111111111111.cockpit.fr-par.scw.cloud
- 11111111-1111-1111-1111-111111111111.cockpit.nl-ams.scw.cloud
- 11111111-1111-1111-1111-111111111111.cockpit.pl-waw.scw.cloud

Here the list of previous PR for scaleway domains: 

- [https://github.com/publicsuffix/list/pull/1507](https://github.com/publicsuffix/list/pull/1507)
- [https://github.com/publicsuffix/list/pull/684](https://github.com/publicsuffix/list/pull/684)

DNS Verification via dig
=======

```
dig +short TXT _psl.cockpit.fr-par.scw.cloud
"https://github.com/publicsuffix/list/pull/1740"
```

```
dig +short TXT _psl.cockpit.nl-ams.scw.cloud
"https://github.com/publicsuffix/list/pull/1740"
```

```
dig +short TXT _psl.cockpit.pl-waw.scw.cloud
"https://github.com/publicsuffix/list/pull/1740"
```



Results of Syntax Checker (`make test`)
=========

```
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC:
OK
-n test_allowedchars:
OK
-n test_dots:
OK
-n test_duplicate:
OK
-n test_exception:
OK
-n test_punycode:
OK
-n test_section1:
OK
-n test_section2:
OK
-n test_section3:
OK
-n test_section4:
OK
-n test_spaces:
OK
-n test_wildcard:
OK
```

Thanks.