### PR TITLE
Drop old pcarrier.ca Software Inc. domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14616,10 +14616,6 @@ pagexl.com
 // pcarrier.ca Software Inc: https://pcarrier.ca/
 // Submitted by Pierre Carrier <pc@rrier.ca>
 *.xmit.co
-bar0.net
-bar1.net
-bar2.net
-rdv.to
 srv.us
 gh.srv.us
 gl.srv.us


### PR DESCRIPTION
Given this is a removal, I don't think the PR template applies. Please let me know if I can clarify anything. I've commented on the removal in the PRs where the records were initially added.