### PR TITLE
Add notion.site as private eTLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14280,6 +14280,10 @@ noop.app
 // Submitted by Laurent Pellegrino <security@noticeable.io>
 noticeable.news
 
+// Notion Labs, Inc : https://www.notion.so/
+// Submitted by Jess Yao <trust-core-team@makenotion.com>
+notion.site
+
 // Now-DNS : https://now-dns.com
 // Submitted by Steve Russell <steve@now-dns.com>
 dnsking.ch


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section **(yes, until 12/08/27)**

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Notion is a connected workspace that provides consumer and business (SaaS) users with tools for documentation, task management, project tracking, etc. In the most typical use case, users create and edit page content, which can be private or easily shared with other users in their organization.

Notion Sites is a product that allows users to "publish" their pages to the broader web, essentially creating a website without any coding required. (Comparable products include Github Pages and Squarespace). Each user can publish pages under their own unique `*.notion.site` domain, e.g. user A might publish `delightful-strawberry-123.notion.site` and user B might publish `lucky-stone-567.notion.site`).

I am an engineer on the Trust Engineering team at Notion, which is a subteam of Security, and have been collaborating with the Notion Sites product team to de-risk our features and prevent abuse.

Organization Website: https://www.notion.so/
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->

Reason for PSL Inclusion
====

We'd like `notion.site` to be on the PSL in order to:
* Restrict these apps' use of cookies to their own personal subdomain. Even though Notion itself serves the pages for each subdomain (less custom code/javascript), this isolation guarantees security to each of our customers (e.g. in the case of some iframe exploit).
* Avoid domain reputation from `a.notion.site` affecting that of `b.notion.site`, given that `a` and `b` are distinct content creators. This also seems to be best practice, given that similar site hosting platforms have entries in the PSL.

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Our domain ownership of `notion.site` was recently renewed and extends until Dec 8, 2027 (> 2 years from now).


<img width="400" alt="Screenshot 2024-05-02 at 2 28 24 PM" src="https://github.com/publicsuffix/list/assets/25401650/b8e41eb6-6b35-47b2-99e4-e2a0290d43f8">


Number of users this request is being made to serve: There are ~5 million distinct "workspaces" that have published pages with their own `*.notion.site` domain, and we expect this to grow.

<!--
Identify if this is current or an estimate.
-->


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

```
> dig TXT +short _psl.notion.site
"https://github.com/publicsuffix/list/pull/1958"
```

<img width="753" alt="Screenshot 2024-04-07 at 10 00 35 PM" src="https://github.com/publicsuffix/list/assets/25401650/c997c613-9f99-4546-90c0-8f3d57b48da9">


Results of Syntax Checker (`make test`)
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->

Yes, tests passed:

<img width="562" alt="Screenshot 2024-04-07 at 9 33 27 PM" src="https://github.com/publicsuffix/list/assets/25401650/b13ff5cd-2365-432b-8aab-086353fbb1af">


<details>
<summary>Click for full output</summary>

```
jyao@Jessicas-MacBook-Pro ~/list  (jyao/add-notion-site-to-etld) $ make test
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC:
OK
-n test_allowedchars:
OK
-n test_dots:
OK
-n test_duplicate:
OK
-n test_exception:
OK
-n test_punycode:
OK
-n test_section1:
OK
-n test_section2:
OK
-n test_section3:
OK
-n test_section4:
OK
-n test_spaces:
OK
-n test_wildcard:
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
	  cd libpsl;                                                                    \
	  git pull;                                                                     \
	  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
	  echo "CLEANFILES =" >> gtk-doc.make;                                          \
	  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:765: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:369: warning: file `version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/Users/jyao/list/public_suffix_list.dat --with-psl-testfile=/Users/jyao/list/tests/tests.txt && make -s clean && make -s check -j4
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
Making check in tools
  CC       psl.o
  CCLD     psl
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
Making check in fuzz
  CC       main.o
  CC       libpsl_load_dafsa_fuzzer.o
  CC       libpsl_fuzzer.o
  CC       libpsl_load_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       common.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-all
  CCLD     test-is-public-builtin
libtool: warning: '-no-install' is ignored for aarch64-apple-darwin23.3.0
libtool: warning: '-no-install' is ignored for aarch64-apple-darwin23.3.0
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: '-no-install' is ignored for aarch64-apple-darwin23.3.0
libtool: warning: '-no-install' is ignored for aarch64-apple-darwin23.3.0
libtool: warning: assuming '-no-fast-install' instead
libtool: warning: assuming '-no-fast-install' instead
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
  CCLD     test-registrable-domain
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
libtool: warning: '-no-install' is ignored for aarch64-apple-darwin23.3.0
libtool: warning: assuming '-no-fast-install' instead
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicuuc.dylib) was built for newer macOS version (14.0) than being linked (13.3)
ld: warning: dylib (/opt/homebrew/Cellar/icu4c/74.2/lib/libicudata.dylib) was built for newer macOS version (14.0) than being linked (13.3)
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-is-public-all
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

</details>
