### PR TITLE
Fix test case for exception rule

### DIFF
--- a/tests/test_psl.txt
+++ b/tests/test_psl.txt
@@ -57,8 +57,8 @@ checkPublicSuffix('a.b.ide.kyoto.jp', 'b.ide.kyoto.jp');
 checkPublicSuffix('c.kobe.jp', null);
 checkPublicSuffix('b.c.kobe.jp', 'b.c.kobe.jp');
 checkPublicSuffix('a.b.c.kobe.jp', 'b.c.kobe.jp');
-checkPublicSuffix('city.kobe.jp', 'city.kobe.jp');
-checkPublicSuffix('www.city.kobe.jp', 'city.kobe.jp');
+checkPublicSuffix('city.kobe.jp', 'kobe.jp');
+checkPublicSuffix('www.city.kobe.jp', 'kobe.jp');
 // TLD with a wildcard rule and exceptions.
 checkPublicSuffix('ck', null);
 checkPublicSuffix('test.ck', null);


### PR DESCRIPTION
As pointed out in #1989 there seems to be a bug in a test case where something that has an explicit exception is returned as a public suffix. This fixes that test case.