### PR TITLE
Add `kropyvnytskyi.ua` for .ua ccTLD in ICANN Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5876,6 +5876,7 @@ kiev.ua
 kirovograd.ua
 km.ua
 kr.ua
+kropyvnytskyi.ua
 krym.ua
 ks.ua
 kv.ua


### PR DESCRIPTION
added new public domain: kropyvnytskyi.ua
see https://www.hostmaster.ua/2ld/ for current list

Public Suffix List (PSL) Pull Request (PR) Template

Submitted on behalf of Hostmastter.UA - .UA ccTLD manager
New public domain would be operating 2023.05.01
see https://www.hostmaster.ua/2ld/ for current UA public domain list 

kropyvnytskyi.ua is delegated already:

% dig +short soa kropyvnytskyi.ua.
ns.host.kr.ua. hostmaster.host.kr.ua. 2022122004 86400 14400 2592000 345600

  * [X ] This request was _not_ submitted with the objective of working around other third-party limits
