### PR TITLE
Remove .zip and .mov

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -8569,9 +8569,6 @@ moto
 // motorcycles : 2014-01-09 XYZ.COM LLC
 motorcycles
 
-// mov : 2014-01-30 Charleston Road Registry Inc.
-mov
-
 // movie : 2015-02-05 Binky Moon, LLC
 movie
 
@@ -10083,9 +10080,6 @@ zara
 
 // zero : 2014-12-18 Amazon Registry Services, Inc.
 zero
-
-// zip : 2014-05-08 Charleston Road Registry Inc.
-zip
 
 // zone : 2013-11-14 Binky Moon, LLC
 zone


### PR DESCRIPTION
Many websites and apps automatically linkify text matching the PSL, causing surprising results and creating a false sense of security. These TLDs are unsafe to be on the PSL due to their deceptive nature. PoCs are emerging and organizations are blocking these TLDs.

- https://twitter.com/SwiftOnSecurity/status/1657111224931459072
- https://twitter.com/_2c2c2/status/1657113931935260672
- https://financialstatement.zip/
- https://twitter.com/mholt6/status/1657133439546695680