### PR TITLE
Update AutoPull - Temporary fix for #1806

### DIFF
--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -118,7 +118,7 @@ func (e *pslEntry) normalize() {
 	e.ALabel = strings.TrimSpace(e.ALabel)
 	e.ULabel = strings.TrimSpace(e.ULabel)
 	e.RegistryOperator = strings.TrimSpace(e.RegistryOperator)
-	e.DateOfContractSignature = strings.TrimSpace(e.DateOfContractSignature)
+	e.DateOfContractSignature = "Contracted"
 
 	// If there is no explicit uLabel use the gTLD as the uLabel.
 	if e.ULabel == "" {
@@ -131,13 +131,12 @@ func (e *pslEntry) normalize() {
 //
 // If the registry operator field is empty the comment will be of the form:
 //
-//    '// <ALabel> : <DateOfContractSignature>'
+//    '// <ALabel> : Contracted'
 //
 // If the registry operator field is not empty the comment will be of the form:
 //
-//    '// <ALabel> : <DateOfContractSignature> <RegistryOperator>'
+//    '// <ALabel> : Contracted <RegistryOperator>'
 //
-// In both cases the <DateOfContractSignature> may be empty.
 func (e pslEntry) Comment() string {
 	parts := []string{
 		"//",


### PR DESCRIPTION
This updates newtlds.go to replace the <contract date> with "Contracted" in the header per 2012 round nTLD as a tempfix to #1806 

Short version of #1806 is that now we're 10 years ++ hence from the 2012 round TLD launches, the contracts are hitting their 10 year horizon and are being renewed.   ICANN is updating the contract date field in the gtlds.json file, and this would result in a large quantity of auto-pull to merge with the new dates as this happens.

There are discussions with ICANN's technical team to see about them leaving the contract dates intact in contractdate vs re-using the contractdate field to store the contract renewal date.

It is anticipated that this pull request being merged will cause one large pull request that alters the entire nTLD section's contracted dates in the comment per nTLD, but will then reduce the subsequent noise level when ICANN renews contracts with the various Registries.




