### PR TITLE
Add `box.ca` (Whatbox)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15467,6 +15467,10 @@ wedeploy.sh
 // Submitted by Jung Jin <jungseok.jin@wdc.com>
 remotewd.com
 
+// Whatbox Inc. : https://whatbox.ca/
+// Submitted by Anthony Ryan <servers@whatbox.ca>
+box.ca
+
 // WIARD Enterprises : https://wiardweb.com
 // Submitted by Kidd Hustle <kiddhustle@wiardweb.com>
 pages.wiardweb.com


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
* [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
* [X] This request was _not_ submitted with the objective of working around other third-party limits
* [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
* [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

Whatbox is an app hosting company operating since 2011. Our customers include both small businesses and prosumers.

We sell hosting solutions for resource-intensive open source applications. Software that requires multi-gigabit network speeds, terabytes of storage space and intensive CPU operations like video transcoding.

We help simplify the configuration, security and updates of these applications while collaborating with open source developers.

This request is Anthony Ryan, CEO of Whatbox Inc.

Organization Website: 
[whatbox.ca](https://whatbox.ca/)


Reason for PSL Inclusion
====

We provide each customer with a subdomain under box.ca, the marketing being "what (is your) box", that is secured by LetsEncrypt SSL certificates.

LetsEncyrpt has been kind enough to raise our renewal rates when it has been necessary, so we have no current or anticipated problems there.

We wish to be added to the public suffix list to avoid the risk of cookie theft between subdomains. Because each subdomain belongs to a separate customer, having them within the same domain namespace is a security risk that the public suffix list can mitigate.


Number of users this request is being made to serve:
Over 9000!

DNS Verification via dig
=======

```
dig +short TXT _psl.box.ca
"https://github.com/publicsuffix/list/issues/1950"
```


Results of Syntax Checker (`make test`)
=========

```
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests

...

PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```