### PR TITLE
Update tld-update.yml to automatically add labels when autopull catches deltas and generates PR

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -39,6 +39,9 @@ jobs:
           committer: "GitHub <noreply@github.com>"
           author: "GitHub <noreply@github.com>"
           branch: psl-gtld-update
+          labels: |
+            ✅ autopull
+            🚩ICANN (IANA/ICP-3) Section
           delete-branch: true
 
       - name: Check outputs


### PR DESCRIPTION
This is non-urgent.

When the autopull runs, this auto-adds labels to indicate this is automation and impacts the upper 'ICANN' section

Did not see a way to also automate the project as well in the automation handler, but this will save volunteers steps in labelling when reviewing.



