### PR TITLE
AWS Submissions to the Public Suffix List - Q2 2024

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11918,8 +11918,8 @@ analytics-gateway.us-west-2.amazonaws.com
 
 // AWS Amplify
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 5ecce854-c033-4fc4-a755-1a9916d9a9bb
-*.amplifyapp.com
+// Reference: c35bed18-6f4f-424f-9298-5756f2f7d72b
+amplifyapp.com
 
 // AWS App Runner
 // Submitted by AWS Security <psl-maintainers@amazon.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11913,6 +11913,11 @@ studio.us-west-2.sagemaker.aws
 studio.cn-north-1.sagemaker.com.cn
 studio.cn-northwest-1.sagemaker.com.cn
 
+// Amazon SageMaker with MLflow
+// Submited by: AWS Security <psl-maintainers@amazon.com>
+// Reference: c19f92b3-a82a-452d-8189-831b572eea7e
+*.experiments.sagemaker.aws
+
 // Analytics on AWS
 // Submitted by AWS Security <psl-maintainers@amazon.com>
 // Reference: 955f9f40-a495-4e73-ae85-67b77ac9cadd

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11344,8 +11344,9 @@ cloudfront.net
 
 // Amazon Cognito
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 09588633-91fe-49d8-b4e7-ec36496d11f3
+// Reference: cb38c251-c93d-4cda-81ec-e72c4f0fdb72
 auth.af-south-1.amazoncognito.com
+auth.ap-east-1.amazoncognito.com
 auth.ap-northeast-1.amazoncognito.com
 auth.ap-northeast-2.amazoncognito.com
 auth.ap-northeast-3.amazoncognito.com
@@ -11356,6 +11357,7 @@ auth.ap-southeast-2.amazoncognito.com
 auth.ap-southeast-3.amazoncognito.com
 auth.ap-southeast-4.amazoncognito.com
 auth.ca-central-1.amazoncognito.com
+auth.ca-west-1.amazoncognito.com
 auth.eu-central-1.amazoncognito.com
 auth.eu-central-2.amazoncognito.com
 auth.eu-north-1.amazoncognito.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11493,23 +11493,32 @@ emrstudio-prod.us-west-2.amazonaws.com
 
 // Amazon Managed Workflows for Apache Airflow
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 87f24ece-a77e-40e8-bb4a-f6b74fe9f975
+// Reference: f5ea5d0a-ec6a-4f23-ac1c-553fbff13f5c
 *.cn-north-1.airflow.amazonaws.com.cn
 *.cn-northwest-1.airflow.amazonaws.com.cn
 *.af-south-1.airflow.amazonaws.com
 *.ap-east-1.airflow.amazonaws.com
 *.ap-northeast-1.airflow.amazonaws.com
 *.ap-northeast-2.airflow.amazonaws.com
+*.ap-northeast-3.airflow.amazonaws.com
 *.ap-south-1.airflow.amazonaws.com
+*.ap-south-2.airflow.amazonaws.com
 *.ap-southeast-1.airflow.amazonaws.com
 *.ap-southeast-2.airflow.amazonaws.com
+*.ap-southeast-3.airflow.amazonaws.com
+*.ap-southeast-4.airflow.amazonaws.com
 *.ca-central-1.airflow.amazonaws.com
+*.ca-west-1.airflow.amazonaws.com
 *.eu-central-1.airflow.amazonaws.com
+*.eu-central-2.airflow.amazonaws.com
 *.eu-north-1.airflow.amazonaws.com
 *.eu-south-1.airflow.amazonaws.com
+*.eu-south-2.airflow.amazonaws.com
 *.eu-west-1.airflow.amazonaws.com
 *.eu-west-2.airflow.amazonaws.com
 *.eu-west-3.airflow.amazonaws.com
+*.il-central-1.airflow.amazonaws.com
+*.me-central-1.airflow.amazonaws.com
 *.me-south-1.airflow.amazonaws.com
 *.sa-east-1.airflow.amazonaws.com
 *.us-east-1.airflow.amazonaws.com


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.


### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example) 
 _AWS does not submit suffixes to the Public Suffix List to work around rate-limits of any third-party products or tooling._

 * [X] This request was _not_ submitted with the objective of working around other third-party limits
 _Please see the Reason section below for objectives in this pull request._

 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies etc. and the rollback timing, etc is acceptable. *Proceed*.

---

