### PR TITLE
Added regist.cc

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9748,6 +9748,10 @@ redstone
 // https://www.iana.org/domains/root/db/redumbrella.html
 redumbrella
 
+// regist.cc : GenerateApps.org
+// https://regist.cc/
+regist.cc
+
 // rehab : Dog Beach, LLC
 // https://www.iana.org/domains/root/db/rehab.html
 rehab


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
====
Our organization, Regist.cc, is a free subdomain service that offers .regist.cc domains to users. We provide users with the ability to create and manage subdomains for various purposes.

Organization Website: [Regist.cc](https://regist.cc)

* [x] Robust Reason for PSL Inclusion
====
We are requesting the inclusion of .regist.cc in the Public Suffix List (PSL) for several reasons:

1. **Cookie Security**: Many web services rely on cookies for user authentication and tracking. By including .regist.cc in the PSL, we can ensure that cookies set on our subdomains are treated securely by browsers, preventing potential security issues.

2. **Let's Encrypt Issuance**: We plan to allow users to obtain Let's Encrypt SSL certificates for their .regist.cc subdomains. Inclusion in the PSL is essential for smooth SSL certificate issuance and renewal.

3. **IOS/Facebook**: Some users may want to link their .regist.cc domains with third-party services like Facebook. Having .regist.cc in the PSL will facilitate this process.

4. **Cloudflare**: Users may choose to use Cloudflare's services with their .regist.cc subdomains. Inclusion in the PSL ensures correct configuration and security for Cloudflare users.

Number of users this request is being made to serve: Estimated to be thousands of users.

* [x] DNS verification via dig
====
For verification, we have created DNS verification records for our domains:

- For .regist.cc: `dig +short TXT _psl.regist.cc "https://github.com/publicsuffix/list/pull/1867"`

Please replace `1867` with the number of this pull request.

* [x] Run Syntax Checker (`make test`)
====
We have run the syntax checker using the following commands:

```bash
git clone https://github.com/publicsuffix/list.git
cd list
make test
