### PR TITLE
additional ngrok domain - add `ngrok.pro`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14168,6 +14168,7 @@ jp.ngrok.io
 sa.ngrok.io
 us.ngrok.io
 ngrok.pizza
+ngrok.pro
 
 // Nicolaus Copernicus University in Torun - MSK TORMAN (https://www.man.torun.pl)
 torun.pl


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

ngrok provides network ingress and tunneling services for more than 5 million developers. ngrok is used by engineers to aid in local development, as well as for network connectivity, and management for systems in production. I am an engineer at ngrok adding additional ingress domains, grouping different types of customers together, and also offering more customer choice.

Organization Website: https://ngrok.com
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->

Reason for PSL Inclusion
====

The reason for inclusion is for Cookie Security between different users' sessions. Customers can reserve or be assigned subdomains of these domains for ingress, browsers should not send cookies across them.

Previous ngrok additions to PSL:
- The initial PR that added `ngrok.io`: https://github.com/publicsuffix/list/pull/48
- An additional PR that added `ngrok.app` `ngrok-free.app` `ngrok.dev` `ngrok-free.dev` more `ngrok.io` and `ngrok.pizza`: https://github.com/publicsuffix/list/pull/1653
  - Some background in a blog post: https://ngrok.com/blog-post/new-ngrok-domains

For this PR:
- ngrok seeks to provide subdomains on `ngrok.pro` as a choice for a specific customer segment, paying customers who want to connect to their ngrok domain via browser using HTTP, not HTTPS.  This requires use of a domain with a TLD that is not on the HSTS preload list utilized by browsers (`.pro` is not on this list, whereas `.app` and `.dev`, the currently supported options on the ngrok platform, are).

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Number of users this request is being made to serve: 
- More than 5 million developers currently (https://ngrok.com/customers) 
<!--
Identify if this is current or an estimate.
-->

Registration expiry is more than 2 years out:
```
ngrok.pro   2026-07-20
```

Example Use-Cases:

A developer wants to test the code running on their laptop with a system like Twilio that uses webhooks. The developer starts an ngrok agent locally and ngrok provides a public url which forwards encrypted traffic to the service running on their local machine. The developer can then configure Twilio to use that domain to call when an event occurs such as an incoming SMS message. A domain in that situation would look like `84c5df439d74.ngrok.dev`, or `3a5c10d67779.eu.ngrok.io` if the agent is configured to use the European region (one of seven regions available).

The user can then easily add [webhook verification](https://ngrok.com/docs/cloud-edge/modules/webhook) to make sure it is Twilio making the request, or add [basic-auth](https://blog.ngrok.com/posts/authentication-with-ngrok), [oauth](https://blog.ngrok.com/posts/how-to-secure-your-network-tunnels-with-oauth-fast), [mutual-TLS](https://ngrok.com/docs/ngrok-agent/ngrok#flags-12), [allow/deny CIDR ranges](https://ngrok.com/docs/ngrok-agent/ngrok#flags-12), and other features. More information is in the [Getting Started guide](https://ngrok.com/docs/getting-started), or this Twilio ["6 awesome reasons to use ngrok when testing webhooks"](https://www.twilio.com/blog/2015/09/6-awesome-reasons-to-use-ngrok-when-testing-webhooks.html) post.

Customers can also reserve specific subdomains instead of having them randomly assigned, which could look like `my-company.ngrok.app` or `webhook-development.ngrok.dev`.  

With the addition of `ngrok.pro` to the ngrok service, paying customers who want to connect to their ngrok domain via browser using HTTP, not HTTPS, would be able to use a subdomain of `ngrok.pro`.

Enterprise customers use ngrok to centrally manage and secure ingress for their many applications deployed across public cloud, serverless platforms, their own data center or Internet of Things devices. This article about the recent ngrok funding raise provides a nice overview: [techcrunch.com/2022/12/13/ngrok-a-service-to-help-devs-deploy-sites-services-and-apps-raises-50m](https://techcrunch.com/2022/12/13/ngrok-a-service-to-help-devs-deploy-sites-services-and-apps-raises-50m/)

DNS Verification via dig
=======

For `ngrok.pro`:
```
dig +short TXT _psl.ngrok.pro  
"https://github.com/publicsuffix/list/pull/1895"
```

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

Results of Syntax Checker (`make test`)
=========

The tests ran successfully:
```
# TOTAL: 5
# PASS:  5
```
<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->


