### PR TITLE
ci: update test workflow triggers to include PRs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: push
+on: [push, pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
This branch updates the `test.yml` GitHub workflow's triggers to include `pull_request` in addition to `push`. This will ensure that when a pull request is opened the CI tasks are run and check statuses added to the PR. 

I overlooked this in my earlier CI cleanup PR and noticed this wasn't happening when I opened https://github.com/publicsuffix/list/pull/1817.

Without an update to the repository settings to enable branch protection rules (_recommended_) these will not be _blocking_ checks.


