### PR TITLE
AWS Submissions to the Public Suffix List - Q1 2024

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11390,7 +11390,7 @@ us-east-1.amazonaws.com
 
 // Amazon EMR
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 597f3f8e-9283-4e48-8e32-7ee25a1ff6ab
+// Reference: 82f43f9f-bbb8-400e-8349-854f5a62f20d
 emrappui-prod.cn-north-1.amazonaws.com.cn
 emrnotebooks-prod.cn-north-1.amazonaws.com.cn
 emrstudio-prod.cn-north-1.amazonaws.com.cn
@@ -11415,6 +11415,9 @@ emrstudio-prod.ap-northeast-3.amazonaws.com
 emrappui-prod.ap-south-1.amazonaws.com
 emrnotebooks-prod.ap-south-1.amazonaws.com
 emrstudio-prod.ap-south-1.amazonaws.com
+emrappui-prod.ap-south-2.amazonaws.com
+emrnotebooks-prod.ap-south-2.amazonaws.com
+emrstudio-prod.ap-south-2.amazonaws.com
 emrappui-prod.ap-southeast-1.amazonaws.com
 emrnotebooks-prod.ap-southeast-1.amazonaws.com
 emrstudio-prod.ap-southeast-1.amazonaws.com
@@ -11424,18 +11427,30 @@ emrstudio-prod.ap-southeast-2.amazonaws.com
 emrappui-prod.ap-southeast-3.amazonaws.com
 emrnotebooks-prod.ap-southeast-3.amazonaws.com
 emrstudio-prod.ap-southeast-3.amazonaws.com
+emrappui-prod.ap-southeast-4.amazonaws.com
+emrnotebooks-prod.ap-southeast-4.amazonaws.com
+emrstudio-prod.ap-southeast-4.amazonaws.com
 emrappui-prod.ca-central-1.amazonaws.com
 emrnotebooks-prod.ca-central-1.amazonaws.com
 emrstudio-prod.ca-central-1.amazonaws.com
+emrappui-prod.ca-west-1.amazonaws.com
+emrnotebooks-prod.ca-west-1.amazonaws.com
+emrstudio-prod.ca-west-1.amazonaws.com
 emrappui-prod.eu-central-1.amazonaws.com
 emrnotebooks-prod.eu-central-1.amazonaws.com
 emrstudio-prod.eu-central-1.amazonaws.com
+emrappui-prod.eu-central-2.amazonaws.com
+emrnotebooks-prod.eu-central-2.amazonaws.com
+emrstudio-prod.eu-central-2.amazonaws.com
 emrappui-prod.eu-north-1.amazonaws.com
 emrnotebooks-prod.eu-north-1.amazonaws.com
 emrstudio-prod.eu-north-1.amazonaws.com
 emrappui-prod.eu-south-1.amazonaws.com
 emrnotebooks-prod.eu-south-1.amazonaws.com
 emrstudio-prod.eu-south-1.amazonaws.com
+emrappui-prod.eu-south-2.amazonaws.com
+emrnotebooks-prod.eu-south-2.amazonaws.com
+emrstudio-prod.eu-south-2.amazonaws.com
 emrappui-prod.eu-west-1.amazonaws.com
 emrnotebooks-prod.eu-west-1.amazonaws.com
 emrstudio-prod.eu-west-1.amazonaws.com
@@ -11445,6 +11460,9 @@ emrstudio-prod.eu-west-2.amazonaws.com
 emrappui-prod.eu-west-3.amazonaws.com
 emrnotebooks-prod.eu-west-3.amazonaws.com
 emrstudio-prod.eu-west-3.amazonaws.com
+emrappui-prod.il-central-1.amazonaws.com
+emrnotebooks-prod.il-central-1.amazonaws.com
+emrstudio-prod.il-central-1.amazonaws.com
 emrappui-prod.me-central-1.amazonaws.com
 emrnotebooks-prod.me-central-1.amazonaws.com
 emrstudio-prod.me-central-1.amazonaws.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11808,6 +11808,22 @@ s3-fips.us-west-2.amazonaws.com
 s3-object-lambda.us-west-2.amazonaws.com
 s3-website.us-west-2.amazonaws.com
 
