### PR TITLE
Add a2hosted.com and cpserver.com suffix to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11210,6 +11210,11 @@ ltd.ua
 // 611coin : https://611project.org/
 611.to
 
+// A2 Hosting
+// Submitted by Tyler Hall <sysadmin@a2hosting.com>
+a2hosted.com
+cpserver.com
+
 // Aaron Marais' Gitlab pages: https://lab.aaronleem.co.za
 // Submitted by Aaron Marais <its_me@aaronleem.co.za>
 graphox.us


### PR DESCRIPTION
Added a2hosted.com and cpserver.com to public_suffer_list.dat on behalf of A2Hosting

Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms

  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

A2 Hosting is a premier web hosting provider, offering a wide array of services to individuals and small businesses across the globe. We have a focus on speed and performance, delivering that not only from the servers to the applications, but also through our robust customer support. Our portfolio includes a diverse range of hosting solutions, from shared and WordPress hosting to reseller options, virtual private servers, and bare metal dedicated servers, tailored to meet the unique needs of our clientele.

The submitter, Tyler Hall, is a Senior Manager for the A2 Hosting Engineering team.

Organization Website: 

https://www.a2hosting.com

Reason for PSL Inclusion
====

As part of our provisioning process, A2 Hosting offers customers subdomains under the a2hosted.com and cpserver.com domain names, while also issuing LetsEncrypt SSL certificates to ensure secure and trusted web experiences.

Number of users this request is being made to serve:

A2 Hosting has over 100,000 customers that utilize the a2hosted.com and cpserver.com hostnames.

DNS Verification via dig
=======

```
$ dig TXT _psl.a2hosted.com +short
"https://github.com/publicsuffix/list/pull/1926"
$ dig TXT _psl.cpserver.com +short
"https://github.com/publicsuffix/list/pull/1926"
```

Results of Syntax Checker (`make test`)
=========

```
PASS: libpsl_icu_load_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================


```