### PR TITLE
PSL: Adding myfritz.link (follow up PR#77)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10407,6 +10407,7 @@ autocode.dev
 
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
+myfritz.link
 myfritz.net
 
 // AVStack Pte. Ltd. : https://avstack.io


### PR DESCRIPTION
Hi,

after [PR#77](https://github.com/publicsuffix/list/pull/77) we are planning to extend feature set of the DynDNS Service provided for our customers, and thus need an additional domain registered on PSL.

Best regards
Andreas


Public Suffix List (PSL) Pull Request (PR) Template
====

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [X] This request was _not_ submitted with the objective of working around other third-party limits


  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting


---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

AVM is one of Europe's leading manufacturers of products for broadband connections and the digital home. FRITZ! brand products are easy to use for everyone. They enable fast internet access, easy networking, convenient telephony and versatile Smart Home applications. 

Customers may register their AVM broadband product at our MyFRITZ!Net Platform [myfritz.net](https://myfritz.net) which enables several features, e.g. DynDNS. We (AVM IT Department) are delivering these services.


Organization Website: 
[avm.de](https://avm.de)

Reason for PSL Inclusion
====

Once a customer registers a product on MyFRITZ!Net platform, the customer may also enable Let's encrypt to secure it's remote access. In 2016 we already registered the major domain `myfritz.net` that we use for DynDNS in PSL, see [PR#77](https://github.com/publicsuffix/list/pull/77). 

We are now extending our DynDNS Service to support `myfritz.link` and require that additional domain to be registered on PSL to restict cookie setting for different DynDNS domains/users and to keep Let`s Encrypt integration working.

MyFRITZ!Net and it's DynDNS functionality is served to millions of customers using FRITZ! brand products.


DNS Verification via dig
=======

```
dig +short TXT _psl.myfritz.link
"https://github.com/publicsuffix/list/pull/1761"
```


Results of Syntax Checker (`make test`)
=========

All pass