+// Amazon SageMaker Ground Truth
+// Submitted by AWS Security <psl-maintainers@amazon.com>
+// Reference: 98dbfde4-7802-48c3-8751-b60f204e0d9c
+labeling.ap-northeast-1.sagemaker.aws
+labeling.ap-northeast-2.sagemaker.aws
+labeling.ap-south-1.sagemaker.aws
+labeling.ap-southeast-1.sagemaker.aws
+labeling.ap-southeast-2.sagemaker.aws
+labeling.ca-central-1.sagemaker.aws
+labeling.eu-central-1.sagemaker.aws
+labeling.eu-west-1.sagemaker.aws
+labeling.eu-west-2.sagemaker.aws
+labeling.us-east-1.sagemaker.aws
+labeling.us-east-2.sagemaker.aws
+labeling.us-west-2.sagemaker.aws
+
 // Amazon SageMaker Notebook Instances
 // Submitted by AWS Security <psl-maintainers@amazon.com>
 // Reference: ce8ae0b1-0070-496d-be88-37c31837af9d

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11871,7 +11871,7 @@ notebook.cn-northwest-1.sagemaker.com.cn
 
 // Amazon SageMaker Studio
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 057ee397-6bf8-4f20-b807-d7bc145ac980
+// Reference: 69c723d9-6e1a-4bff-a203-48eecd203183
 studio.af-south-1.sagemaker.aws
 studio.ap-east-1.sagemaker.aws
 studio.ap-northeast-1.sagemaker.aws
@@ -11885,6 +11885,7 @@ studio.ca-central-1.sagemaker.aws
 studio.eu-central-1.sagemaker.aws
 studio.eu-north-1.sagemaker.aws
 studio.eu-south-1.sagemaker.aws
+studio.eu-south-2.sagemaker.aws
 studio.eu-west-1.sagemaker.aws
 studio.eu-west-2.sagemaker.aws
 studio.eu-west-3.sagemaker.aws

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11956,6 +11956,11 @@ webview-assets.aws-cloud9.us-west-2.amazonaws.com
 vfs.cloud9.us-west-2.amazonaws.com
 webview-assets.cloud9.us-west-2.amazonaws.com
 
+// AWS Directory Service
+// Submitted by AWS Security <psl-maintainers@amazon.com>
+// Reference: a13203e8-42dc-4045-a0d2-2ee67bed1068
+awsapps.com
+
 // AWS Elastic Beanstalk
 // Submitted by AWS Security <psl-maintainers@amazon.com>
 // Reference: bb5a965c-dec3-4967-aa22-e306ad064797

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11826,7 +11826,7 @@ labeling.us-west-2.sagemaker.aws
 
 // Amazon SageMaker Notebook Instances
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: ce8ae0b1-0070-496d-be88-37c31837af9d
+// Reference: b5ea56df-669e-43cc-9537-14aa172f5dfc
 notebook.af-south-1.sagemaker.aws
 notebook.ap-east-1.sagemaker.aws
 notebook.ap-northeast-1.sagemaker.aws
@@ -11863,6 +11863,7 @@ notebook-fips.us-gov-east-1.sagemaker.aws
 notebook.us-gov-west-1.sagemaker.aws
 notebook-fips.us-gov-west-1.sagemaker.aws
 notebook.us-west-1.sagemaker.aws
+notebook-fips.us-west-1.sagemaker.aws
 notebook.us-west-2.sagemaker.aws
 notebook-fips.us-west-2.sagemaker.aws
 notebook.cn-north-1.sagemaker.com.cn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11493,9 +11493,11 @@ emrstudio-prod.us-west-2.amazonaws.com
 
 // Amazon Managed Workflows for Apache Airflow
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 4ab55e6f-90c0-4a8d-b6a0-52ca5dbb1c2e
+// Reference: 87f24ece-a77e-40e8-bb4a-f6b74fe9f975
 *.cn-north-1.airflow.amazonaws.com.cn
 *.cn-northwest-1.airflow.amazonaws.com.cn
+*.af-south-1.airflow.amazonaws.com
+*.ap-east-1.airflow.amazonaws.com
 *.ap-northeast-1.airflow.amazonaws.com
 *.ap-northeast-2.airflow.amazonaws.com
 *.ap-south-1.airflow.amazonaws.com
@@ -11504,12 +11506,15 @@ emrstudio-prod.us-west-2.amazonaws.com
 *.ca-central-1.airflow.amazonaws.com
 *.eu-central-1.airflow.amazonaws.com
 *.eu-north-1.airflow.amazonaws.com
+*.eu-south-1.airflow.amazonaws.com
 *.eu-west-1.airflow.amazonaws.com
 *.eu-west-2.airflow.amazonaws.com
 *.eu-west-3.airflow.amazonaws.com
+*.me-south-1.airflow.amazonaws.com
 *.sa-east-1.airflow.amazonaws.com
 *.us-east-1.airflow.amazonaws.com
 *.us-east-2.airflow.amazonaws.com
