### PR TITLE
Add `at.emf.camp`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12955,6 +12955,10 @@ easypanel.host
 // Submitted by <infracloudteam@namecheap.com>
 *.ewp.live
 
+// Electromagnetic Field : https://www.emfcamp.org
+// Submitted by <noc@emfcamp.org>
+at.emf.camp
+
 // Elementor : Elementor Ltd.
 // Submitted by Anton Barkan <antonb@elementor.com>
 elementor.cloud


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organisation
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig  **pending PR number**
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook   
    _(there are none)_

  * [x] This request was _not_ submitted with the objective of working around other third-party limits


  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organisation
====

[Electromagnetic Field](https://www.emfcamp.org) (EMF) is a nonprofit 'hacker' festival held in the UK.  The next event will be EMF 2024.

I am one of the volunteers organising and running EMF 2024, in particular in the Network (NOC) team, having performed the same for the previous EMF.

A key element of the festival's character is an IP network, with wired and wireless gigabit+ access, running in EMF's Autonomous System ([AS60079](https://bgp.tools/as/60079)) with transit links to the wider internet via fibre.  The network facilitates the running of the event as well as being offered to attendees.

As a result, EMF's network hosts countless IP-connected projects, installations and demos brought by the public to the event; this is a fact relevant to this PR.

The event's primary domain is `emfcamp.org`, which is used for the public website, internal applications and email systems, but the separate domain `emf.camp` is used for DNS in the 'event infrastructure'.  This PR is to add a subdomain of `emf.camp` to the PSL, and so there is no concern around breaking our website(s) etc.


Organisation Website: 
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->

https://www.emfcamp.org/

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Starting at EMF 2024 and continuing in future EMF events, we plan to provide to attendees the option to register DNS records under the `at.emf.camp` domain which point at on-site devices.

The intended use is to provide friendly DNS names for network-connected hosts/devices brought by the public (attendees) to the event.  These have been known to range in scale from IoT devices to rack-mountable servers, often running a web server and/or other interactive user-facing services.

From a security point of view, these network devices/services are **mutually distrustful**, having been brought to EMF by people who are most likely to be strangers to each other.  While there is no commercial model to consider, the security model for EMF is similar to that of a shared/cloud hosting provider, where our 'customers' are not expected to maintain high levels of mutual trust.

We therefore intend for the PSL inclusion of `at.emf.camp` to establish isolation between direct subdomains, where implemented (e.g. in browser cookies), and to signify the intended security boundaries between its subdomains wherever the PSL is used by third parties to do so.

### Domain registration declaration

`emf.camp` is currently registered until 2 April 2029 and we intend to maintain its registration indefinitely.

### User count estimate

Number of users this request is being made to serve: **at least 3500** (planned EMF 2024 attendance + some accounting (~10% extra) for outside-event internet clients).  Over the years the attendance figure at EMF has grown steadily.

The EMF network is open to the internet, and so hosts under `at.emf.camp` will not be generally restricted from being accessed over the internet too.  Attendees commonly publicise their projects/installations on social media or other web platforms, leading to increased visitation over the network from the wider internet.


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

(pending PR number allocation)

Results of Syntax Checker (`make test`)
=========

```
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

(...)

PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```