### PR TITLE
tools: skip contract date rendering, small CI fixups.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,22 @@ permissions:
 
 jobs:
   make-test:
-    name: make test
+    name: Unit tests
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.15'
+
+      - name: Run Go unit tests
+        run: go test tools/*.go
+
       - name: Install dependencies
         run: sudo apt install -y autopoint
 
-      - name: Run test
+      - name: Run makefile tests
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.15'
+          go-version: 'stable'
 
       - name: Run Go unit tests
         run: go test tools/*.go

--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -1,4 +1,3 @@
-# Put this automation on hold, until it is able to ignore changes that only update the header timestamp.
 name: tld-update
 on:
   workflow_dispatch:

--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.15'
+          go-version: 'stable'
 
       - name: Run unit tests
         run: go test tools/*.go

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -100,8 +100,6 @@ type pslEntry struct {
 	// RegistryOperator holds the name of the registry operator that operates the
 	// gTLD (may be empty).
 	RegistryOperator string
-	// DateOfContractSignature holds the date the gTLD contract was signed (may be empty).
-	DateOfContractSignature string
 	// ContractTerminated indicates whether the contract has been terminated by
 	// ICANN. When rendered by the pslTemplate only entries with
 	// ContractTerminated = false are included.
@@ -118,7 +116,6 @@ func (e *pslEntry) normalize() {
 	e.ALabel = strings.TrimSpace(e.ALabel)
 	e.ULabel = strings.TrimSpace(e.ULabel)
 	e.RegistryOperator = strings.TrimSpace(e.RegistryOperator)
-	e.DateOfContractSignature = strings.TrimSpace(e.DateOfContractSignature)
 
 	// If there is no explicit uLabel use the gTLD as the uLabel.
 	if e.ULabel == "" {
@@ -131,23 +128,19 @@ func (e *pslEntry) normalize() {
 //
 // If the registry operator field is empty the comment will be of the form:
 //
-//    '// <ALabel> : <DateOfContractSignature>'
+//	'// <ALabel>
 //
 // If the registry operator field is not empty the comment will be of the form:
 //
-//    '// <ALabel> : <DateOfContractSignature> <RegistryOperator>'
-//
-// In both cases the <DateOfContractSignature> may be empty.
+//	'// <ALabel> : <RegistryOperator>'
 func (e pslEntry) Comment() string {
 	parts := []string{
 		"//",
 		e.ALabel,
-		":",
-		e.DateOfContractSignature,
 	}
 	// Avoid two trailing spaces if registry operator is empty
 	if e.RegistryOperator != "" {
-		parts = append(parts, e.RegistryOperator)
+		parts = append(parts, []string{":", e.RegistryOperator}...)
 	}
 	return strings.Join(parts, " ")
 }
@@ -365,10 +358,10 @@ func filterGTLDs(entries []*pslEntry) []*pslEntry {
 }
 
 // getPSLEntries fetches a list of pslEntry objects (or returns an error) by:
-//   1. getting the raw JSON data from the provided url string.
-//   2. unmarshaling the JSON data to create pslEntry objects.
-//   3. normalizing the pslEntry objects.
-//   4. filtering out any legacy or contract terminated gTLDs
+//  1. getting the raw JSON data from the provided url string.
+//  2. unmarshaling the JSON data to create pslEntry objects.
+//  3. normalizing the pslEntry objects.
+//  4. filtering out any legacy or contract terminated gTLDs
 //
 // If there are no pslEntry objects after unmarshaling the data in step 2 or
 // filtering the gTLDs in step 4 it is considered an error condition.

--- a/tools/newgtlds_test.go
+++ b/tools/newgtlds_test.go
@@ -23,31 +23,27 @@ func TestEntryNormalize(t *testing.T) {
 		{
 			name: "already normalized",
 			inputEntry: pslEntry{
-				ALabel:                  "cpu",
-				ULabel:                  "ｃｐｕ",
-				DateOfContractSignature: "2019-06-13",
-				RegistryOperator:        "@cpu's bargain gTLD emporium",
+				ALabel:           "cpu",
+				ULabel:           "ｃｐｕ",
+				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
 			expectedEntry: pslEntry{
-				ALabel:                  "cpu",
-				ULabel:                  "ｃｐｕ",
-				DateOfContractSignature: "2019-06-13",
-				RegistryOperator:        "@cpu's bargain gTLD emporium",
+				ALabel:           "cpu",
+				ULabel:           "ｃｐｕ",
+				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
 		},
 		{
 			name: "extra whitespace",
 			inputEntry: pslEntry{
-				ALabel:                  "  cpu    ",
-				ULabel:                  "   ｃｐｕ   ",
-				DateOfContractSignature: "   2019-06-13    ",
+				ALabel: "  cpu    ",
+				ULabel: "   ｃｐｕ   ",
 				RegistryOperator: "     @cpu's bargain gTLD emporium " +
 					"(now with bonus whitespace)    ",
 			},
 			expectedEntry: pslEntry{
-				ALabel:                  "cpu",
-				ULabel:                  "ｃｐｕ",
-				DateOfContractSignature: "2019-06-13",
+				ALabel: "cpu",
+				ULabel: "ｃｐｕ",
 				RegistryOperator: "@cpu's bargain gTLD emporium " +
 					"(now with bonus whitespace)",
 			},
@@ -55,15 +51,13 @@ func TestEntryNormalize(t *testing.T) {
 		{
 			name: "no explicit uLabel",
 			inputEntry: pslEntry{
-				ALabel:                  "cpu",
-				DateOfContractSignature: "2019-06-13",
-				RegistryOperator:        "@cpu's bargain gTLD emporium",
+				ALabel:           "cpu",
+				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
 			expectedEntry: pslEntry{
-				ALabel:                  "cpu",
-				ULabel:                  "cpu",
-				DateOfContractSignature: "2019-06-13",
-				RegistryOperator:        "@cpu's bargain gTLD emporium",
+				ALabel:           "cpu",
+				ULabel:           "cpu",
+				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
 		},
 	}
@@ -89,26 +83,25 @@ func TestEntryComment(t *testing.T) {
 		{
 			name: "Full entry",
 			entry: pslEntry{
-				ALabel:                  "cpu",
-				DateOfContractSignature: "2019-06-13",
-				RegistryOperator:        "@cpu's bargain gTLD emporium",
+				ALabel:           "cpu",
+				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
-			expected: "// cpu : 2019-06-13 @cpu's bargain gTLD emporium",
+			expected: "// cpu : @cpu's bargain gTLD emporium",
 		},
 		{
-			name: "Entry with empty contract signature date and operator",
+			name: "Entry without operator",
 			entry: pslEntry{
 				ALabel: "cpu",
 			},
-			expected: "// cpu : ",
+			expected: "// cpu",
 		},
 		{
-			name: "Entry with empty contract signature and non-empty operator",
+			name: "Entry with non-empty operator",
 			entry: pslEntry{
 				ALabel:           "cpu",
 				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
-			expected: "// cpu :  @cpu's bargain gTLD emporium",
+			expected: "// cpu : @cpu's bargain gTLD emporium",
 		},
 	}
 
@@ -162,29 +155,25 @@ func TestGetPSLEntries(t *testing.T) {
 	}{
 		GTLDs: []pslEntry{
 			{
-				ALabel:                  "ceepeeyou",
-				DateOfContractSignature: "2099-06-13",
-				RegistryOperator:        "@cpu's bargain gTLD emporium",
+				ALabel:           "ceepeeyou",
+				RegistryOperator: "@cpu's bargain gTLD emporium",
 			},
 			{
 				// NOTE: we include whitespace in this entry to test that normalization
 				// occurs.
-				ALabel:                  "  cpu    ",
-				ULabel:                  "   ｃｐｕ   ",
-				DateOfContractSignature: "   2019-06-13    ",
+				ALabel: "  cpu    ",
+				ULabel: "   ｃｐｕ   ",
 				RegistryOperator: "     @cpu's bargain gTLD emporium " +
 					"(now with bonus whitespace)    ",
 			},
 			{
 				// NOTE: we include a legacy gTLD here to test that filtering of legacy
 				// gTLDs occurs.
-				ALabel:                  "aero",
-				DateOfContractSignature: "1999-10-31",
-				RegistryOperator:        "Department of Historical Baggage and Technical Debt",
+				ALabel:           "aero",
+				RegistryOperator: "Department of Historical Baggage and Technical Debt",
 			},
 			{
-				ALabel:                  "terminated",
-				DateOfContractSignature: "1987-10-31",
+				ALabel: "terminated",
 				// NOTE: we include a contract terminated = true entry here to test that
 				// filtering of terminated entries occurs.
 				ContractTerminated: true,
@@ -197,15 +186,13 @@ func TestGetPSLEntries(t *testing.T) {
 
 	expectedEntries := []pslEntry{
 		{
-			ALabel:                  "ceepeeyou",
-			ULabel:                  "ceepeeyou",
-			DateOfContractSignature: "2099-06-13",
-			RegistryOperator:        "@cpu's bargain gTLD emporium",
+			ALabel:           "ceepeeyou",
+			ULabel:           "ceepeeyou",
+			RegistryOperator: "@cpu's bargain gTLD emporium",
 		},
 		{
-			ALabel:                  "cpu",
-			ULabel:                  "ｃｐｕ",
-			DateOfContractSignature: "2019-06-13",
+			ALabel: "cpu",
+			ULabel: "ｃｐｕ",
 			RegistryOperator: "@cpu's bargain gTLD emporium " +
 				"(now with bonus whitespace)",
 		},
@@ -265,21 +252,18 @@ func TestGetPSLEntriesEmptyFilteredResults(t *testing.T) {
 		GTLDs: []pslEntry{
 			{
 				// NOTE: GTLD matches a legacyGTLDs map entry to ensure filtering.
-				ALabel:                  "aero",
-				DateOfContractSignature: "1999-10-31",
-				RegistryOperator:        "Department of Historical Baggage and Technical Debt",
+				ALabel:           "aero",
+				RegistryOperator: "Department of Historical Baggage and Technical Debt",
 			},
 			{
-				ALabel:                  "terminated",
-				DateOfContractSignature: "1987-10-31",
+				ALabel: "terminated",
 				// NOTE: Setting ContractTerminated to ensure filtering.
 				ContractTerminated: true,
 			},
 			{
-				ALabel:                  "removed",
-				DateOfContractSignature: "1999-10-31",
-				RegistryOperator:        "Department of Historical Baggage and Technical Debt",
-				RemovalDate:             "2019-08-06",
+				ALabel:           "removed",
+				RegistryOperator: "Department of Historical Baggage and Technical Debt",
+				RemovalDate:      "2019-08-06",
 			},
 		},
 	}
@@ -301,22 +285,20 @@ func TestGetPSLEntriesEmptyFilteredResults(t *testing.T) {
 func TestRenderData(t *testing.T) {
 	entries := []*pslEntry{
 		{
-			ALabel:                  "ceepeeyou",
-			ULabel:                  "ceepeeyou",
-			DateOfContractSignature: "2099-06-13",
-			RegistryOperator:        "@cpu's bargain gTLD emporium",
+			ALabel:           "ceepeeyou",
+			ULabel:           "ceepeeyou",
+			RegistryOperator: "@cpu's bargain gTLD emporium",
 		},
 		{
-			ALabel:                  "cpu",
-			ULabel:                  "ｃｐｕ",
-			DateOfContractSignature: "2019-06-13",
+			ALabel: "cpu",
+			ULabel: "ｃｐｕ",
 		},
 	}
 
-	expectedList := `// ceepeeyou : 2099-06-13 @cpu's bargain gTLD emporium
+	expectedList := `// ceepeeyou : @cpu's bargain gTLD emporium
 ceepeeyou
 
-// cpu : 2019-06-13
+// cpu
 ｃｐｕ
 
 `
@@ -675,7 +657,7 @@ func TestProcess(t *testing.T) {
 
 // List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2021-02-07T13:25:56-05:00
 // This list is auto-generated, don't edit it manually.
-// aaa : 2015-02-26 American Automobile Association, Inc.
+// aaa : American Automobile Association, Inc.
 aaa
 
 
@@ -688,7 +670,6 @@ aaa
 	"gTLDs": [
 		{
 			"contractTerminated": false,
-			"dateOfContractSignature": "2015-02-26",
 			"gTLD": "aaa",
 			"registryOperator": "American Automobile Association, Inc.",
 			"removalDate": null,
@@ -703,7 +684,6 @@ aaa
 	"gTLDs": [
 		{
 			"contractTerminated": false,
-			"dateOfContractSignature": "2015-02-26",
 			"gTLD": "aaa",
 			"registryOperator": "American Automobile Association, Inc.",
 			"removalDate": null,
@@ -711,7 +691,6 @@ aaa
 		},
 		{
 			"contractTerminated": false,
-			"dateOfContractSignature": "2014-03-20",
 			"gTLD": "accountants",
 			"registryOperator": "Binky Moon, LLC",
 			"removalDate": null,
@@ -731,10 +710,10 @@ aaa
 
 // List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2021-02-10T00:24:14Z
 // This list is auto-generated, don't edit it manually.
-// aaa : 2015-02-26 American Automobile Association, Inc.
+// aaa : American Automobile Association, Inc.
 aaa
 
-// accountants : 2014-03-20 Binky Moon, LLC
+// accountants : Binky Moon, LLC
 accountants
 
 


### PR DESCRIPTION
## Description

This is an alternative to https://github.com/publicsuffix/list/pull/1809

More cleanup is probably in order (in particular, making a proper Go module for this tool) but for now let's do the simple stuff.

### tools: don't render date of contract signature.
ICANN is updating the contract date field in the `gtlds.json` file for many contracts in the near future. Since including the contract date in the `.dat` file as comments isn't very helpful to anyone, and leaving it in during this renewal period would result in a large quantity of auto-pull requests for no-op changes, we choose to omit the date as a quick fix.

This commit updates the `newtlds.go` tool to no longer process/render the `DateOfContractSignature`. Unit tests are updated to reflect this change.

### ci: run Go unit tests as part of test.yml.
Previously the Go unit tests for the `newgtlds` tool were run as part of the Travis workflow for each branch push. This is helpful to catch breaking changes to the Go tooling _before_ they are merged and used in the `tld-update.yml` workflow.

This commit adds the required steps to `test.yml` so that these unit tests are run by GitHub actions similar to the way they were for Travis.

### ci: switch to latest stable go.

Does what it says on the tin.

### ci: remove stale comment in tld-update.yml

The comment about the automation being on-hold was leftover from a period ~two years ago. It isn't accurate, the automation _has_ been running, and it properly handles the header timestamp issue that caused it to be temporarily disabled.

## Meta discussion

Speaking frankly: I find it hard to prioritize supporting this automation. I'm not a maintainer of this repo, I don't have as much stake in the PSL as when I worked at Let's Encrypt, I've been writing less Go lately, and I have other hobby projects to spend my free time on :-) 

I'd be happy for someone else to take over maintenance and future development. Alternatively, if Mozilla or another organization has funding I'm available for part-time contract work. 

However, since I know many of the folks involved here are volunteers and the PSL is load bearing for the broader internet I will continue to help where I can if there aren't better alternatives. Mostly I feel it's important to lay my cards on the table to help set expectations.
