### PR TITLE
 Handle EBEROs: Use DelegationDate alongside ContractTerminated

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6710,7 +6710,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2023-11-03T15:13:18Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2023-11-14T19:15:48Z
 // This list is auto-generated, don't edit it manually.
 // aaa : American Automobile Association, Inc.
 // https://www.iana.org/domains/root/db/aaa.html
@@ -7751,6 +7751,10 @@ dental
 // dentist : Dog Beach, LLC
 // https://www.iana.org/domains/root/db/dentist.html
 dentist
+
+// desi
+// https://www.iana.org/domains/root/db/desi.html
+desi
 
 // design : Registry Services, LLC
 // https://www.iana.org/domains/root/db/design.html
@@ -10679,6 +10683,10 @@ weber
 // website : Radix FZC DMCC
 // https://www.iana.org/domains/root/db/website.html
 website
+
+// wed
+// https://www.iana.org/domains/root/db/wed.html
+wed
 
 // wedding : Registry Services, LLC
 // https://www.iana.org/domains/root/db/wedding.html

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13193,7 +13193,7 @@ shw.io
 // Submitted by Jonathan Rudenberg <jonathan@flynn.io>
 flynnhosting.net
 
-// Forgerock : https://www.forgerock.com
+// Forgerock : https://www.forgerock.com
 // Submitted by Roderick Parr <roderick.parr@forgerock.com>
 forgeblocks.com
 id.forgerock.io
@@ -14887,7 +14887,7 @@ alpha.bounty-full.com
 beta.bounty-full.com
 
 // Smallregistry by Promopixel SARL: https://www.smallregistry.net
