### PR TITLE
Add darklang.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11999,6 +11999,7 @@ dyndns.dappnode.io
 // Dark, Inc. : https://darklang.com
 // Submitted by Paul Biggar <ops@darklang.com>
 builtwithdark.com
+darklang.io
 
 // DataDetect, LLC. : https://datadetect.com
 // Submitted by Andrew Banchich <abanchich@sceven.com>


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section
__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Organization Website: https://darklang.com/

Darklang is a holistic programming language and infrastructure, for building backend web services. We are the company building Darklang. 

I'm a co-founder and CTO of Darklang.

Reason for PSL Inclusion
====

We have an [existing domain on the PSL](https://github.com/publicsuffix/list/pull/857), and intend to migrate usage of that domain to a new domain for marketing/product reasons (aka it looks nicer).

Number of users this request is being made to serve: ~1000

- We provide each customer with a unique subdomain of darklang.io
- We want our customers' apps to be isolated from each other (cookies, etc.)
- We want to prevent setting cookies on the apex domains

---

- We have extended registration longer than 2 years.
- We are not attempting to work around any 3rd party limits.
- We previously [added builtwithdark.com](https://github.com/publicsuffix/list/pull/857).




DNS Verification via dig
=======

```
dig +short TXT _psl.darklang.io
"https://github.com/publicsuffix/list/pull/1880"
```

Results of Syntax Checker (`make test`)
=========


