### PR TITLE
Add an alphabetic check for submissions

### DIFF
--- a/.github/workflows/test-alphabetical.yml
+++ b/.github/workflows/test-alphabetical.yml
@@ -24,7 +24,7 @@ jobs:
                 ref: ${{ github.event.pull_request.base.ref }}
                 path: base
             - name: Content check
-              run: python3 base/alphabet_script.py pull-request/public_suffix_list.dat > results.txt
+              run: python3 base/tools/alphabet_script.py pull-request/public_suffix_list.dat > results.txt
             - name: Read the result
               id: read_results
               uses: andstor/file-reader-action@v1

--- a/.github/workflows/test-alphabetical.yml
+++ b/.github/workflows/test-alphabetical.yml
@@ -31,6 +31,7 @@ jobs:
               with:
                 path: "results.txt"
             - name: Create Comment
+              if: steps.read_results.outputs.contents != ''
               uses: mshick/add-pr-comment@v2
               with:
                 message-path: "results.txt"

--- a/.github/workflows/test-alphabetical.yml
+++ b/.github/workflows/test-alphabetical.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Get PR files
               uses: actions/checkout@v2
               with:
-                ref: "${{ github.ref }}"
+                ref: "${{ github.event.pull_request.head.sha }}"
                 path: "pull-request"
             - name: Get base ref
               uses: actions/checkout@v2

--- a/.github/workflows/test-alphabetical.yml
+++ b/.github/workflows/test-alphabetical.yml
@@ -46,8 +46,4 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     labels: ['Alphabet Check Success']
-                    })
-
-              
-
-            
+                    })          

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6710,7 +6710,7 @@ org.zw
 
 // newGTLDs
 
-// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2024-01-24T15:14:29Z
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2024-02-08T15:13:14Z
 // This list is auto-generated, don't edit it manually.
 // aaa : American Automobile Association, Inc.
 // https://www.iana.org/domains/root/db/aaa.html
@@ -7539,10 +7539,6 @@ college
 // cologne : dotKoeln GmbH
 // https://www.iana.org/domains/root/db/cologne.html
 cologne
-
-// comcast : Comcast IP Holdings I, LLC
-// https://www.iana.org/domains/root/db/comcast.html
-comcast
 
 // commbank : COMMONWEALTH BANK OF AUSTRALIA
 // https://www.iana.org/domains/root/db/commbank.html
@@ -10755,10 +10751,6 @@ xbox
 // xerox : Xerox DNHC LLC
 // https://www.iana.org/domains/root/db/xerox.html
 xerox
-
-// xfinity : Comcast IP Holdings I, LLC
-// https://www.iana.org/domains/root/db/xfinity.html
-xfinity
 
 // xihuan : Beijing Qihu Keji Co., Ltd.
 // https://www.iana.org/domains/root/db/xihuan.html

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12426,6 +12426,10 @@ feste-ip.net
 knx-server.net
 static-access.net
 
+// cPanel L.L.C. : https://www.cpanel.net/
+// Submitted by Dustin Scherer <public.suffix@cpanel.net>
+*.cprapid.com
+
 // Craynic, s.r.o. : http://www.craynic.com/
 // Submitted by Ales Krajnik <ales.krajnik@craynic.com>
 realm.cz

--- a/tools/alphabet_script.py
+++ b/tools/alphabet_script.py
@@ -13,7 +13,7 @@ def check_private_domains(file):
                     before_private = False
                 else:
                     continue
-            if re.search("^\/\/ .* *: *https:\/\/.*", line):
+            if re.search("^\/\/ .* *: *https?:\/\/.*", line):
                 wrong_domains, next_index = title_is_less(content, index)
                 if wrong_domains:
                     wrong_order_submissions.append(wrong_domains)
@@ -28,7 +28,7 @@ def title_is_less(content, starting_index):
     wrong_order = []
     end_index = -1
     for index, line in enumerate(content[starting_index+1:], starting_index+1):
-        if re.search("^\/\/ .* *: *https:\/\/.*", line):
+        if re.search("^\/\/ .* *: *https?:\/\/.*", line):
             end_index = index
             next_domain = line.removeprefix("//").lower().strip()
             if domain > next_domain:


### PR DESCRIPTION
This PR attempts to add a check that will assess whether the "business name" of entries in the private domain are in alphabetical order, and that the domains listed under each entry are in the correct order at time of submission.

The check contained here attempts to use a regular expression to identify entries into the private domains list. However, this is not perfect - it seems like there is some inconsistency with the formatting of entries, making it difficult to pick a perfect way of identifying entries in the current list. The current expression identifies the vast majority of entries from what I can tell, but happy to use an alternative  method if one exists. 

Additionally, while creating this check it became apparent that there are currently many entries in the list that are not sorted correctly according to the existing guidelines. I'm happy to re-sort the list accordingly in this PR or in a preceding PR before this is merged.