### PR TITLE
Update Rad Web Hosting Domains section - add myradweb.net, servername.us

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12931,6 +12931,8 @@ qbuser.com
 // Rad Web Hosting: https://radwebhosting.com
 // Submitted by Scott Claeys <s.claeys@radwebhosting.com>
 cloudsite.builders
+myradweb.net
+servername.us
 
 // Redgate Software: https://red-gate.com
 // Submitted by Andrew Farries <andrew.farries@red-gate.com>


### PR DESCRIPTION
> Also, the template had 10 tasks. Please put them all back and complete them.

### Checklist of required steps

* [x ] Description of Organization
Organization Website: https://radwebhosting.com

My name is Scott Claeys, I am a network engineer, and I represent Rad Web Hosting.

Rad Web Hosting provides web hosting and servers to users around the globe.
* [ x] Robust Reason for PSL Inclusion
Rad Web Hosting offers clients the ability to reserve unclaimed subdomains of *.myradweb.net for the purpose of staging incoming site migrations, viewing site updates in the wild, or for creation of webspaces to host websites and applications without registering a paid domain name.

We need to isolate them from one another (eg: we don't want client1.myradweb.net to be able to set a cookie readable from client2.myradweb.net).

Same applies for region specific endpoints. client1.uscp.myradweb.net should not be able to set cookies readable from bob-client2.uscp.myradweb.net site.

Number of users this request is being made to serve: Currently some hundreds are already using the service, but it is estimated to increase to thousands as our clients are continuously finding new creative use-cases for use of these "staging" domains.

Rad Web Hosting automatically generates unique hostnames for every cloud instance deployed that utilizes the *.servername.us second-level domain. These hostnames also provide access to a DNS zone which can be modified and customized by client.

We need to isolate them from one another (eg: we don't want client1.servername.us to be able to set a cookie readable from client2.servername.us).

Same applies for region specific endpoints. client1.us.servername.us should not be able to set cookies readable from bob-client2.us.servername.us site.

Number of users this request is being made to serve: Currently, this system is supporting hundreds of instances.
* [ x] DNS verification via dig
```
dig +short TXT _psl.myradweb.net
"https://github.com/publicsuffix/list/pull/1760"
```

```
dig +short TXT _psl.servername.us
"https://github.com/publicsuffix/list/pull/1760"
```
* [ x] Run Syntax Checker (make test)
Test run successfully

* [x ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x ] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x ] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x ] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [ x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.


