### PR TITLE
Remove k12.de.us

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6031,7 +6031,6 @@ k12.ca.us
 k12.co.us
 k12.ct.us
 k12.dc.us
-k12.de.us
 k12.fl.us
 k12.ga.us
 k12.gu.us


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.


### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)


  * [X] This request was _not_ submitted with the objective of working around other third-party limits

  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---




Description of Organization
====

State of Delaware K-12 education community.  This community's DNS servers are owned and operated by (DTI) the Delaware Department of Technology and Information.  DTI is the service provider for all K-12 school districts and charter schools in the State.

I, Jon McCullin, work for the DTI engineering team and I am one of the responsible persons for operation of the k12.de.us namespace.

Organization Website: 
https://dti.delaware.gov/

Reason for PSL Inclusion
====

N/A - Requesting domain removal

Number of users this request is being made to serve:
130,000 current users of the State of Delaware K-12 education community.


DNS Verification via dig
=======

dig TXT _psl.k12.de.us

; <<>> DiG 9.16.28 <<>> TXT _psl.k12.de.us
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57577
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4000
;; QUESTION SECTION:
;_psl.k12.de.us.                        IN      TXT

;; ANSWER SECTION:
_psl.k12.de.us.         871     IN      TXT     "https://github.com/publicsuffix/list/pull/1854"

Results of Syntax Checker (`make test`)
=========

Tests completed successfully