+*.us-west-1.airflow.amazonaws.com
 *.us-west-2.airflow.amazonaws.com
 
 // Amazon S3

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11346,23 +11346,28 @@ cloudfront.net
 
 // Amazon Cognito
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 7bee1013-f456-47df-bfe8-03c78d946d61
+// Reference: 09588633-91fe-49d8-b4e7-ec36496d11f3
 auth.af-south-1.amazoncognito.com
 auth.ap-northeast-1.amazoncognito.com
 auth.ap-northeast-2.amazoncognito.com
 auth.ap-northeast-3.amazoncognito.com
 auth.ap-south-1.amazoncognito.com
+auth.ap-south-2.amazoncognito.com
 auth.ap-southeast-1.amazoncognito.com
 auth.ap-southeast-2.amazoncognito.com
 auth.ap-southeast-3.amazoncognito.com
+auth.ap-southeast-4.amazoncognito.com
 auth.ca-central-1.amazoncognito.com
 auth.eu-central-1.amazoncognito.com
+auth.eu-central-2.amazoncognito.com
 auth.eu-north-1.amazoncognito.com
 auth.eu-south-1.amazoncognito.com
+auth.eu-south-2.amazoncognito.com
 auth.eu-west-1.amazoncognito.com
 auth.eu-west-2.amazoncognito.com
 auth.eu-west-3.amazoncognito.com
 auth.il-central-1.amazoncognito.com
+auth.me-central-1.amazoncognito.com
 auth.me-south-1.amazoncognito.com
 auth.sa-east-1.amazoncognito.com
 auth.us-east-1.amazoncognito.com


### PR DESCRIPTION
# Public Suffix List (PSL) Pull Request (PR) Template
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps
* [x]  Description of Organization
* [x]  Robust Reason for PSL Inclusion
* [x]  DNS verification via dig
* [x]  Run Syntax Checker (make test)
* [x]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place in the respective zone(s) in the affected section

**Submitter affirms the following:**

* [x]  We are listing _any_ third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  _AWS does not submit suffixes to the Public Suffix List to work around rate-limits of any third-party products or tooling._
* [x]  This request was _not_ submitted with the objective of working around other third-party limits
  _Please see the Reason section below for objectives in this pull request._
* [x]  The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
* [x]  The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [x]  _Yes, I understand_. I could break my organization's website cookies etc. and the rollback timing, etc is acceptable. _Proceed_.

