### PR TITLE
Automation - Roll back broken 'project' assignment in autopull 

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -43,14 +43,6 @@ jobs:
             🚩ICANN (IANA/ICP-3) Section
           delete-branch: true
           
-      - name: Create or Update to List Add/Mod/Del To-Do Card
-        if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: peter-evans/create-or-update-project-card@v2
-        with:
-          project-number: 2
-          column-name: To-Do
-          issue-number: ${{ steps.cpr.outputs.pull-request-number }}
-
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
Stripping out the project/card definition stuff - appears to use a different context of "project" than intended

This rolls back the cause of the https://github.com/publicsuffix/list/pull/1815#issuecomment-1667496019 and fixes the daily ICANN automation 




