### PR TITLE
Add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+on: push
+
+permissions:
+  contents: read
+
+jobs:
+  make-test:
+    name: make test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt install -y autopoint
+
+      - name: Run test
+        run: make test


### PR DESCRIPTION
This PR adds a new workflow to help with the reviewing of PSL submissions.
Right now this workflow will only run `make test` so reviewers can be assured that tests do pass without issue.

In the future, this can be expanded to check the order, check DNS entries, etc.
Wanted to make sure we started simple right now.

Some submitters have had issues running the tests (such as #1562) or don't post the result / just say "passed". This will mean the tests just run in GitHub and can always be seen as passing/failing.

Example run of this push from my own fork: https://github.com/WalshyDev/list/actions/runs/4850740715/jobs/8643920527