### PR TITLE
Reattach of.by to the Belarus ccTLD block

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -675,7 +675,6 @@ mil.by
 // second-level domain, but it's being used as one (see www.google.com.by and
 // www.yahoo.com.by, for example), so we list it here for safety's sake.
 com.by
-
 // http://hoster.by/
 of.by
 


### PR DESCRIPTION
It's in the same situation as `com.by`: not officially reserved according to available documentation, but third-level domain registrations are available as if it were. Logically it belongs in the same block as `com.by`.

Found while developing #1987, because it resulted in surprising output. simon-friedberger recommended making this .dat change, rather than add a custom lint exemption that's only necessary for this one entry.

This is a minor lint cleanup, so most of the PR template does not apply. Applicable items:
 - **Description of change**: above.
 - **make test**: runs successfully, no errors.
 - **Authority**: I'm not authoritative for `by` or `of.by`. However I am not adding/removing any suffixes, only adjusting whitespace.
 - **Justification**: I studied the `by` [registry policy](https://cctld.by/en/documents/instruction-on-the-procedure-of-registration-of-domain/), and verified that neither `com.by` or `of.by` are listed. However I can purchase a 3rd level domain in those suffixes right now, so empirically they should be treated as public suffixes.
   - I'm digging into the registry history and policies more to figure out if a bigger update is justified. This PR is just recognizing the fact that `com.by` and `of.by` are both in the same category of "not on an official list but seem to be public suffixes in BY".