### PR TITLE
Salesforce crm dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14860,7 +14860,7 @@ from.tv
 sakura.tv
 
 // Salesforce.com, Inc. https://salesforce.com/
-// Submitted by Michael Biven <mbiven@salesforce.com>, Aaron Romeo <aaron.romeo@salesforce.com>, and Steven Lawrance <slawrance@salesforce.com>
+// Submitted by Salesforce Public Suffix List Team <public-suffix-list@salesforce.com>
 *.builder.code.com
 *.dev-builder.code.com
 *.stg-builder.code.com
@@ -14873,26 +14873,6 @@ sakura.tv
 *.wd.crm.dev
 *.we.crm.dev
 *.wf.crm.dev
-*.wg.crm.dev
-*.wh.crm.dev
-*.wi.crm.dev
-*.wj.crm.dev
-*.wk.crm.dev
-*.wl.crm.dev
-*.wm.crm.dev
-*.wn.crm.dev
-*.wo.crm.dev
-*.wp.crm.dev
-*.wq.crm.dev
-*.wr.crm.dev
-*.ws.crm.dev
-*.wt.crm.dev
-*.wu.crm.dev
-*.wv.crm.dev
-*.ww.crm.dev
-*.wx.crm.dev
-*.wy.crm.dev
-*.wz.crm.dev
 
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14866,6 +14866,38 @@ sakura.tv
 *.stg-builder.code.com
 *.001.test.code-builder-stg.platform.salesforce.com
 
+// Salesforce.com, Inc. Sales Cloud https://salesforce.com/
+// Submitted by Steven Lawrance <slawrance@salesforce.com>
+*.crm.dev
+*.d.crm.dev
+*.w.crm.dev
+*.wa.crm.dev
+*.wb.crm.dev
+*.wc.crm.dev
+*.wd.crm.dev
+*.we.crm.dev
+*.wf.crm.dev
+*.wg.crm.dev
+*.wh.crm.dev
+*.wi.crm.dev
+*.wj.crm.dev
+*.wk.crm.dev
+*.wl.crm.dev
+*.wm.crm.dev
+*.wn.crm.dev
+*.wo.crm.dev
+*.wp.crm.dev
+*.wq.crm.dev
+*.wr.crm.dev
+*.ws.crm.dev
+*.wt.crm.dev
+*.wu.crm.dev
+*.wv.crm.dev
+*.ww.crm.dev
+*.wx.crm.dev
+*.wy.crm.dev
+*.wx.crm.dev
+
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>
 sandcats.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14868,7 +14868,6 @@ sakura.tv
 
 // Salesforce.com, Inc. Sales Cloud https://salesforce.com/
 // Submitted by Steven Lawrance <slawrance@salesforce.com>
-*.crm.dev
 *.d.crm.dev
 *.w.crm.dev
 *.wa.crm.dev

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14896,7 +14896,7 @@ sakura.tv
 *.ww.crm.dev
 *.wx.crm.dev
 *.wy.crm.dev
-*.wx.crm.dev
+*.wz.crm.dev
 
 // Sandstorm Development Group, Inc. : https://sandcats.io/
 // Submitted by Asheesh Laroia <asheesh@sandstorm.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14860,14 +14860,11 @@ from.tv
 sakura.tv
 
 // Salesforce.com, Inc. https://salesforce.com/
-// Submitted by Michael Biven <mbiven@salesforce.com> and Aaron Romeo <aaron.romeo@salesforce.com>
+// Submitted by Michael Biven <mbiven@salesforce.com>, Aaron Romeo <aaron.romeo@salesforce.com>, and Steven Lawrance <slawrance@salesforce.com>
 *.builder.code.com
 *.dev-builder.code.com
 *.stg-builder.code.com
 *.001.test.code-builder-stg.platform.salesforce.com
-
-// Salesforce.com, Inc. Sales Cloud https://salesforce.com/
-// Submitted by Steven Lawrance <slawrance@salesforce.com>
 *.d.crm.dev
 *.w.crm.dev
 *.wa.crm.dev


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section: Expiration is now 2029-02-12T23:46:32Z, as per https://whois-webform.markmonitor.com/whois/

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
We're not seeking to work around browser limits. Instead, we're seeking to have our entries treated as domain suffixes to maximize the fidelity of Salesforce's internal development environment with its production systems while making use of crm.dev instead of the actual production domains.

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
Salesforce, Inc. is an American cloud-based software company headquartered in San Francisco, California. It provides customer relationship management (CRM) software and applications focused on sales, customer service, marketing automation, e-commerce, analytics, and application development. A core component of this is Salesforce's Sales, Service, and Experience Cloud, which is an integrated software system that undergoes continuous development by around 10,000 software developers.