# Description of Organization
Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopted cloud, offering over 200 fully featured services from data centers globally. More information about AWS is available on our website: [What is AWS?](https://aws.amazon.com/what-is-aws/)

**Organization Website:** [AWS Homepage](https://aws.amazon.com)

# Reason for PSL Inclusion
These features/services have been identified by AWS Security and AWS service teams as supporting different distinct customers/resources across shared DNS suffixes. Adding these suffixes to the PSL is expected to improve the security posture of customers using our services. This may include:

* impact to the Same-Origin Policy in modern browsers (cookies + others)
* representation of these domains to the CA/Browser Forum
* any other use-cases of the PSL which may benefit from updated information about multi-tenant AWS services

**Number of users this request is being made to serve:**

These changes are expected to impact all customers using these AWS services. This includes both AWS-internal and external customers. Specific user counts for these listed features/services are not publicly available.

# Services/Features in PR:

- Amazon Cognito
- Amazon EMR
- Amazon Managed Workflows for Apache Airflow
- Amazon SageMaker Ground Truth
- Amazon SageMaker Notebook Instances
- Amazon SageMaker Studio
- AWS Directory Service

# DNS Verification via dig
<details>
<summary>DNS query results</summary>

```
auth.ap-south-2.amazoncognito.com: dig +short -t TXT _psl.auth.ap-south-2.amazoncognito.com)
"https://github.com/publicsuffix/list/pull/1919"



auth.ap-southeast-4.amazoncognito.com: dig +short -t TXT _psl.auth.ap-southeast-4.amazoncognito.com)
"https://github.com/publicsuffix/list/pull/1919"



auth.eu-central-2.amazoncognito.com: dig +short -t TXT _psl.auth.eu-central-2.amazoncognito.com)
"https://github.com/publicsuffix/list/pull/1919"



auth.eu-south-2.amazoncognito.com: dig +short -t TXT _psl.auth.eu-south-2.amazoncognito.com)
"https://github.com/publicsuffix/list/pull/1919"



auth.me-central-1.amazoncognito.com: dig +short -t TXT _psl.auth.me-central-1.amazoncognito.com)
"https://github.com/publicsuffix/list/pull/1919"



awsapps.com: dig +short -t TXT _psl.awsapps.com)
"https://github.com/publicsuffix/list/pull/1919"



emrappui-prod.ap-south-2.amazonaws.com: dig +short -t TXT _psl.emrappui-prod.ap-south-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrnotebooks-prod.ap-south-2.amazonaws.com: dig +short -t TXT _psl.emrnotebooks-prod.ap-south-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrstudio-prod.ap-south-2.amazonaws.com: dig +short -t TXT _psl.emrstudio-prod.ap-south-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrappui-prod.ap-southeast-4.amazonaws.com: dig +short -t TXT _psl.emrappui-prod.ap-southeast-4.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrnotebooks-prod.ap-southeast-4.amazonaws.com: dig +short -t TXT _psl.emrnotebooks-prod.ap-southeast-4.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrstudio-prod.ap-southeast-4.amazonaws.com: dig +short -t TXT _psl.emrstudio-prod.ap-southeast-4.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrappui-prod.ca-west-1.amazonaws.com: dig +short -t TXT _psl.emrappui-prod.ca-west-1.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrnotebooks-prod.ca-west-1.amazonaws.com: dig +short -t TXT _psl.emrnotebooks-prod.ca-west-1.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrstudio-prod.ca-west-1.amazonaws.com: dig +short -t TXT _psl.emrstudio-prod.ca-west-1.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrappui-prod.eu-central-2.amazonaws.com: dig +short -t TXT _psl.emrappui-prod.eu-central-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrnotebooks-prod.eu-central-2.amazonaws.com: dig +short -t TXT _psl.emrnotebooks-prod.eu-central-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrstudio-prod.eu-central-2.amazonaws.com: dig +short -t TXT _psl.emrstudio-prod.eu-central-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrappui-prod.eu-south-2.amazonaws.com: dig +short -t TXT _psl.emrappui-prod.eu-south-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrnotebooks-prod.eu-south-2.amazonaws.com: dig +short -t TXT _psl.emrnotebooks-prod.eu-south-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrstudio-prod.eu-south-2.amazonaws.com: dig +short -t TXT _psl.emrstudio-prod.eu-south-2.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrappui-prod.il-central-1.amazonaws.com: dig +short -t TXT _psl.emrappui-prod.il-central-1.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrnotebooks-prod.il-central-1.amazonaws.com: dig +short -t TXT _psl.emrnotebooks-prod.il-central-1.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



emrstudio-prod.il-central-1.amazonaws.com: dig +short -t TXT _psl.emrstudio-prod.il-central-1.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



*.af-south-1.airflow.amazonaws.com: dig +short -t TXT _psl.af-south-1.airflow.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



*.ap-east-1.airflow.amazonaws.com: dig +short -t TXT _psl.ap-east-1.airflow.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



*.eu-south-1.airflow.amazonaws.com: dig +short -t TXT _psl.eu-south-1.airflow.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



*.me-south-1.airflow.amazonaws.com: dig +short -t TXT _psl.me-south-1.airflow.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



*.us-west-1.airflow.amazonaws.com: dig +short -t TXT _psl.us-west-1.airflow.amazonaws.com)
"https://github.com/publicsuffix/list/pull/1919"



labeling.ap-northeast-1.sagemaker.aws: dig +short -t TXT _psl.labeling.ap-northeast-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.ap-northeast-2.sagemaker.aws: dig +short -t TXT _psl.labeling.ap-northeast-2.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.ap-south-1.sagemaker.aws: dig +short -t TXT _psl.labeling.ap-south-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.ap-southeast-1.sagemaker.aws: dig +short -t TXT _psl.labeling.ap-southeast-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.ap-southeast-2.sagemaker.aws: dig +short -t TXT _psl.labeling.ap-southeast-2.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.ca-central-1.sagemaker.aws: dig +short -t TXT _psl.labeling.ca-central-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.eu-central-1.sagemaker.aws: dig +short -t TXT _psl.labeling.eu-central-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.eu-west-1.sagemaker.aws: dig +short -t TXT _psl.labeling.eu-west-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.eu-west-2.sagemaker.aws: dig +short -t TXT _psl.labeling.eu-west-2.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.us-east-1.sagemaker.aws: dig +short -t TXT _psl.labeling.us-east-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.us-east-2.sagemaker.aws: dig +short -t TXT _psl.labeling.us-east-2.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



labeling.us-west-2.sagemaker.aws: dig +short -t TXT _psl.labeling.us-west-2.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



notebook-fips.us-west-1.sagemaker.aws: dig +short -t TXT _psl.notebook-fips.us-west-1.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"



studio.eu-south-2.sagemaker.aws: dig +short -t TXT _psl.studio.eu-south-2.sagemaker.aws)
"https://github.com/publicsuffix/list/pull/1919"




```

</details>

# Results of Syntax Checker (`make test`)
<details>
<summary>Test results</summary>

```
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/__fake__/public_suffix_list.dat --with-psl-testfile=/__fake__/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       common.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc

```

</details>
