### PR TITLE
Update Supabase domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14538,10 +14538,10 @@ temp-dns.com
 
 // Supabase : https://supabase.io
 // Submitted by Inian Parameshwaran <security@supabase.io>
+supabase.black
 supabase.co
 supabase.in
-supabase.net
-su.paba.se
+supabase.red
 
 // Symfony, SAS : https://symfony.com/
 // Submitted by Fabien Potencier <fabien@symfony.com>


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)


  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

## Description of Organization
Supabase is a hosted platform where users get a Postgres database with realtime capabilities, Authentication and Storage. Each user on the platform gets their own domain like *.supabase.co. I am from the Security team of Supabase.


Organization Website: https://supabase.com

## Reason for PSL Inclusion
Reason for PSL inclusion is for cookie security. We let users upload assets via [Supabase Storage](https://supabase.io/storage). Some users have been using this to host websites and we want to ensure that websites hosted at user's subdomains have cookies properly segregated. Some of our domains have changed since the original PSL inclusion [here](https://github.com/publicsuffix/list/pull/1363)


## DNS Verification via dig

```
dig +short TXT _psl.supabase.red
"https://github.com/publicsuffix/list/pull/1846"
```

```
dig +short TXT _psl.supabase.black
"https://github.com/publicsuffix/list/pull/1846"
```

## Results of Syntax Checker (`make test`)
Tests pass
```
============================================================================
Testsuite summary for libpsl 0.21.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