I am Steven Lawrance, an architect on Salesforce's Sales, Service, and Experience Cloud that focuses on how the system makes use of DNS names for maximizing web security and isolation for customers in a scalable manner.
<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Organization Website: 
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->
https://www.salesforce.com

Reason for PSL Inclusion
====
The Salesforce Sales, Service, and Experience Cloud system serves a large number of URL hostname patterns. To represent these in our internal development environment used by ~10,000 developers while separating the actual production and development domains, we use a URL hostname format that looks like MyDomainName.my.salesforce-com.WorkspaceID.w.crm.dev. To have WorkspaceID.w.crm.dev treated the same as 'com', we need to have *.w.crm.dev in the PSL. The salesforce-com (or force-com, etc.) subdomain thus gets treated as a registrable domain for cookie and privacy features within web browsers, mimicking the production salesforce.com and force.com domains. In addition to *.w.crm.dev, Salesforce has 26 partitions based on a letter that follows the 'w', hence the *.wa.crm.dev, *.wb.crm.dev, and so on names. Salesforce also has a separate development environment that uses 'd' instead of 'w', which is why *.d.crm.dev is in the list.
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Number of users this request is being made to serve: Around 10,000 (estimated)
<!--
Identify if this is current or an estimate.
-->


DNS Verification via dig
=======
```
dig +short TXT _psl.d.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.w.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wa.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wb.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wc.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wd.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.we.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wf.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wg.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wh.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wi.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wj.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wk.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wl.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wm.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wn.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wo.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wp.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wq.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wr.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.ws.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wt.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wu.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wv.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.ww.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wx.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wy.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```

```
dig +short TXT _psl.wz.crm.dev
"https://github.com/publicsuffix/list/pull/1941"
```
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

Results of Syntax Checker (`make test`)
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->
```
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC: 
OK
-n test_allowedchars: 
OK
-n test_dots: 
OK
-n test_duplicate: 
OK
-n test_exception: 
OK
-n test_punycode: 
OK
-n test_section1: 
OK
-n test_section2: 
OK
-n test_section3: 
OK
-n test_section4: 
OK
-n test_spaces: 
OK
-n test_wildcard: 
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
	  cd libpsl;                                                                    \
	  git pull;                                                                     \
	  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
	  echo "CLEANFILES =" >> gtk-doc.make;                                          \
	  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file 'version.txt' included several times
configure.ac:4: warning: file 'version.txt' included several times
aclocal.m4:765: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:369: warning: file 'version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/Users/slawrance/dev/list/public_suffix_list.dat --with-psl-testfile=/Users/slawrance/dev/list/tests/tests.txt && make -s clean && make -s check -j4
configure: error: 'CPPFLAGS' was set to '-I/usr/local/opt/icu4c/include' in the previous run
configure: error: in '/Users/slawrance/dev/list/libpsl':
configure: error: changes in the environment can compromise the build
configure: error: run 'make distclean' and/or 'rm config.cache'
	    and start over
make: *** [libpsl-libicu] Error 1
slawran-ltm3b7r:list slawrance$ export CPPFLAGS=-I/usr/local/opt/icu4c/include
slawran-ltm3b7r:list slawrance$ make
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC: 
OK
-n test_allowedchars: 
OK
-n test_dots: 
OK
-n test_duplicate: 
OK
-n test_exception: 
OK
-n test_punycode: 
OK
-n test_section1: 
OK
-n test_section2: 
OK
-n test_section3: 
OK
-n test_section4: 
OK
-n test_spaces: 
OK
-n test_wildcard: 
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
	  cd libpsl;                                                                    \
	  git pull;                                                                     \
	  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
	  echo "CLEANFILES =" >> gtk-doc.make;                                          \
	  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file 'version.txt' included several times
configure.ac:4: warning: file 'version.txt' included several times
aclocal.m4:765: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:369: warning: file 'version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/Users/slawrance/dev/list/public_suffix_list.dat --with-psl-testfile=/Users/slawrance/dev/list/tests/tests.txt && make -s clean && make -s check -j4
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       test-is-cookie-domain-acceptable.o
  CC       common.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-all
  CCLD     test-is-public-builtin
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin23.3.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin23.3.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin23.3.0
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin23.3.0
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
  CCLD     test-registrable-domain
libtool: warning: '-no-install' is ignored for x86_64-apple-darwin23.3.0
libtool: warning: assuming '-no-fast-install' instead
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public-all
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```