### PR TITLE
Add Clever Cloud's domains for customers

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12368,9 +12368,9 @@ discourse.team
 // Clever Cloud : https://www.clever-cloud.com/
 // Submitted by Quentin Adam <noc@clever-cloud.com>
 cleverapps.cc
+*.services.clever-cloud.com
 cleverapps.io
 cleverapps.tech
-*.services.clever-cloud.com
 
 // Clerk : https://www.clerk.dev
 // Submitted by Colin Sidoti <systems@clerk.dev>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12367,7 +12367,10 @@ discourse.team
 
 // Clever Cloud : https://www.clever-cloud.com/
 // Submitted by Quentin Adam <noc@clever-cloud.com>
+cleverapps.cc
 cleverapps.io
+cleverapps.tech
+*.services.clever-cloud.com
 
 // Clerk : https://www.clerk.dev
 // Submitted by Colin Sidoti <systems@clerk.dev>


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
    - https://www.microsoft.com/en-us/edge/features/microsoft-defender-smartscreen?form=MA13FJ
  * [x] This request was _not_ submitted with the objective of working around other third-party limits
  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

Description of Organization
====

Clever Cloud provides hosting services. (see https://www.clever-cloud.com/)
As part of hosting, Clever Cloud provides the privately-owned `cleverapps.cc` and `cleverapps.tech` domains _for dev purposes_.
Customers can use a subdomain of `cleverapps.cc` and `cleverapps.tech` for free. These domains records are managed by Clever Cloud and will point towards our own infrastructure.

The same happens for some domains in `*.services.clever-cloud.com`, which we use to offer object storage services, like:
- `cellar-c2.services.clever-cloud.com` 
- `cellar-fr-north-hds-c1.services.clever-cloud.com`
- `cellar-fr-north-c1.services.clever-cloud.com`

Clever Cloud also provides services using a uniquely generated domain under some subdomains, like:
- `grafana.services.clever-cloud.com`
- `services.clever-cloud.com`
- (and others)

Reason for PSL Inclusion
====

This is a follow-up for https://github.com/publicsuffix/list/pull/634

All subdomains of `cleverapps.tech`, `cleverapps.cc` and `*.services.clever-cloud.com` are considered mutually-untrusting parties/clients.
Since the domains can be used "for free", we need to protect against cookie-sharing attacks and being reported to security databases when bad users use them for fraudulent purposes.
(We have active detection processes and automated responses to phishing reports from security companies, but it's an ever evolving game.)

As such we request that it is added to the private section of the Public Suffix List.

Number of users this request is being made to serve: around 150k at the moment.


DNS Verification via dig
=======

```
dig +short TXT _psl.cleverapps.cc
"https://github.com/publicsuffix/list/pull/1974"
```

```
dig +short TXT _psl.cleverapps.tech
"https://github.com/publicsuffix/list/pull/1974"
```

```
dig +short TXT _psl.services.clever-cloud.com
"https://github.com/publicsuffix/list/pull/1974"
```

Results of Syntax Checker (`make test`)
=========

```
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       common.o
  CC       test-is-public-all.o
  CC       test-is-public.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
===========================================================================
```

