### PR TITLE
Add Cloudflare CNAME setup domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12353,6 +12353,11 @@ trycloudflare.com
 pages.dev
 r2.dev
 workers.dev
+cdn.cloudflareanycast.net
+cdn.cloudflarecn.net
+cdn.cloudflareglobal.net
+cloudflare.net
+cdn.cloudflare.net
 
 // cloudscale.ch AG : https://www.cloudscale.ch/
 // Submitted by Gaudenz Steinlin <support@cloudscale.ch>


### PR DESCRIPTION
Main motivation is web browser cookie hijack preventation.

Documentation: https://developers.cloudflare.com/dns/zone-setups/partial-setup/setup/
Cloudflare reference: DNS-10787
Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>