### PR TITLE
Add `icp.international`, `public.icp.international` and `verified.icp.international`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12072,6 +12072,7 @@ pixolino.com
 icp.international
 public.icp.international
 verified.icp.international
+icp.lol
 
 // Internet-Pro, LLP: https://netangels.ru/
 // Submitted by Vasiliy Sheredeko <piphon@gmail.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12067,6 +12067,11 @@ to.leg.br
 // Submitted by Wolfgang Schwarz <admin@intermetrics.de>
 pixolino.com
 
+// International Internet Content Provider VerificatioN
+// Submitted by Gary Chan <gary@iicpv.org>
+public.icp.international
+verified.icp.international
+
 // Internet-Pro, LLP: https://netangels.ru/
 // Submitted by Vasiliy Sheredeko <piphon@gmail.com>
 na4u.ru

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12137,7 +12137,6 @@ pixolino.com
 icp.international
 public.icp.international
 verified.icp.international
-icp.lol
 
 // Internet-Pro, LLP: https://netangels.ru/
 // Submitted by Vasiliy Sheredeko <piphon@gmail.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12067,7 +12067,7 @@ to.leg.br
 // Submitted by Wolfgang Schwarz <admin@intermetrics.de>
 pixolino.com
 
-// International Internet Content Provider VerificatioN
+// International Internet Content Provider Verification
 // Submitted by Gary Chan <gary@iicpv.org>
 icp.international
 public.icp.international

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12071,6 +12071,7 @@ pixolino.com
 // Submitted by Gary Chan <gary@iicpv.org>
 public.icp.international
 verified.icp.international
+icp.international
 
 // Internet-Pro, LLP: https://netangels.ru/
 // Submitted by Vasiliy Sheredeko <piphon@gmail.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12069,9 +12069,9 @@ pixolino.com
 
 // International Internet Content Provider VerificatioN
 // Submitted by Gary Chan <gary@iicpv.org>
+icp.international
 public.icp.international
 verified.icp.international
-icp.international
 
 // Internet-Pro, LLP: https://netangels.ru/
 // Submitted by Vasiliy Sheredeko <piphon@gmail.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12133,7 +12133,7 @@ to.leg.br
 pixolino.com
 
 // International Internet Content Provider Verification
-// Submitted by Gary Chan <gary@iicpv.org>
+// Submitted by Gary Chan <domain@iicpv.org>
 icp.international
 public.icp.international
 verified.icp.international


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

International Internet Content Provider Verification (IICPV) is a public welfare group, we hope to provide a platform for friends (whether professional or non-professional) who create websites all over the world to communicate and exchange friendship links. We hope that more excellent websites created by individuals can be seen by the public.

Organization Website:  [https://www.iicpv.org/](https://www.iicpv.org)

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Website creators can obtain a custom like `example.icp.international` domain name for testing pages

- Domain abuse - while we actively find and shut down spam/phishing subdomains, some spam check sites flag the entire domain
- Analytics pollution - Google Analytics and FB pixel cookie integrations result in analytics cookies getting set at domain level
- Site Settings - without PSL, site settings changes in the browser apply for all customer sites at the same time

Number of users this request is being made to serve:
<!--
Identify if this is current or an estimate.
-->

It is estimated that there will be more than 10,000 icp.lol subdomains, more than 1,000 icp.international subdomains of icp.international, more than 10,000 public.icp.international test subdomains, and more than 10,000 verified.icp.international subdomains

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

```
dig +short TXT _psl.icp.international
"https://github.com/publicsuffix/list/pull/1751"
```

```
dig +short TXT _psl.public.icp.international
"https://github.com/publicsuffix/list/pull/1751"
```

```
dig +short TXT _psl.verified.icp.international
"https://github.com/publicsuffix/list/pull/1751"
```


Results of Syntax Checker (`make test`)
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->

All tests pass