Description of Organization
====

Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopted cloud, offering over 200 fully featured services from data centers globally. 
More information about AWS is available on our website:
[What is AWS?](https://aws.amazon.com/what-is-aws/)

**Organization Website:** 
[AWS Homepage](https://aws.amazon.com)

Reason for PSL Inclusion
====

These features/services have been identified by AWS Security and AWS service
teams as supporting different distinct customers/resources across shared
DNS suffixes. Adding these suffixes to the PSL is expected to improve the
security posture of customers using our services. This may include:

- impact to the Same-Origin Policy in modern browsers (cookies + others)
- representation of these domains to the CA/Browser Forum
- any other use-cases of the PSL which may benefit from updated information about multi-tenant AWS services

**Number of users this request is being made to serve:**

These changes are expected to impact all customers using these AWS services.
This includes both AWS-internal and external customers. Specific user counts
for these listed features/services are not publicly available.

Services/Features in PR:
====

- Amazon SageMaker with MLflow
- Amazon Managed Workflows for Apache Airflow
- Amazon Cognito
- AWS Amplify

DNS Verification via dig
=======

<details>
<summary>DNS query results</summary>

```
amplifyapp.com: dig +short -t TXT _psl.amplifyapp.com
"https://github.com/publicsuffix/list/pull/1954"



auth.ap-east-1.amazoncognito.com: dig +short -t TXT _psl.auth.ap-east-1.amazoncognito.com
"https://github.com/publicsuffix/list/pull/1954"



auth.ca-west-1.amazoncognito.com: dig +short -t TXT _psl.auth.ca-west-1.amazoncognito.com
"https://github.com/publicsuffix/list/pull/1954"



*.ap-northeast-3.airflow.amazonaws.com: dig +short -t TXT _psl.ap-northeast-3.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.ap-south-2.airflow.amazonaws.com: dig +short -t TXT _psl.ap-south-2.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.ap-southeast-3.airflow.amazonaws.com: dig +short -t TXT _psl.ap-southeast-3.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.ap-southeast-4.airflow.amazonaws.com: dig +short -t TXT _psl.ap-southeast-4.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.ca-west-1.airflow.amazonaws.com: dig +short -t TXT _psl.ca-west-1.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.eu-central-2.airflow.amazonaws.com: dig +short -t TXT _psl.eu-central-2.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.eu-south-2.airflow.amazonaws.com: dig +short -t TXT _psl.eu-south-2.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.il-central-1.airflow.amazonaws.com: dig +short -t TXT _psl.il-central-1.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.me-central-1.airflow.amazonaws.com: dig +short -t TXT _psl.me-central-1.airflow.amazonaws.com
"https://github.com/publicsuffix/list/pull/1954"



*.experiments.sagemaker.aws: dig +short -t TXT _psl.experiments.sagemaker.aws
"https://github.com/publicsuffix/list/pull/1954"



```

</details>

Results of Syntax Checker (`make test`)
=========

<details>
<summary>Test results</summary>

```
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Updating 477c582..490bd6f
Fast-forward
 .github/workflows/unit-tests.yml         |  48 +++++++
 .travis.yml                              |  59 --------
 .travis_coveralls.sh                     |   6 -
 COPYING                                  |   2 +-
 LICENSE                                  |   2 +-
 NEWS                                     |  14 +-
 README.md                                |  43 +++---
 configure.ac                             |  24 +---
 contrib/check-hard                       |   2 +-
 contrib/check-hard-meson                 |   2 +-
 contrib/mingw.static                     |  55 ++++++++
 docs/libpsl/meson.build                  |  14 +-
 fuzz/fuzzer.h                            |   2 +-
 fuzz/libpsl_fuzzer.c                     |   2 +-
 fuzz/libpsl_load_dafsa_fuzzer.c          |   2 +-
 fuzz/libpsl_load_fuzzer.c                |   2 +-
 fuzz/main.c                              |   2 +-
 fuzz/run-afl.sh                          |   2 +-
 fuzz/run-clang.sh                        |   2 +-
 include/libpsl.h.in                      |   2 +-
 libpsl.pc.in                             |   1 +
 libtool_version_info.txt                 |   2 +-
 list                                     |   2 +-
 m4/absolute-header.m4                    | 100 ++++++++++++++
 m4/libunistring.m4                       | 143 ++++++++++++++++++++
 meson.build                              |   8 +-
 msvc/config-msvc.mak.in                  |   2 +-
 msvc/config.h.win32.in                   |   3 -
 src/Makefile.am                          |   4 +-
 src/psl.c                                | 224 ++++++++++++++++++++++---------
 tests/Makefile.am                        |   7 +
 tests/common.c                           |  48 +++++++
 tests/common.h                           |  38 ++++++
 tests/meson.build                        |  14 +-
 tests/test-is-cookie-domain-acceptable.c |  28 +---
 tests/test-is-public-all.c               |  16 +--
 tests/test-is-public-builtin.c           |  12 +-
 tests/test-is-public.c                   |  12 +-
 tests/test-registrable-domain.c          |  18 +--
 tools/psl.c                              |  34 ++---
 version.txt                              |   2 +-
 41 files changed, 709 insertions(+), 296 deletions(-)
 create mode 100644 .github/workflows/unit-tests.yml
 delete mode 100644 .travis.yml
 delete mode 100755 .travis_coveralls.sh
 create mode 100755 contrib/mingw.static
 create mode 100644 m4/absolute-header.m4
 create mode 100644 m4/libunistring.m4
 create mode 100644 tests/common.c
 create mode 100644 tests/common.h
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/__fake__/public_suffix_list.dat --with-psl-testfile=/__fake__/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       common.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc

```

</details>