### PR TITLE
Update Company Name (new Legal Structure)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12783,7 +12783,7 @@ freemyip.com
 // Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
 wien.funkfeuer.at
 
-// Futureweb OG : http://www.futureweb.at
+// Futureweb GmbH : https://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 *.futurecms.at
 *.ex.futurecms.at


### PR DESCRIPTION
The company legal structure has changed from a general partnership (OG) to a limited liability company (GmbH). Please refer to: https://www.futureweb.at/de/impressum/ for more details.


