### PR TITLE
Add ```us.kg```

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -905,6 +905,10 @@ cz
 // reservations) 2008-07-01
 de
 
+// DigitalPlat : https://www.digitalplat.org/
+// Submitted by Edward Hsing <xingyujie@digitalplat.org>
+us.kg
+
 // dj : https://en.wikipedia.org/wiki/.dj
 dj
 
@@ -13760,9 +13764,5 @@ bss.design
 basicserver.io
 virtualserver.io
 enterprisecloud.nu
-
-// DigitalPlat : https://www.digitalplat.org/
-// Submitted by Edward Hsing <xingyujie@digitalplat.org>
-us.kg
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11229,7 +11229,7 @@ ondigitalocean.app
 *.digitaloceanspaces.com
 
 // DigitalPlat : https://www.digitalplat.org/
-// Submitted by Edward Hsing <xingyujie@digitalplat.org>
+// Submitted by Edward Hsing <contact@digitalplat.org>
 us.kg
 
 // dnstrace.pro : https://dnstrace.pro/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -905,10 +905,6 @@ cz
 // reservations) 2008-07-01
 de
 
-// DigitalPlat : https://www.digitalplat.org/
-// Submitted by Edward Hsing <xingyujie@digitalplat.org>
-us.kg
-
 // dj : https://en.wikipedia.org/wiki/.dj
 dj
 
@@ -11231,6 +11227,10 @@ ondigitalocean.app
 // DigitalOcean Spaces : https://www.digitalocean.com/products/spaces/
 // Submitted by Robin H. Johnson <psl-maintainers@digitalocean.com>
 *.digitaloceanspaces.com
+
+// DigitalPlat : https://www.digitalplat.org/
+// Submitted by Edward Hsing <xingyujie@digitalplat.org>
+us.kg
 
 // dnstrace.pro : https://dnstrace.pro/
 // Submitted by Chris Partridge <chris@partridge.tech>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13764,4 +13764,5 @@ enterprisecloud.nu
 // DigitalPlat : https://www.digitalplat.org/
 // Submitted by Edward Hsing <xingyujie@digitalplat.org>
 us.kg
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13761,4 +13761,7 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// DigitalPlat : https://www.digitalplat.org/
+// Submitted by Edward Hsing <xingyujie@digitalplat.org>
+us.kg
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Add us.kg DNS public suffixes
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Organization Website: https://digitalplat.org

A global non-profit organization that supports open source and community development and explores innovative projects, I am the Founder of DigitalPlat.

We see that many people cannot build a website because of the expensive domain name. DigitalPlat is a non-profit organization (I am the Founder), and we are using US.KG to open a free domain name website. Anyone can get their own third-level domain (free subdomain) for projects or personal use that don't require a paid domain

The original owner of this domain requested deletion in #1741, and I took over us.kg to continue the mission of free subdomains

We're close to release and would like PSL inclusion before launch for the reasons listed below. Right now, during internal testing phase, there are only a few domains active.

<!-- 
Provide the website address of 
the Org as a full URL i.e. https://digitalplat.org
-->

Reason for PSL Inclusion
====
All Third Level Domains are completely independent and should be protected by browsers' security features. (e.g. to prevent setting cookies on the parent domain and hostname highlighting where supported)

We allow name server delegation of our Third-Level-Domains by NS record and we've learned that some DNS, hosting and proxy services validate domains using the PSL in order to prevent users from accidentally adding subdomains instead of their main domain.

We will not use wildcard TLS certificates on the parent domains nor will there be any content.

Subdomain owners cannot use DNS management platforms such as Cloudflare to manage their own subdomain DNS
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->
<!--
Identify if this is current or an estimate.
-->


DNS Verification via dig
=======

```
dig +short TXT _psl.us.kg
"https://github.com/publicsuffix/list/pull/1755"
```

Results of Syntax Checker (`make test`)
=========
```
13766: error: Found doublette/ambiguity (previous line was 13608): 'us.kg'
make: *** [Makefile:12: test-syntax] Error 1
```
The original owner of this domain requested deletion in #1741, and I took over us.kg to continue the mission of free subdomains
<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->