-// Former AFNIC's SLDs 
+// Former AFNIC's SLDs
 // Submitted by Jérôme Lipowicz <support@promopixel.com>
 aeroport.fr
 avocat.fr

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -96,6 +96,9 @@ type pslEntry struct {
 	// ALabel contains the ASCII gTLD name. For internationalized gTLDs the GTLD
 	// field is expressed in punycode.
 	ALabel string `json:"gTLD"`
+	// DelegationDate holds the date the gTLD was delegated to the root zone.
+	// A TLD should be considered dead if the delegation date is empty.
+	DelegationDate string
 	// ULabel contains the unicode representation of the gTLD name. When the gTLD
 	// ULabel in the ICANN gTLD data is empty (e.g for an ASCII gTLD like
 	// '.pizza') the PSL entry will use the ALabel as the ULabel.
@@ -362,7 +365,7 @@ func filterGTLDs(entries []*pslEntry) []*pslEntry {
 		if _, isLegacy := legacyGTLDs[entry.ALabel]; isLegacy {
 			continue
 		}
-		if entry.ContractTerminated {
+		if entry.DelegationDate == "" {
 			continue
 		}
 		if entry.RemovalDate != "" {

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -366,10 +366,10 @@ func filterGTLDs(entries []*pslEntry) []*pslEntry {
 		if _, isLegacy := legacyGTLDs[entry.ALabel]; isLegacy {
 			continue
 		}
-		if entry.RemovalDate != "" {
+		if entry.ContractTerminated && entry.DelegationDate == "" {
 			continue
 		}
-		if entry.ContractTerminated && entry.DelegationDate == "" {
+		if entry.RemovalDate != "" {
 			continue
 		}
 		filtered = append(filtered, entry)

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -358,17 +358,18 @@ func getData(url string) ([]byte, error) {
 }
 
 // filterGTLDs removes entries that are present in the legacyGTLDs map or have
-// ContractTerminated equal to true, or a non-empty RemovalDate.
+// ContractTerminated equal to true and an empty DelegationDate,
+// or a non-empty RemovalDate.
 func filterGTLDs(entries []*pslEntry) []*pslEntry {
 	var filtered []*pslEntry
 	for _, entry := range entries {
 		if _, isLegacy := legacyGTLDs[entry.ALabel]; isLegacy {
 			continue
 		}
-		if entry.DelegationDate == "" {
+		if entry.RemovalDate != "" {
 			continue
 		}
-		if entry.RemovalDate != "" {
+		if entry.ContractTerminated && entry.DelegationDate == "" {
 			continue
 		}
 		filtered = append(filtered, entry)

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -366,6 +366,7 @@ func filterGTLDs(entries []*pslEntry) []*pslEntry {
 		if _, isLegacy := legacyGTLDs[entry.ALabel]; isLegacy {
 			continue
 		}
+		// If the Delegation Date is not empty, the gTLD is likely in EBERO.
 		if entry.ContractTerminated && entry.DelegationDate == "" {
 			continue
 		}

--- a/tools/newgtlds_test.go
+++ b/tools/newgtlds_test.go
@@ -177,6 +177,15 @@ func TestGetPSLEntries(t *testing.T) {
 				// NOTE: we include a contract terminated = true entry here to test that
 				// filtering of terminated entries occurs.
 				ContractTerminated: true,
+				DelegationDate:     "", // Explicitly state that delegation date is empty.
+			},
+			{
+				ALabel: "ebero",
+				// NOTE: We include contract terminated = true with a delegation date that
+				// has data here to ensure we capture TLDs that are in EBERO.
+				ContractTerminated: true,
+				DelegationDate:     "2012-12-21",
+				RegistryOperator:   "ICANN't itself",
 			},
 		},
 	}
@@ -195,6 +204,13 @@ func TestGetPSLEntries(t *testing.T) {
 			ULabel: "ｃｐｕ",
 			RegistryOperator: "@cpu's bargain gTLD emporium " +
 				"(now with bonus whitespace)",
+		},
+		{
+			ALabel:             "ebero",
+			ULabel:             "ebero",
+			RegistryOperator:   "ICANN't itself",
+			ContractTerminated: true,
+			DelegationDate:     "2012-12-21",
 		},
 	}
 
@@ -259,6 +275,7 @@ func TestGetPSLEntriesEmptyFilteredResults(t *testing.T) {
 				ALabel: "terminated",
 				// NOTE: Setting ContractTerminated to ensure filtering.
 				ContractTerminated: true,
+				DelegationDate:     "", // Explicitly state that DelegationDate is empty
 			},
 			{
 				ALabel:           "removed",


### PR DESCRIPTION
Solution for #1174. Replaces #1754

Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Organization Website:  N/A
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Number of users this request is being made to serve: N/A
<!--
Identify if this is current or an estimate.
-->

`.wed` is an EBERO TLD. This means it's still an active suffix for domains (e.g. may27.wed). I've updated the updater code to ensure that these DNS names (currently only one) don't get dropped by the automation until they're ready to be dropped.

DNS Verification via dig
=======

```
dig soa +short wed.
dns1.emdns.uk. hostmaster.nominet.org.uk. 2100001071 7200 900 2419200 3600
```

```
whois wed.
% IANA WHOIS server
% for more information on IANA, visit http://www.iana.org
% This query returned 1 object

domain:       WED

organisation: Emergency Back-End Registry Operator Program - ICANN
address:      12025 Waterfront Drive
address:      Suite 300
address:      Los Angeles CA 90094
address:      United States of America (the)

contact:      administrative
name:         EBERO Event Director
organisation: Internet Corporation for Assigned Names and Numbers (ICANN)
address:      12025 Waterfront Drive
address:      Suite 300
address:      Los Angeles CA 90094
address:      United States of America (the)
phone:        +1 310 301 5800
fax-no:       +1 310 823 8649
e-mail:       eventdirector@icann.org

contact:      technical
name:         Nominet EBERO Event Manager
organisation: Nominet
address:      Minerva House
address:      Edmund Halley Road
address:      Oxford Science Park
address:      Oxford Oxon OX4 4DQ
address:      United Kingdom of Great Britain and Northern Ireland (the)
phone:        +44 1865 332470
e-mail:       ebero@nominet.uk

nserver:      DNS1.EMDNS.UK 213.248.217.153 2a01:618:401:0:0:0:0:153
nserver:      DNS2.EMDNS.UK 103.49.81.153 2401:fd80:401:0:0:0:0:153
nserver:      DNS3.EMDNS.UK 213.248.221.153 2a01:618:405:0:0:0:0:153
nserver:      DNS4.EMDNS.UK 2401:fd80:405:0:0:0:0:153 43.230.49.153
nserver:      DNSA.EMDNS.UK 156.154.100.3 2001:502:ad09:0:0:0:0:3
nserver:      DNSB.EMDNS.UK 156.154.101.3 2001:502:2eda:0:0:0:0:3
nserver:      DNSC.EMDNS.UK 156.154.102.3 2610:a1:1009:0:0:0:0:3
nserver:      DNSD.EMDNS.UK 156.154.103.3 2610:a1:1010:0:0:0:0:3
ds-rdata:     60571 8 2 32ed00d841e724eaa980472283420ee9de48905e1b04709e79fc418c08fa1561

whois:        whois.nic.wed

status:       ACTIVE
remarks:      Registration information:
remarks:      https://www.icann.org/resources/pages/ebero-2013-04-02-en

created:      2013-12-12
changed:      2021-11-11
source:       IANA
```

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

Results of Syntax Checker (`make test`)
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->

```
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.2
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.2
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

