### PR TITLE
tools/internal/parser: refactor to separate text processing from parser main logic

### DIFF
--- a/tools/internal/parser/errors.go
+++ b/tools/internal/parser/errors.go
@@ -55,7 +55,7 @@ type UnknownSectionMarker struct {
 }
 
 func (e UnknownSectionMarker) Error() string {
-	return fmt.Sprintf("unknown kind of section marker %q at %s", e.Line.Raw, e.Line.LocationString())
+	return fmt.Sprintf("unknown kind of section marker %q at %s", e.Line.Text(), e.Line.LocationString())
 }
 
 // UnterminatedSectionMarker reports that a section marker is missing
@@ -65,7 +65,7 @@ type UnterminatedSectionMarker struct {
 }
 
 func (e UnterminatedSectionMarker) Error() string {
-	return fmt.Sprintf(`section marker %q at %s is missing trailing "==="`, e.Line.Raw, e.Line.LocationString())
+	return fmt.Sprintf(`section marker %q at %s is missing trailing "==="`, e.Line.Text(), e.Line.LocationString())
 }
 
 // MissingEntityName reports that a block of suffixes does not have a

--- a/tools/internal/parser/errors.go
+++ b/tools/internal/parser/errors.go
@@ -55,7 +55,7 @@ type UnknownSectionMarker struct {
 }
 
 func (e UnknownSectionMarker) Error() string {
-	return fmt.Sprintf("unknown kind of section marker %q at %s", trimComment(e.Line.Raw), e.Line.LocationString())
+	return fmt.Sprintf("unknown kind of section marker %q at %s", e.Line.Raw, e.Line.LocationString())
 }
 
 // UnterminatedSectionMarker reports that a section marker is missing
@@ -65,7 +65,7 @@ type UnterminatedSectionMarker struct {
 }
 
 func (e UnterminatedSectionMarker) Error() string {
-	return fmt.Sprintf(`section marker %q at %s is missing trailing "==="`, trimComment(e.Line.Raw), e.Line.LocationString())
+	return fmt.Sprintf(`section marker %q at %s is missing trailing "==="`, e.Line.Raw, e.Line.LocationString())
 }
 
 // MissingEntityName reports that a block of suffixes does not have a

--- a/tools/internal/parser/exceptions.go
+++ b/tools/internal/parser/exceptions.go
@@ -21,7 +21,7 @@ import "strings"
 func downgradeToWarning(e error) bool {
 	switch v := e.(type) {
 	case MissingEntityEmail:
-		return sourceIsExempted(missingEmail, v.Suffixes.Raw)
+		return sourceIsExempted(missingEmail, v.Suffixes.Text())
 	}
 	return false
 }

--- a/tools/internal/parser/file.go
+++ b/tools/internal/parser/file.go
@@ -64,48 +64,6 @@ func (f *File) SuffixBlocksInSection(name string) []Suffixes {
 	return ret
 }
 
-// Source is a piece of source text with location information.
-//
-// A Source is effectively a slice of the input file's lines, with
-// some extra information attached. As such, the start/end indexes
-// behave the same as in Go slices, and select the half-open interval
-// [start:end).
-type Source struct {
-	// StartLine is the line of the input file where this Source
-	// begins.
-	StartLine int
-	// EndLine is the line of the input file where this Source
-	// ends. The line identified by EndLine is not included in the
-	// Source block.
-	EndLine int
-	// Raw is the unparsed source text for this block.
-	Raw string
-}
-
-// LocationString returns a short string describing the source
-// location.
-func (s Source) LocationString() string {
-	// For printing diagnostics, 0-indexed [start:end) is confusing
-	// and not how editors present text to people. Adjust the offsets
-	// to be 1-indexed [start:end] instead. EndLine doesn't need any
-	// adjusting, because 0->1 indexing and open->closed interval
-	// cancel each other out.
-	start := s.StartLine + 1
-	end := s.EndLine
-
-	if end < start {
-		// The parser should never produce this, but Source is
-		// exported and callers could construct invalid
-		// representations. Fail gracefully instead of panicking.
-		return fmt.Sprintf("<invalid Source, %d line range %d-%d>", s.EndLine-s.StartLine, end, start)
-	}
-
-	if start == end {
-		return fmt.Sprintf("line %d", start)
-	}
-	return fmt.Sprintf("lines %d-%d", start, end)
-}
-
 // A Block is a parsed chunk of a PSL file.
 // In Parse's output, a Block is one of the following concrete types:
 // Comment, StartSection, EndSection, Suffixes.

--- a/tools/internal/parser/parser.go
+++ b/tools/internal/parser/parser.go
@@ -27,23 +27,13 @@ func parseWithExceptions(src string, downgradeToWarning func(error) bool) *File 
 	p := parser{
 		downgradeToWarning: downgradeToWarning,
 	}
-	p.Parse(src)
+	p.Parse(newSource(src))
 	p.Validate()
 	return &p.File
 }
 
 // parser is the state for a single PSL file parse.
 type parser struct {
-	// blockStart, if non-zero, is the line on which the current block
-	// began. The block continues until the following empty line.
-	blockStart int
-	// blockEnd, if non-zero, is the line on which the last complete
-	// block ended.
-	blockEnd int
-	// lines is the lines of source text between blockStart and
-	// blockEnd.
-	lines []string
-
 	// currentSection is the logical file section the parser is
 	// currently in. This is used to verify that StartSection and
 	// EndSection blocks are paired correctly, and may be nil when the
@@ -62,32 +52,21 @@ type parser struct {
 }
 
 // Parse parses src as a PSL file and returns the parse result.
-func (p *parser) Parse(src string) {
-	lines := strings.Split(src, "\n")
-	// Add a final empty line to process, so that the block
-	// consumption logic works even if there is no final empty line in
-	// the source. This avoids the need for some final off-by-one
-	// cleanup after the main parsing loop.
-	lines = append(lines, "\n")
+func (p *parser) Parse(src source) {
+	blankLine := func(line source) bool { return line.Text() == "" }
+	blocks := src.Split(blankLine)
 
-	// The top-level structure of a PSL file is blocks of non-empty
-	// lines separated by one or more empty lines. This loop
-	// accumulates one block at a time then gets consumeBlock() to
-	// turn it into a parse output.
-	for i, line := range lines {
-		line = strings.TrimSpace(line)
-
-		if line == "" {
-			if len(p.lines) > 0 {
-				p.blockEnd = i
-				p.consumeBlock()
-			}
-			continue
+	for _, block := range blocks {
+		// Does this block have any non-comments in it? If so, it's a
+		// suffix block, otherwise it's a comment/section marker
+		// block.
+		notComment := func(line source) bool { return !strings.HasPrefix(line.Text(), "//") }
+		comment, rest, hasSuffixes := block.Cut(notComment)
+		if hasSuffixes {
+			p.processSuffixes(block, comment, rest)
+		} else {
+			p.processTopLevelComment(comment)
 		}
-		if p.blockStart == 0 {
-			p.blockStart = i + 1 // we 1-index, range 0-indexes
-		}
-		p.lines = append(p.lines, line)
 	}
 
 	// At EOF with an open section.
@@ -98,114 +77,74 @@ func (p *parser) Parse(src string) {
 	}
 }
 
-// consumeBlock consumes the currently accumulated p.lines and
-// produces one or more Blocks into p.File.Blocks.
-//
-// consumeBlock assumes that p.lines contains at least one line, and
-// that p.blockStart and p.blockEnd are both non-zero. It resets all
-// those fields to their zero value when it returns.
-func (p *parser) consumeBlock() {
-	defer func() {
-		p.lines = nil
-		p.blockStart = 0
-		p.blockEnd = 0
-	}()
+// processSuffixes parses a block that consists of domain suffixes and
+// a metadata header.
+func (p *parser) processSuffixes(block, header, rest source) {
+	s := Suffixes{
+		Source: block.Source(),
+	}
 
-	// Suffix blocks are distinguished by whether or not there are any
-	// non-comment lines.
-	var header, entries, comments []Source
-	for i, l := range p.lines {
-		src := Source{p.blockStart + i, p.blockStart + i, l}
-		if !strings.HasPrefix(l, "//") {
-			entries = append(entries, src)
-		} else if len(entries) > 0 {
-			comments = append(comments, src)
+	var metadataSrc []string
+	for _, line := range header.Lines() {
+		// TODO: s.Header should be a single Source for the entire
+		// comment.
+		s.Header = append(s.Header, line.Source())
+		// Trim the comment prefix in two steps, because some PSL
+		// comments don't have whitepace between the // and the
+		// following text.
+		metadataSrc = append(metadataSrc, strings.TrimSpace(strings.TrimPrefix(line.Text(), "//")))
+	}
+
+	// rest consists of suffixes and possibly inline comments.
+	commentLine := func(line source) bool { return strings.HasPrefix(line.Text(), "//") }
+	rest.ForEachRun(commentLine, func(block source, isComment bool) {
+		if isComment {
+			s.InlineComments = append(s.InlineComments, block.Source())
 		} else {
-			header = append(header, src)
+			// TODO: parse entries properly, for how we just
+			// accumulate them as individual Sources, one per suffix.
+			for _, entry := range block.Lines() {
+				s.Entries = append(s.Entries, entry.Source())
+			}
 		}
-	}
+	})
 
-	if len(entries) > 0 {
-		// Suffixes are easy to build, but require a lot more parsing
-		// and validation to extract comment metadata.
-		s := Suffixes{
-			Source:         p.blockSource(),
-			Header:         header,
-			Entries:        entries,
-			InlineComments: comments,
-		}
-		p.enrichSuffixes(&s)
-		p.addBlock(s)
-		return
-	}
-
-	// Not a suffix block, so this is a comment block, possibly with
-	// embedded section markers.
-
-	linesConsumed := 0
-
-	// maybeOutputComment outputs a Comment block, if there are
-	// accumulated comment lines to output.
-	maybeOutputComment := func(endLine int) {
-		if endLine == linesConsumed {
-			return
-		}
-
-		first := p.blockStart + linesConsumed
-		last := p.blockStart + endLine - 1
-		block := Comment{
-			Source: Source{
-				StartLine: first,
-				EndLine:   last,
-				Raw:       strings.Join(p.lines[linesConsumed:endLine], "\n"),
-			},
-		}
-		p.addBlock(block)
-		linesConsumed = endLine
-	}
-
-	for i, line := range p.lines {
-		if !strings.HasPrefix(line, sectionMarker) {
-			continue
-		}
-
-		maybeOutputComment(i)
-
-		// Current line looks like a section marker.
-		p.consumeSectionMarker(Source{
-			StartLine: p.blockStart + i,
-			EndLine:   p.blockStart + i,
-			Raw:       line,
-		})
-		linesConsumed++
-	}
-
-	// There might be a final bit of comments that haven't been
-	// consumed yet.
-	maybeOutputComment(len(p.lines))
+	p.enrichSuffixes(&s, metadataSrc)
+	p.addBlock(s)
 }
 
-const sectionMarker = "// ==="
+const sectionMarkerPrefix = "// ==="
 
-// consumeSectionMarker treats the given line as a section marker and
-// generates appropriate StartSection/EndSection blocks.
-//
-// consumeSectionMarker reports errors for mismatched section
-// start/end pairs, nested sections, and lines that look like section
-// markers but aren't one of the known kinds.
-func (p *parser) consumeSectionMarker(line Source) {
-	markerWithoutStart := strings.TrimPrefix(line.Raw, sectionMarker)
-	if markerWithoutStart == line.Raw {
-		// Somehow we got called with a line that doesn't look have
-		// the right prefix, something is very wrong.
-		panic("consumeSectionMarker called with non-marker line")
+// processTopLevelComment parses a block that has only comment lines,
+// no suffixes. Some of those comments may be markers for the
+// start/end of file sections.
+func (p *parser) processTopLevelComment(block source) {
+	sectionLine := func(line source) bool {
+		return strings.HasPrefix(line.Text(), sectionMarkerPrefix)
 	}
+	block.ForEachRun(sectionLine, func(block source, isSectionLine bool) {
+		if isSectionLine {
+			for _, line := range block.Lines() {
+				p.processSectionMarker(line)
+			}
+		} else {
+			p.addBlock(Comment{block.Source()})
+		}
+	})
+}
+
+// processSectionMarker parses line as a file section marker, and
+// enforces correct start/end pairing.
+func (p *parser) processSectionMarker(line source) {
+	// Trim here rather than in the caller, so that we still have the
+	// complete input line available to use in errors.
+	marker := strings.TrimPrefix(line.Text(), sectionMarkerPrefix)
 
 	// Note hasTrailer gets used below to report an error if the
-	// trailing === is missing. We delay reporting the error so that
+	// trailing "===" is missing. We delay reporting the error so that
 	// if the entire line is invalid, we don't report both a
 	// whole-line error and also an unterminated marker error.
-	marker, hasTrailer := strings.CutSuffix(markerWithoutStart, "===")
+	marker, hasTrailer := strings.CutSuffix(marker, "===")
 
 	markerType, name, ok := strings.Cut(marker, " ")
 	if !ok {
@@ -216,10 +155,14 @@ func (p *parser) consumeSectionMarker(line Source) {
 		markerType = ""
 	}
 
+	// No matter what, we're going to output something that needs to
+	// reference this line.
+	src := line.Source()
+
 	switch markerType {
 	case "BEGIN":
 		start := StartSection{
-			Source: line,
+			Source: src,
 			Name:   name,
 		}
 		if p.currentSection != nil {
@@ -232,13 +175,13 @@ func (p *parser) consumeSectionMarker(line Source) {
 			})
 		}
 		if !hasTrailer {
-			p.addError(UnterminatedSectionMarker{line})
+			p.addError(UnterminatedSectionMarker{src})
 		}
 		p.currentSection = &start
 		p.addBlock(start)
 	case "END":
 		end := EndSection{
-			Source: line,
+			Source: src,
 			Name:   name,
 		}
 		if p.currentSection == nil {
@@ -255,7 +198,7 @@ func (p *parser) consumeSectionMarker(line Source) {
 			})
 		}
 		if !hasTrailer {
-			p.addError(UnterminatedSectionMarker{line})
+			p.addError(UnterminatedSectionMarker{src})
 		}
 		p.currentSection = nil
 		p.addBlock(end)
@@ -267,15 +210,15 @@ func (p *parser) consumeSectionMarker(line Source) {
 		// Comment. Top-level comments are just freeform text, which
 		// is technically correct here since this isn't a valid
 		// section marker.
-		p.addError(UnknownSectionMarker{line})
-		p.addBlock(Comment{line})
+		p.addError(UnknownSectionMarker{src})
+		p.addBlock(Comment{src})
 	}
 }
 
 // enrichSuffixes extracts structured metadata from suffixes.Header
 // and populates the appropriate fields of suffixes.
-func (p *parser) enrichSuffixes(suffixes *Suffixes) {
-	if len(suffixes.Header) == 0 {
+func (p *parser) enrichSuffixes(suffixes *Suffixes, metadata []string) {
+	if len(metadata) == 0 {
 		return
 	}
 
@@ -289,8 +232,8 @@ func (p *parser) enrichSuffixes(suffixes *Suffixes) {
 	// validation errors in future, but currently do not.
 	//
 	// See splitNameish for a list of accepted alternate forms.
-	for _, line := range suffixes.Header {
-		name, url, contact := splitNameish(trimComment(line.Raw))
+	for _, line := range metadata {
+		name, url, contact := splitNameish(line)
 		if name == "" {
 			continue
 		}
@@ -307,7 +250,7 @@ func (p *parser) enrichSuffixes(suffixes *Suffixes) {
 	if suffixes.Entity == "" {
 		// Assume the first line is the entity name, if it's not
 		// obviously something else.
-		first := trimComment(suffixes.Header[0].Raw)
+		first := metadata[0]
 		// "see also" is the first line of a number of ICANN TLD
 		// sections.
 		if getSubmitter(first) == nil && getURL(first) == nil && first != "see also" {
@@ -320,16 +263,16 @@ func (p *parser) enrichSuffixes(suffixes *Suffixes) {
 	// "Submitted by <contact>", or failing that a parseable RFC5322
 	// email on a line by itself.
 	if suffixes.Submitter == nil {
-		for _, line := range suffixes.Header {
-			if submitter := getSubmitter(trimComment(line.Raw)); submitter != nil {
+		for _, line := range metadata {
+			if submitter := getSubmitter(line); submitter != nil {
 				suffixes.Submitter = submitter
 				break
 			}
 		}
 	}
 	if suffixes.Submitter == nil {
-		for _, line := range suffixes.Header {
-			if submitter, err := mail.ParseAddress(trimComment(line.Raw)); err == nil {
+		for _, line := range metadata {
+			if submitter, err := mail.ParseAddress(line); err == nil {
 				suffixes.Submitter = submitter
 				break
 			}
@@ -340,8 +283,8 @@ func (p *parser) enrichSuffixes(suffixes *Suffixes) {
 	// only remaining format we understand is a line with a URL by
 	// itself.
 	if suffixes.URL == nil {
-		for _, line := range suffixes.Header {
-			if u := getURL(trimComment(line.Raw)); u != nil {
+		for _, line := range metadata {
+			if u := getURL(line); u != nil {
 				suffixes.URL = u
 				break
 			}
@@ -528,20 +471,6 @@ func getSubmitter(line string) *mail.Address {
 	}
 
 	return nil
-}
-
-// trimComment removes the leading // and outer whitespace from line.
-func trimComment(line string) string {
-	return strings.TrimSpace(strings.TrimPrefix(line, "//"))
-}
-
-// blockSource returns a Source for p.lines.
-func (p *parser) blockSource() Source {
-	return Source{
-		StartLine: p.blockStart,
-		EndLine:   p.blockEnd,
-		Raw:       strings.Join(p.lines, "\n"),
-	}
 }
 
 // addBlock adds b to p.File.Blocks.

--- a/tools/internal/parser/parser_test.go
+++ b/tools/internal/parser/parser_test.go
@@ -46,8 +46,8 @@ func TestParser(t *testing.T) {
 			),
 			want: File{
 				Blocks: []Block{
-					Comment{Source: src(1, 1, "// This is an empty PSL file.")},
-					Comment{Source: src(3, 3, "// Here is a second comment.")},
+					Comment{Source: src(0, 1, "// This is an empty PSL file.")},
+					Comment{Source: src(2, 3, "// Here is a second comment.")},
 				},
 			},
 		},
@@ -62,22 +62,22 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 3, "example.com\nother.example.com\n*.example.org"),
+						Source: src(0, 3, "example.com\nother.example.com\n*.example.org"),
 						Entries: []Source{
-							src(1, 1, "example.com"),
-							src(2, 2, "other.example.com"),
-							src(3, 3, "*.example.org"),
+							src(0, 1, "example.com"),
+							src(1, 2, "other.example.com"),
+							src(2, 3, "*.example.org"),
 						},
 					},
 				},
 				Errors: []error{
 					MissingEntityName{
 						Suffixes: Suffixes{
-							Source: src(1, 3, "example.com\nother.example.com\n*.example.org"),
+							Source: src(0, 3, "example.com\nother.example.com\n*.example.org"),
 							Entries: []Source{
-								src(1, 1, "example.com"),
-								src(2, 2, "other.example.com"),
-								src(3, 3, "*.example.org"),
+								src(0, 1, "example.com"),
+								src(1, 2, "other.example.com"),
+								src(2, 3, "*.example.org"),
 							},
 						},
 					},
@@ -97,19 +97,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(1, 1, "// ===BEGIN IMAGINARY DOMAINS==="),
+						Source: src(0, 1, "// ===BEGIN IMAGINARY DOMAINS==="),
 						Name:   "IMAGINARY DOMAINS",
 					},
 					EndSection{
-						Source: src(3, 3, "// ===END IMAGINARY DOMAINS==="),
+						Source: src(2, 3, "// ===END IMAGINARY DOMAINS==="),
 						Name:   "IMAGINARY DOMAINS",
 					},
 					StartSection{
-						Source: src(4, 4, "// ===BEGIN FAKE DOMAINS==="),
+						Source: src(3, 4, "// ===BEGIN FAKE DOMAINS==="),
 						Name:   "FAKE DOMAINS",
 					},
 					EndSection{
-						Source: src(5, 5, "// ===END FAKE DOMAINS==="),
+						Source: src(4, 5, "// ===END FAKE DOMAINS==="),
 						Name:   "FAKE DOMAINS",
 					},
 				},
@@ -124,14 +124,14 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(1, 1, "// ===BEGIN ICANN DOMAINS==="),
+						Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 				},
 				Errors: []error{
 					UnclosedSectionError{
 						Start: StartSection{
-							Source: src(1, 1, "// ===BEGIN ICANN DOMAINS==="),
+							Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 					},
@@ -150,36 +150,36 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(1, 1, "// ===BEGIN ICANN DOMAINS==="),
+						Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 					StartSection{
-						Source: src(2, 2, "// ===BEGIN SECRET DOMAINS==="),
+						Source: src(1, 2, "// ===BEGIN SECRET DOMAINS==="),
 						Name:   "SECRET DOMAINS",
 					},
 					EndSection{
-						Source: src(3, 3, "// ===END SECRET DOMAINS==="),
+						Source: src(2, 3, "// ===END SECRET DOMAINS==="),
 						Name:   "SECRET DOMAINS",
 					},
 					EndSection{
-						Source: src(4, 4, "// ===END ICANN DOMAINS==="),
+						Source: src(3, 4, "// ===END ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 				},
 				Errors: []error{
 					NestedSectionError{
 						Outer: StartSection{
-							Source: src(1, 1, "// ===BEGIN ICANN DOMAINS==="),
+							Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 						Inner: StartSection{
-							Source: src(2, 2, "// ===BEGIN SECRET DOMAINS==="),
+							Source: src(1, 2, "// ===BEGIN SECRET DOMAINS==="),
 							Name:   "SECRET DOMAINS",
 						},
 					},
 					UnstartedSectionError{
 						EndSection{
-							Source: src(4, 4, "// ===END ICANN DOMAINS==="),
+							Source: src(3, 4, "// ===END ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 					},
@@ -196,22 +196,22 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(1, 1, "// ===BEGIN ICANN DOMAINS==="),
+						Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 					EndSection{
-						Source: src(3, 3, "// ===END PRIVATE DOMAINS==="),
+						Source: src(2, 3, "// ===END PRIVATE DOMAINS==="),
 						Name:   "PRIVATE DOMAINS",
 					},
 				},
 				Errors: []error{
 					MismatchedSectionError{
 						Start: StartSection{
-							Source: src(1, 1, "// ===BEGIN ICANN DOMAINS==="),
+							Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 						End: EndSection{
-							Source: src(3, 3, "// ===END PRIVATE DOMAINS==="),
+							Source: src(2, 3, "// ===END PRIVATE DOMAINS==="),
 							Name:   "PRIVATE DOMAINS",
 						},
 					},
@@ -227,12 +227,12 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Comment{
-						Source: src(1, 1, "// ===TRANSFORM DOMAINS==="),
+						Source: src(0, 1, "// ===TRANSFORM DOMAINS==="),
 					},
 				},
 				Errors: []error{
 					UnknownSectionMarker{
-						Line: src(1, 1, "// ===TRANSFORM DOMAINS==="),
+						Line: src(0, 1, "// ===TRANSFORM DOMAINS==="),
 					},
 				},
 			},
@@ -249,19 +249,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 4, lines(
+						Source: src(0, 4, lines(
 							"// Unstructured header.",
 							"// I'm just going on about random things.",
 							"example.com",
 							"example.org",
 						)),
 						Header: []Source{
-							src(1, 1, "// Unstructured header."),
-							src(2, 2, "// I'm just going on about random things."),
+							src(0, 1, "// Unstructured header."),
+							src(1, 2, "// I'm just going on about random things."),
 						},
 						Entries: []Source{
-							src(3, 3, "example.com"),
-							src(4, 4, "example.org"),
+							src(2, 3, "example.com"),
+							src(3, 4, "example.org"),
 						},
 						Entity: "Unstructured header.",
 					},
@@ -281,7 +281,7 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 5, lines(
+						Source: src(0, 5, lines(
 							"// DuckCorp Inc: https://example.com",
 							"// Submitted by Not A Duck <duck@example.com>",
 							"// Seriously, not a duck",
@@ -289,13 +289,13 @@ func TestParser(t *testing.T) {
 							"example.org",
 						)),
 						Header: []Source{
-							src(1, 1, "// DuckCorp Inc: https://example.com"),
-							src(2, 2, "// Submitted by Not A Duck <duck@example.com>"),
-							src(3, 3, "// Seriously, not a duck"),
+							src(0, 1, "// DuckCorp Inc: https://example.com"),
+							src(1, 2, "// Submitted by Not A Duck <duck@example.com>"),
+							src(2, 3, "// Seriously, not a duck"),
 						},
 						Entries: []Source{
-							src(4, 4, "example.com"),
-							src(5, 5, "example.org"),
+							src(3, 4, "example.com"),
+							src(4, 5, "example.org"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -314,15 +314,15 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 2, lines(
+						Source: src(0, 2, lines(
 							"// DuckCorp Inc: submitted by Not A Duck <duck@example.com>",
 							"example.com",
 						)),
 						Header: []Source{
-							src(1, 1, "// DuckCorp Inc: submitted by Not A Duck <duck@example.com>"),
+							src(0, 1, "// DuckCorp Inc: submitted by Not A Duck <duck@example.com>"),
 						},
 						Entries: []Source{
-							src(2, 2, "example.com"),
+							src(1, 2, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						Submitter: mustEmail("Not A Duck <duck@example.com>"),
@@ -342,19 +342,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 4, lines(
+						Source: src(0, 4, lines(
 							"// DuckCorp Inc",
 							"// https://example.com",
 							"// Submitted by Not A Duck <duck@example.com>",
 							"example.com",
 						)),
 						Header: []Source{
-							src(1, 1, "// DuckCorp Inc"),
-							src(2, 2, "// https://example.com"),
-							src(3, 3, "// Submitted by Not A Duck <duck@example.com>"),
+							src(0, 1, "// DuckCorp Inc"),
+							src(1, 2, "// https://example.com"),
+							src(2, 3, "// Submitted by Not A Duck <duck@example.com>"),
 						},
 						Entries: []Source{
-							src(4, 4, "example.com"),
+							src(3, 4, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -374,17 +374,17 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 3, lines(
+						Source: src(0, 3, lines(
 							"// Submitted by Not A Duck <duck@example.com>",
 							"// DuckCorp Inc: https://example.com",
 							"example.com",
 						)),
 						Header: []Source{
-							src(1, 1, "// Submitted by Not A Duck <duck@example.com>"),
-							src(2, 2, "// DuckCorp Inc: https://example.com"),
+							src(0, 1, "// Submitted by Not A Duck <duck@example.com>"),
+							src(1, 2, "// DuckCorp Inc: https://example.com"),
 						},
 						Entries: []Source{
-							src(3, 3, "example.com"),
+							src(2, 3, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -405,19 +405,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 4, lines(
+						Source: src(0, 4, lines(
 							"// This is an unstructured comment.",
 							"// DuckCorp Inc: https://example.com",
 							"// Submitted by Not A Duck <duck@example.com>",
 							"example.com",
 						)),
 						Header: []Source{
-							src(1, 1, "// This is an unstructured comment."),
-							src(2, 2, "// DuckCorp Inc: https://example.com"),
-							src(3, 3, "// Submitted by Not A Duck <duck@example.com>"),
+							src(0, 1, "// This is an unstructured comment."),
+							src(1, 2, "// DuckCorp Inc: https://example.com"),
+							src(2, 3, "// Submitted by Not A Duck <duck@example.com>"),
 						},
 						Entries: []Source{
-							src(4, 4, "example.com"),
+							src(3, 4, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -439,15 +439,15 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 2, lines(
+						Source: src(0, 2, lines(
 							"// https://example.com",
 							"example.com",
 						)),
 						Header: []Source{
-							src(1, 1, "// https://example.com"),
+							src(0, 1, "// https://example.com"),
 						},
 						Entries: []Source{
-							src(2, 2, "example.com"),
+							src(1, 2, "example.com"),
 						},
 						URL: mustURL("https://example.com"),
 					},
@@ -455,15 +455,15 @@ func TestParser(t *testing.T) {
 				Warnings: []error{
 					MissingEntityName{
 						Suffixes: Suffixes{
-							Source: src(1, 2, lines(
+							Source: src(0, 2, lines(
 								"// https://example.com",
 								"example.com",
 							)),
 							Header: []Source{
-								src(1, 1, "// https://example.com"),
+								src(0, 1, "// https://example.com"),
 							},
 							Entries: []Source{
-								src(2, 2, "example.com"),
+								src(1, 2, "example.com"),
 							},
 							URL: mustURL("https://example.com"),
 						},
@@ -483,12 +483,12 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 2, "// Future Versatile Group：https://example.org\nexample.com"),
+						Source: src(0, 2, "// Future Versatile Group：https://example.org\nexample.com"),
 						Header: []Source{
-							src(1, 1, "// Future Versatile Group：https://example.org"),
+							src(0, 1, "// Future Versatile Group：https://example.org"),
 						},
 						Entries: []Source{
-							src(2, 2, "example.com"),
+							src(1, 2, "example.com"),
 						},
 						Entity: "Future Versatile Group",
 						URL:    mustURL("https://example.org"),
@@ -508,12 +508,12 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 2, "// Parens Appreciation Society (https://example.org)\nexample.com"),
+						Source: src(0, 2, "// Parens Appreciation Society (https://example.org)\nexample.com"),
 						Header: []Source{
-							src(1, 1, "// Parens Appreciation Society (https://example.org)"),
+							src(0, 1, "// Parens Appreciation Society (https://example.org)"),
 						},
 						Entries: []Source{
-							src(2, 2, "example.com"),
+							src(1, 2, "example.com"),
 						},
 						Entity: "Parens Appreciation Society",
 						URL:    mustURL("https://example.org"),
@@ -537,23 +537,23 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 2, "// Parens Appreciation Society (hostyhosting.com)\nexample.com"),
+						Source: src(0, 2, "// Parens Appreciation Society (hostyhosting.com)\nexample.com"),
 						Header: []Source{
-							src(1, 1, "// Parens Appreciation Society (hostyhosting.com)"),
+							src(0, 1, "// Parens Appreciation Society (hostyhosting.com)"),
 						},
 						Entries: []Source{
-							src(2, 2, "example.com"),
+							src(1, 2, "example.com"),
 						},
 						Entity: "Parens Appreciation Society",
 						URL:    mustURL("https://hostyhosting.com"),
 					},
 					Suffixes{
-						Source: src(4, 5, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)\npolicy.example.org"),
+						Source: src(3, 5, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)\npolicy.example.org"),
 						Header: []Source{
-							src(4, 4, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)"),
+							src(3, 4, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)"),
 						},
 						Entries: []Source{
-							src(5, 5, "policy.example.org"),
+							src(4, 5, "policy.example.org"),
 						},
 						Entity: "Parens Policy Panel",
 						URL:    mustURL("https://www.task.gda.pl/uslugi/dns"),
@@ -577,17 +577,17 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(1, 3, lines(
+						Source: src(0, 3, lines(
 							"// cd : https://en.wikipedia.org/wiki/.cd",
 							"// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1",
 							"cd",
 						)),
 						Header: []Source{
-							src(1, 1, "// cd : https://en.wikipedia.org/wiki/.cd"),
-							src(2, 2, "// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1"),
+							src(0, 1, "// cd : https://en.wikipedia.org/wiki/.cd"),
+							src(1, 2, "// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1"),
 						},
 						Entries: []Source{
-							src(3, 3, "cd"),
+							src(2, 3, "cd"),
 						},
 						Entity: "cd",
 						URL:    mustURL("https://en.wikipedia.org/wiki/.cd"),
@@ -670,7 +670,7 @@ func TestRoundtripRealList(t *testing.T) {
 		t.Fatal("Parse errors, not attempting to roundtrip")
 	}
 
-	prevLine := 1
+	prevLine := 0
 	var rebuilt bytes.Buffer
 	for _, block := range f.Blocks {
 		src := block.source()
@@ -683,7 +683,7 @@ func TestRoundtripRealList(t *testing.T) {
 		}
 		rebuilt.WriteString(src.Raw)
 		rebuilt.WriteByte('\n')
-		prevLine = src.EndLine + 1
+		prevLine = src.EndLine
 	}
 
 	got := strings.Split(strings.TrimSpace(rebuilt.String()), "\n")
@@ -709,7 +709,7 @@ func TestRoundtripRealListDetailed(t *testing.T) {
 		t.Fatal("Parse errors, not attempting to roundtrip")
 	}
 
-	prevLine := 1
+	prevLine := 0
 	var rebuilt bytes.Buffer
 	for _, block := range f.Blocks {
 		srcs := []Source{block.source()}
@@ -739,7 +739,7 @@ func TestRoundtripRealListDetailed(t *testing.T) {
 			}
 			rebuilt.WriteString(src.Raw)
 			rebuilt.WriteByte('\n')
-			prevLine = src.EndLine + 1
+			prevLine = src.EndLine
 		}
 	}
 

--- a/tools/internal/parser/parser_test.go
+++ b/tools/internal/parser/parser_test.go
@@ -46,8 +46,8 @@ func TestParser(t *testing.T) {
 			),
 			want: File{
 				Blocks: []Block{
-					Comment{Source: src(0, 1, "// This is an empty PSL file.")},
-					Comment{Source: src(2, 3, "// Here is a second comment.")},
+					Comment{Source: mkSrc(0, "// This is an empty PSL file.")},
+					Comment{Source: mkSrc(2, "// Here is a second comment.")},
 				},
 			},
 		},
@@ -62,22 +62,22 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 3, "example.com\nother.example.com\n*.example.org"),
+						Source: mkSrc(0, "example.com", "other.example.com", "*.example.org"),
 						Entries: []Source{
-							src(0, 1, "example.com"),
-							src(1, 2, "other.example.com"),
-							src(2, 3, "*.example.org"),
+							mkSrc(0, "example.com"),
+							mkSrc(1, "other.example.com"),
+							mkSrc(2, "*.example.org"),
 						},
 					},
 				},
 				Errors: []error{
 					MissingEntityName{
 						Suffixes: Suffixes{
-							Source: src(0, 3, "example.com\nother.example.com\n*.example.org"),
+							Source: mkSrc(0, "example.com", "other.example.com", "*.example.org"),
 							Entries: []Source{
-								src(0, 1, "example.com"),
-								src(1, 2, "other.example.com"),
-								src(2, 3, "*.example.org"),
+								mkSrc(0, "example.com"),
+								mkSrc(1, "other.example.com"),
+								mkSrc(2, "*.example.org"),
 							},
 						},
 					},
@@ -97,19 +97,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(0, 1, "// ===BEGIN IMAGINARY DOMAINS==="),
+						Source: mkSrc(0, "// ===BEGIN IMAGINARY DOMAINS==="),
 						Name:   "IMAGINARY DOMAINS",
 					},
 					EndSection{
-						Source: src(2, 3, "// ===END IMAGINARY DOMAINS==="),
+						Source: mkSrc(2, "// ===END IMAGINARY DOMAINS==="),
 						Name:   "IMAGINARY DOMAINS",
 					},
 					StartSection{
-						Source: src(3, 4, "// ===BEGIN FAKE DOMAINS==="),
+						Source: mkSrc(3, "// ===BEGIN FAKE DOMAINS==="),
 						Name:   "FAKE DOMAINS",
 					},
 					EndSection{
-						Source: src(4, 5, "// ===END FAKE DOMAINS==="),
+						Source: mkSrc(4, "// ===END FAKE DOMAINS==="),
 						Name:   "FAKE DOMAINS",
 					},
 				},
@@ -124,14 +124,14 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
+						Source: mkSrc(0, "// ===BEGIN ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 				},
 				Errors: []error{
 					UnclosedSectionError{
 						Start: StartSection{
-							Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
+							Source: mkSrc(0, "// ===BEGIN ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 					},
@@ -150,36 +150,36 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
+						Source: mkSrc(0, "// ===BEGIN ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 					StartSection{
-						Source: src(1, 2, "// ===BEGIN SECRET DOMAINS==="),
+						Source: mkSrc(1, "// ===BEGIN SECRET DOMAINS==="),
 						Name:   "SECRET DOMAINS",
 					},
 					EndSection{
-						Source: src(2, 3, "// ===END SECRET DOMAINS==="),
+						Source: mkSrc(2, "// ===END SECRET DOMAINS==="),
 						Name:   "SECRET DOMAINS",
 					},
 					EndSection{
-						Source: src(3, 4, "// ===END ICANN DOMAINS==="),
+						Source: mkSrc(3, "// ===END ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 				},
 				Errors: []error{
 					NestedSectionError{
 						Outer: StartSection{
-							Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
+							Source: mkSrc(0, "// ===BEGIN ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 						Inner: StartSection{
-							Source: src(1, 2, "// ===BEGIN SECRET DOMAINS==="),
+							Source: mkSrc(1, "// ===BEGIN SECRET DOMAINS==="),
 							Name:   "SECRET DOMAINS",
 						},
 					},
 					UnstartedSectionError{
 						EndSection{
-							Source: src(3, 4, "// ===END ICANN DOMAINS==="),
+							Source: mkSrc(3, "// ===END ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 					},
@@ -196,22 +196,22 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					StartSection{
-						Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
+						Source: mkSrc(0, "// ===BEGIN ICANN DOMAINS==="),
 						Name:   "ICANN DOMAINS",
 					},
 					EndSection{
-						Source: src(2, 3, "// ===END PRIVATE DOMAINS==="),
+						Source: mkSrc(2, "// ===END PRIVATE DOMAINS==="),
 						Name:   "PRIVATE DOMAINS",
 					},
 				},
 				Errors: []error{
 					MismatchedSectionError{
 						Start: StartSection{
-							Source: src(0, 1, "// ===BEGIN ICANN DOMAINS==="),
+							Source: mkSrc(0, "// ===BEGIN ICANN DOMAINS==="),
 							Name:   "ICANN DOMAINS",
 						},
 						End: EndSection{
-							Source: src(2, 3, "// ===END PRIVATE DOMAINS==="),
+							Source: mkSrc(2, "// ===END PRIVATE DOMAINS==="),
 							Name:   "PRIVATE DOMAINS",
 						},
 					},
@@ -227,12 +227,12 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Comment{
-						Source: src(0, 1, "// ===TRANSFORM DOMAINS==="),
+						Source: mkSrc(0, "// ===TRANSFORM DOMAINS==="),
 					},
 				},
 				Errors: []error{
 					UnknownSectionMarker{
-						Line: src(0, 1, "// ===TRANSFORM DOMAINS==="),
+						Line: mkSrc(0, "// ===TRANSFORM DOMAINS==="),
 					},
 				},
 			},
@@ -249,19 +249,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 4, lines(
+						Source: mkSrc(0,
 							"// Unstructured header.",
 							"// I'm just going on about random things.",
 							"example.com",
 							"example.org",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// Unstructured header."),
-							src(1, 2, "// I'm just going on about random things."),
+							mkSrc(0, "// Unstructured header."),
+							mkSrc(1, "// I'm just going on about random things."),
 						},
 						Entries: []Source{
-							src(2, 3, "example.com"),
-							src(3, 4, "example.org"),
+							mkSrc(2, "example.com"),
+							mkSrc(3, "example.org"),
 						},
 						Entity: "Unstructured header.",
 					},
@@ -281,21 +281,21 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 5, lines(
+						Source: mkSrc(0,
 							"// DuckCorp Inc: https://example.com",
 							"// Submitted by Not A Duck <duck@example.com>",
 							"// Seriously, not a duck",
 							"example.com",
 							"example.org",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// DuckCorp Inc: https://example.com"),
-							src(1, 2, "// Submitted by Not A Duck <duck@example.com>"),
-							src(2, 3, "// Seriously, not a duck"),
+							mkSrc(0, "// DuckCorp Inc: https://example.com"),
+							mkSrc(1, "// Submitted by Not A Duck <duck@example.com>"),
+							mkSrc(2, "// Seriously, not a duck"),
 						},
 						Entries: []Source{
-							src(3, 4, "example.com"),
-							src(4, 5, "example.org"),
+							mkSrc(3, "example.com"),
+							mkSrc(4, "example.org"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -314,15 +314,15 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 2, lines(
+						Source: mkSrc(0,
 							"// DuckCorp Inc: submitted by Not A Duck <duck@example.com>",
 							"example.com",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// DuckCorp Inc: submitted by Not A Duck <duck@example.com>"),
+							mkSrc(0, "// DuckCorp Inc: submitted by Not A Duck <duck@example.com>"),
 						},
 						Entries: []Source{
-							src(1, 2, "example.com"),
+							mkSrc(1, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						Submitter: mustEmail("Not A Duck <duck@example.com>"),
@@ -342,19 +342,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 4, lines(
+						Source: mkSrc(0,
 							"// DuckCorp Inc",
 							"// https://example.com",
 							"// Submitted by Not A Duck <duck@example.com>",
 							"example.com",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// DuckCorp Inc"),
-							src(1, 2, "// https://example.com"),
-							src(2, 3, "// Submitted by Not A Duck <duck@example.com>"),
+							mkSrc(0, "// DuckCorp Inc"),
+							mkSrc(1, "// https://example.com"),
+							mkSrc(2, "// Submitted by Not A Duck <duck@example.com>"),
 						},
 						Entries: []Source{
-							src(3, 4, "example.com"),
+							mkSrc(3, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -374,17 +374,17 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 3, lines(
+						Source: mkSrc(0,
 							"// Submitted by Not A Duck <duck@example.com>",
 							"// DuckCorp Inc: https://example.com",
 							"example.com",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// Submitted by Not A Duck <duck@example.com>"),
-							src(1, 2, "// DuckCorp Inc: https://example.com"),
+							mkSrc(0, "// Submitted by Not A Duck <duck@example.com>"),
+							mkSrc(1, "// DuckCorp Inc: https://example.com"),
 						},
 						Entries: []Source{
-							src(2, 3, "example.com"),
+							mkSrc(2, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -405,19 +405,19 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 4, lines(
+						Source: mkSrc(0,
 							"// This is an unstructured comment.",
 							"// DuckCorp Inc: https://example.com",
 							"// Submitted by Not A Duck <duck@example.com>",
 							"example.com",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// This is an unstructured comment."),
-							src(1, 2, "// DuckCorp Inc: https://example.com"),
-							src(2, 3, "// Submitted by Not A Duck <duck@example.com>"),
+							mkSrc(0, "// This is an unstructured comment."),
+							mkSrc(1, "// DuckCorp Inc: https://example.com"),
+							mkSrc(2, "// Submitted by Not A Duck <duck@example.com>"),
 						},
 						Entries: []Source{
-							src(3, 4, "example.com"),
+							mkSrc(3, "example.com"),
 						},
 						Entity:    "DuckCorp Inc",
 						URL:       mustURL("https://example.com"),
@@ -439,15 +439,15 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 2, lines(
+						Source: mkSrc(0,
 							"// https://example.com",
 							"example.com",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// https://example.com"),
+							mkSrc(0, "// https://example.com"),
 						},
 						Entries: []Source{
-							src(1, 2, "example.com"),
+							mkSrc(1, "example.com"),
 						},
 						URL: mustURL("https://example.com"),
 					},
@@ -455,15 +455,15 @@ func TestParser(t *testing.T) {
 				Warnings: []error{
 					MissingEntityName{
 						Suffixes: Suffixes{
-							Source: src(0, 2, lines(
+							Source: mkSrc(0,
 								"// https://example.com",
 								"example.com",
-							)),
+							),
 							Header: []Source{
-								src(0, 1, "// https://example.com"),
+								mkSrc(0, "// https://example.com"),
 							},
 							Entries: []Source{
-								src(1, 2, "example.com"),
+								mkSrc(1, "example.com"),
 							},
 							URL: mustURL("https://example.com"),
 						},
@@ -483,12 +483,12 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 2, "// Future Versatile Group：https://example.org\nexample.com"),
+						Source: mkSrc(0, "// Future Versatile Group：https://example.org", "example.com"),
 						Header: []Source{
-							src(0, 1, "// Future Versatile Group：https://example.org"),
+							mkSrc(0, "// Future Versatile Group：https://example.org"),
 						},
 						Entries: []Source{
-							src(1, 2, "example.com"),
+							mkSrc(1, "example.com"),
 						},
 						Entity: "Future Versatile Group",
 						URL:    mustURL("https://example.org"),
@@ -508,12 +508,12 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 2, "// Parens Appreciation Society (https://example.org)\nexample.com"),
+						Source: mkSrc(0, "// Parens Appreciation Society (https://example.org)", "example.com"),
 						Header: []Source{
-							src(0, 1, "// Parens Appreciation Society (https://example.org)"),
+							mkSrc(0, "// Parens Appreciation Society (https://example.org)"),
 						},
 						Entries: []Source{
-							src(1, 2, "example.com"),
+							mkSrc(1, "example.com"),
 						},
 						Entity: "Parens Appreciation Society",
 						URL:    mustURL("https://example.org"),
@@ -537,23 +537,23 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 2, "// Parens Appreciation Society (hostyhosting.com)\nexample.com"),
+						Source: mkSrc(0, "// Parens Appreciation Society (hostyhosting.com)", "example.com"),
 						Header: []Source{
-							src(0, 1, "// Parens Appreciation Society (hostyhosting.com)"),
+							mkSrc(0, "// Parens Appreciation Society (hostyhosting.com)"),
 						},
 						Entries: []Source{
-							src(1, 2, "example.com"),
+							mkSrc(1, "example.com"),
 						},
 						Entity: "Parens Appreciation Society",
 						URL:    mustURL("https://hostyhosting.com"),
 					},
 					Suffixes{
-						Source: src(3, 5, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)\npolicy.example.org"),
+						Source: mkSrc(3, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)", "policy.example.org"),
 						Header: []Source{
-							src(3, 4, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)"),
+							mkSrc(3, "// Parens Policy Panel (www.task.gda.pl/uslugi/dns)"),
 						},
 						Entries: []Source{
-							src(4, 5, "policy.example.org"),
+							mkSrc(4, "policy.example.org"),
 						},
 						Entity: "Parens Policy Panel",
 						URL:    mustURL("https://www.task.gda.pl/uslugi/dns"),
@@ -577,17 +577,17 @@ func TestParser(t *testing.T) {
 			want: File{
 				Blocks: []Block{
 					Suffixes{
-						Source: src(0, 3, lines(
+						Source: mkSrc(0,
 							"// cd : https://en.wikipedia.org/wiki/.cd",
 							"// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1",
 							"cd",
-						)),
+						),
 						Header: []Source{
-							src(0, 1, "// cd : https://en.wikipedia.org/wiki/.cd"),
-							src(1, 2, "// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1"),
+							mkSrc(0, "// cd : https://en.wikipedia.org/wiki/.cd"),
+							mkSrc(1, "// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1"),
 						},
 						Entries: []Source{
-							src(2, 3, "cd"),
+							mkSrc(2, "cd"),
 						},
 						Entity: "cd",
 						URL:    mustURL("https://en.wikipedia.org/wiki/.cd"),
@@ -605,9 +605,7 @@ func TestParser(t *testing.T) {
 				exc = downgradeToWarning
 			}
 			got := parseWithExceptions(test.psl, exc)
-			if diff := diff.Diff(&test.want, got); diff != "" {
-				t.Errorf("unexpected parse result (-want +got):\n%s", diff)
-			}
+			checkDiff(t, "parse result", got, &test.want)
 		})
 	}
 }
@@ -631,12 +629,11 @@ func mustEmail(s string) *mail.Address {
 	return a
 }
 
-// src returns a Source with the given start, end, and dedented text.
-func src(start, end int, text string) Source {
+// mkSrc returns a Source with the given start, end, and dedented text.
+func mkSrc(start int, lines ...string) Source {
 	return Source{
-		StartLine: start,
-		EndLine:   end,
-		Raw:       text,
+		lineOffset: start,
+		lines:      lines,
 	}
 }
 
@@ -674,16 +671,16 @@ func TestRoundtripRealList(t *testing.T) {
 	var rebuilt bytes.Buffer
 	for _, block := range f.Blocks {
 		src := block.source()
-		if src.StartLine < prevLine {
-			t.Fatalf("ordering error: previous block ended at %d but this block starts at %d:\n%s", prevLine, src.StartLine, src.Raw)
+		if src.lineOffset < prevLine {
+			t.Fatalf("ordering error: previous block ended at %d but this block starts at %d:\n%s", prevLine, src.lineOffset, src.Text())
 		}
-		for prevLine < src.StartLine {
+		for prevLine < src.lineOffset {
 			rebuilt.WriteByte('\n')
 			prevLine++
 		}
-		rebuilt.WriteString(src.Raw)
+		rebuilt.WriteString(src.Text())
 		rebuilt.WriteByte('\n')
-		prevLine = src.EndLine
+		prevLine = src.lineOffset + len(src.lines)
 	}
 
 	got := strings.Split(strings.TrimSpace(rebuilt.String()), "\n")
@@ -725,21 +722,21 @@ func TestRoundtripRealListDetailed(t *testing.T) {
 				srcs = append(srcs, c)
 			}
 			slices.SortFunc(srcs, func(a, b Source) int {
-				return cmp.Compare(a.StartLine, b.StartLine)
+				return cmp.Compare(a.lineOffset, b.lineOffset)
 			})
 		}
 
 		for _, src := range srcs {
-			if src.StartLine < prevLine {
-				t.Fatalf("ordering error: previous block ended at %d but this block starts at %d:\n%s", prevLine, src.StartLine, src.Raw)
+			if src.lineOffset < prevLine {
+				t.Fatalf("ordering error: previous block ended at %d but this block starts at %d:\n%s", prevLine, src.lineOffset, src.Text())
 			}
-			for prevLine < src.StartLine {
+			for prevLine < src.lineOffset {
 				rebuilt.WriteByte('\n')
 				prevLine++
 			}
-			rebuilt.WriteString(src.Raw)
+			rebuilt.WriteString(src.Text())
 			rebuilt.WriteByte('\n')
-			prevLine = src.EndLine
+			prevLine = src.lineOffset + len(src.lines)
 		}
 	}
 

--- a/tools/internal/parser/text.go
+++ b/tools/internal/parser/text.go
@@ -32,11 +32,9 @@ func (s source) Source() Source {
 		// it visible.
 		panic("can't construct a zero-line Source")
 	}
-	start := s.lineOffset + 1
-	end := start + len(s.lines) - 1
 	return Source{
-		StartLine: start,
-		EndLine:   end,
+		StartLine: s.lineOffset,
+		EndLine:   s.lineOffset + len(s.lines),
 		Raw:       s.Text(),
 	}
 }

--- a/tools/internal/parser/text.go
+++ b/tools/internal/parser/text.go
@@ -1,14 +1,17 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 )
 
-// source is a block of zero or more lines of source text. It can be
-// decomposed into smaller sub-blocks using its parsing methods. It
-// also preserves source line information and can be turned into an
-// exported Source when needed.
-type source struct {
+// Source is a piece of source text with location information.
+//
+// A Source is effectively a slice of the input file's lines, with
+// some extra information attached. As such, the start/end indexes
+// behave the same as in Go slices, and select the half-open interval
+// [start:end).
+type Source struct {
 	// The lines of source text.
 	lines []string
 	// lineOffset is how many lines are before the beginning of lines,
@@ -16,26 +19,42 @@ type source struct {
 	lineOffset int
 }
 
-// newSource returns a source for src.
-func newSource(src string) source {
-	return source{
-		lines:      strings.Split(src, "\n"),
-		lineOffset: 0,
+// Text returns the source text of s as a string.
+func (s Source) Text() string {
+	if len(s.lines) == 1 {
+		return s.lines[0]
 	}
+	return strings.Join(s.lines, "\n")
 }
 
-// Source returns the exported Source counterpart of s.
-func (s source) Source() Source {
-	if len(s.lines) == 0 {
-		// Letting a zero-byte source range escape from the parser
-		// package is the sign of a bug somewhere, so blow up and make
-		// it visible.
-		panic("can't construct a zero-line Source")
+// LocationString returns a short string describing the source
+// location.
+func (s Source) LocationString() string {
+	// For printing diagnostics, 0-indexed [start:end) is confusing
+	// and not how editors present text to people. Adjust the offsets
+	// to be 1-indexed [start:end] instead.
+	start := s.lineOffset + 1
+	end := s.lineOffset + len(s.lines)
+
+	if end < start {
+		// Zero line Source. We can sometimes produce these internally
+		// during parsing, but they should not escape outside the
+		// package. We still print them gracefully instead of
+		// panicking, because it's useful for debugging the parser.
+		return fmt.Sprintf("<invalid Source, 0-line range before line %d>", start)
 	}
+
+	if start == end {
+		return fmt.Sprintf("line %d", start)
+	}
+	return fmt.Sprintf("lines %d-%d", start, end)
+}
+
+// newSource returns a Source for src.
+func newSource(src string) Source {
 	return Source{
-		StartLine: s.lineOffset,
-		EndLine:   s.lineOffset + len(s.lines),
-		Raw:       s.Text(),
+		lines:      strings.Split(src, "\n"),
+		lineOffset: 0,
 	}
 }
 
@@ -43,66 +62,58 @@ func (s source) Source() Source {
 //
 // startLine and endLine behave like normal slice offsets, i.e. they
 // represent the half-open range [startLine:endLine).
-func (s source) slice(startLine, endLine int) source {
+func (s Source) slice(startLine, endLine int) Source {
 	if startLine < 0 || startLine > len(s.lines) || endLine < startLine || endLine > len(s.lines) {
 		panic("invalid input to slice")
 	}
-	return source{
+	return Source{
 		lines:      s.lines[startLine:endLine],
 		lineOffset: s.lineOffset + startLine,
 	}
 }
 
-// Line returns the nth line of s.
-func (s source) line(n int) source {
+// line returns the nth line of s.
+func (s Source) line(n int) Source {
 	return s.slice(n, n+1)
 }
 
-// Lines slices s into one source per line.
-func (s source) Lines() []source {
+// lineSources slices s into one Source per line.
+func (s Source) lineSources() []Source {
 	if len(s.lines) == 1 {
-		return []source{s}
+		return []Source{s}
 	}
 
-	ret := make([]source, len(s.lines))
+	ret := make([]Source, len(s.lines))
 	for i := range s.lines {
 		ret[i] = s.slice(i, i+1)
 	}
 	return ret
 }
 
-// Text returns the source text of s as a string.
-func (s source) Text() string {
-	if len(s.lines) == 1 {
-		return s.lines[0]
-	}
-	return strings.Join(s.lines, "\n")
-}
-
-// Cut slices s at the first cut line, as determined by cutHere. It
-// returns two source blocks: the part of s before the cut line, and
+// cut slices s at the first cut line, as determined by cutHere. It
+// returns two Source blocks: the part of s before the cut line, and
 // the rest of s including the cut line. The found result reports
-// whether a cut was found. If s does not contain a cut line, Cut
+// whether a cut was found. If s does not contain a cut line, cut
 // returns s, <invalid>, false.
-func (s source) Cut(cutHere func(source) bool) (before source, rest source, found bool) {
+func (s Source) cut(cutHere func(Source) bool) (before Source, rest Source, found bool) {
 	for i := range s.lines {
 		if cutHere(s.line(i)) {
 			return s.slice(0, i), s.slice(i, len(s.lines)), true
 		}
 	}
-	return s, source{}, false
+	return s, Source{}, false
 }
 
-// Split slices s into all sub-blocks separated by lines identified by
+// split slices s into all sub-blocks separated by lines identified by
 // isSeparator, and returns a slice of the non-empty blocks between
 // those separators.
 //
 // Note the semantics are different from strings.Split: sub-blocks
 // that contain no lines are not returned. This works better for what
 // the PSL format needs.
-func (s source) Split(isSeparator func(line source) bool) []source {
-	ret := []source{}
-	s.ForEachRun(isSeparator, func(block source, isSep bool) {
+func (s Source) split(isSeparator func(line Source) bool) []Source {
+	ret := []Source{}
+	s.forEachRun(isSeparator, func(block Source, isSep bool) {
 		if isSep {
 			return
 		}
@@ -111,13 +122,13 @@ func (s source) Split(isSeparator func(line source) bool) []source {
 	return ret
 }
 
-// ForEachRun calls processBlock for every run of consecutive lines
+// forEachRun calls processBlock for every run of consecutive lines
 // where classify returns the same result.
 //
 // For example, if classify returns true on lines starting with "//",
 // processBlock gets called with alternating blocks consisting of only
 // comments, or only non-comments.
-func (s source) ForEachRun(classify func(line source) bool, processBlock func(block source, classifyResult bool)) {
+func (s Source) forEachRun(classify func(line Source) bool, processBlock func(block Source, classifyResult bool)) {
 	if len(s.lines) == 0 {
 		return
 	}

--- a/tools/internal/parser/text.go
+++ b/tools/internal/parser/text.go
@@ -16,7 +16,7 @@ type source struct {
 	lineOffset int
 }
 
-// newSource returns a source for bs.
+// newSource returns a source for src.
 func newSource(src string) source {
 	return source{
 		lines:      strings.Split(src, "\n"),

--- a/tools/internal/parser/text.go
+++ b/tools/internal/parser/text.go
@@ -1,0 +1,141 @@
+package parser
+
+import (
+	"strings"
+)
+
+// source is a block of zero or more lines of source text. It can be
+// decomposed into smaller sub-blocks using its parsing methods. It
+// also preserves source line information and can be turned into an
+// exported Source when needed.
+type source struct {
+	// The lines of source text.
+	lines []string
+	// lineOffset is how many lines are before the beginning of lines,
+	// for sources that represent a subset of the input.
+	lineOffset int
+}
+
+// newSource returns a source for bs.
+func newSource(src string) source {
+	return source{
+		lines:      strings.Split(src, "\n"),
+		lineOffset: 0,
+	}
+}
+
+// Source returns the exported Source counterpart of s.
+func (s source) Source() Source {
+	if len(s.lines) == 0 {
+		// Letting a zero-byte source range escape from the parser
+		// package is the sign of a bug somewhere, so blow up and make
+		// it visible.
+		panic("can't construct a zero-line Source")
+	}
+	start := s.lineOffset + 1
+	end := start + len(s.lines) - 1
+	return Source{
+		StartLine: start,
+		EndLine:   end,
+		Raw:       s.Text(),
+	}
+}
+
+// slice returns the slice of s between startLine and endLine.
+//
+// startLine and endLine behave like normal slice offsets, i.e. they
+// represent the half-open range [startLine:endLine).
+func (s source) slice(startLine, endLine int) source {
+	if startLine < 0 || startLine > len(s.lines) || endLine < startLine || endLine > len(s.lines) {
+		panic("invalid input to slice")
+	}
+	return source{
+		lines:      s.lines[startLine:endLine],
+		lineOffset: s.lineOffset + startLine,
+	}
+}
+
+// Line returns the nth line of s.
+func (s source) line(n int) source {
+	return s.slice(n, n+1)
+}
+
+// Lines slices s into one source per line.
+func (s source) Lines() []source {
+	if len(s.lines) == 1 {
+		return []source{s}
+	}
+
+	ret := make([]source, len(s.lines))
+	for i := range s.lines {
+		ret[i] = s.slice(i, i+1)
+	}
+	return ret
+}
+
+// Text returns the source text of s as a string.
+func (s source) Text() string {
+	if len(s.lines) == 1 {
+		return s.lines[0]
+	}
+	return strings.Join(s.lines, "\n")
+}
+
+// Cut slices s at the first cut line, as determined by cutHere. It
+// returns two source blocks: the part of s before the cut line, and
+// the rest of s including the cut line. The found result reports
+// whether a cut was found. If s does not contain a cut line, Cut
+// returns s, <invalid>, false.
+func (s source) Cut(cutHere func(source) bool) (before source, rest source, found bool) {
+	for i := range s.lines {
+		if cutHere(s.line(i)) {
+			return s.slice(0, i), s.slice(i, len(s.lines)), true
+		}
+	}
+	return s, source{}, false
+}
+
+// Split slices s into all sub-blocks separated by lines identified by
+// isSeparator, and returns a slice of the non-empty blocks between
+// those separators.
+//
+// Note the semantics are different from strings.Split: sub-blocks
+// that contain no lines are not returned. This works better for what
+// the PSL format needs.
+func (s source) Split(isSeparator func(line source) bool) []source {
+	ret := []source{}
+	s.ForEachRun(isSeparator, func(block source, isSep bool) {
+		if isSep {
+			return
+		}
+		ret = append(ret, block)
+	})
+	return ret
+}
+
+// ForEachRun calls processBlock for every run of consecutive lines
+// where classify returns the same result.
+//
+// For example, if classify returns true on lines starting with "//",
+// processBlock gets called with alternating blocks consisting of only
+// comments, or only non-comments.
+func (s source) ForEachRun(classify func(line source) bool, processBlock func(block source, classifyResult bool)) {
+	if len(s.lines) == 0 {
+		return
+	}
+
+	currentBlock := 0
+	currentVal := classify(s.line(0))
+	for i := range s.lines[1:] {
+		line := i + 1
+		v := classify(s.line(line))
+		if v != currentVal {
+			processBlock(s.slice(currentBlock, line), currentVal)
+			currentVal = v
+			currentBlock = line
+		}
+	}
+	if currentBlock != len(s.lines) {
+		processBlock(s.slice(currentBlock, len(s.lines)), currentVal)
+	}
+}

--- a/tools/internal/parser/text_test.go
+++ b/tools/internal/parser/text_test.go
@@ -55,7 +55,7 @@ func TestSourceText(t *testing.T) {
 		{
 			src: mkSrc(0, "abc"),
 			want: Source{
-				StartLine: 1,
+				StartLine: 0,
 				EndLine:   1,
 				Raw:       "abc",
 			},
@@ -63,7 +63,7 @@ func TestSourceText(t *testing.T) {
 		{
 			src: mkSrc(0, "abc", "def"),
 			want: Source{
-				StartLine: 1,
+				StartLine: 0,
 				EndLine:   2,
 				Raw:       "abc\ndef",
 			},
@@ -71,7 +71,7 @@ func TestSourceText(t *testing.T) {
 		{
 			src: mkSrc(0, "abc", "def").line(0),
 			want: Source{
-				StartLine: 1,
+				StartLine: 0,
 				EndLine:   1,
 				Raw:       "abc",
 			},
@@ -79,7 +79,7 @@ func TestSourceText(t *testing.T) {
 		{
 			src: mkSrc(0, "abc", "def").line(1),
 			want: Source{
-				StartLine: 2,
+				StartLine: 1,
 				EndLine:   2,
 				Raw:       "def",
 			},

--- a/tools/internal/parser/text_test.go
+++ b/tools/internal/parser/text_test.go
@@ -1,0 +1,401 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLineSlicing(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{"abc", "def", "ghi", "jkl"}
+	src := mkSrc(0, lines...)
+
+	wantLines := []source{
+		mkSrc(0, "abc"),
+		mkSrc(1, "def"),
+		mkSrc(2, "ghi"),
+		mkSrc(3, "jkl"),
+	}
+	checkDiff(t, "src.Lines()", src.Lines(), wantLines)
+
+	// slice and line are internal helpers, but if they behave
+	// incorrectly some higher level methods have very confusing
+	// behavior, so test explicitly as well.
+	for i, wantLine := range wantLines {
+		checkDiff(t, fmt.Sprintf("src.line(%d)", i), src.line(i), wantLine)
+	}
+
+	for start := 0; start <= len(lines); start++ {
+		for end := start + 1; end <= len(lines); end++ {
+			t.Run(fmt.Sprintf("slice_%d_to_%d", start, end), func(t *testing.T) {
+				want := mkSrc(start, lines[start:end]...)
+				checkDiff(t, fmt.Sprintf("src.slice(%d, %d)", start, end), src.slice(start, end), want)
+			})
+		}
+	}
+}
+
+func TestSourceText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		src       source
+		want      Source
+		wantPanic bool
+	}{
+		{
+			src:       mkSrc(0),
+			wantPanic: true,
+		},
+		{
+			src: mkSrc(0, "abc"),
+			want: Source{
+				StartLine: 1,
+				EndLine:   1,
+				Raw:       "abc",
+			},
+		},
+		{
+			src: mkSrc(0, "abc", "def"),
+			want: Source{
+				StartLine: 1,
+				EndLine:   2,
+				Raw:       "abc\ndef",
+			},
+		},
+		{
+			src: mkSrc(0, "abc", "def").line(0),
+			want: Source{
+				StartLine: 1,
+				EndLine:   1,
+				Raw:       "abc",
+			},
+		},
+		{
+			src: mkSrc(0, "abc", "def").line(1),
+			want: Source{
+				StartLine: 2,
+				EndLine:   2,
+				Raw:       "def",
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			if tc.wantPanic {
+				defer func() {
+					if err := recover(); err == nil {
+						t.Errorf("wanted panic but got success")
+					}
+				}()
+			}
+			got := tc.src.Source()
+			checkDiff(t, "Source()", got, tc.want)
+			checkDiff(t, "Source().Raw vs. Text()", tc.src.Text(), got.Raw)
+		})
+	}
+}
+
+func TestForEachRun(t *testing.T) {
+	t.Parallel()
+
+	isComment := func(line source) bool {
+		return strings.HasPrefix(line.Text(), "// ")
+	}
+	// some weird arbitrary classifier, to verify that ForEachRun is
+	// using the classifier correctly
+	groupCnt := 0
+	groupsOf2And1 := func(line source) bool {
+		groupCnt = (groupCnt + 1) % 3
+		return groupCnt == 0
+	}
+
+	type Run struct {
+		IsMatch bool
+		Block   source
+	}
+	tests := []struct {
+		name     string
+		src      source
+		classify func(source) bool
+		want     []Run
+	}{
+		{
+			name: "comments",
+			src: mkSrc(0,
+				"// foo",
+				"// bar",
+				"abc",
+				"def",
+				"// other",
+				"ghi",
+			),
+			classify: isComment,
+			want: []Run{
+				{true, mkSrc(0, "// foo", "// bar")},
+				{false, mkSrc(2, "abc", "def")},
+				{true, mkSrc(4, "// other")},
+				{false, mkSrc(5, "ghi")},
+			},
+		},
+		{
+			name: "only_comments",
+			src: mkSrc(0,
+				"// abc",
+				"// def",
+				"// ghi",
+			),
+			classify: isComment,
+			want: []Run{
+				{true, mkSrc(0, "// abc", "// def", "// ghi")},
+			},
+		},
+		{
+			name: "comment_at_end",
+			src: mkSrc(0,
+				"// abc",
+				"def",
+				"// ghi",
+			),
+			classify: isComment,
+			want: []Run{
+				{true, mkSrc(0, "// abc")},
+				{false, mkSrc(1, "def")},
+				{true, mkSrc(2, "// ghi")},
+			},
+		},
+		{
+			name: "no_comments",
+			src: mkSrc(0,
+				"abc",
+				"def",
+				"ghi",
+			),
+			classify: isComment,
+			want: []Run{
+				{false, mkSrc(0, "abc", "def", "ghi")},
+			},
+		},
+		{
+			name: "weird_classifier",
+			src: mkSrc(0,
+				"abc",
+				"def",
+				"ghi",
+				"jkl",
+				"mno",
+				"pqr",
+				"stu",
+			),
+			classify: groupsOf2And1,
+			want: []Run{
+				{false, mkSrc(0, "abc", "def")},
+				{true, mkSrc(2, "ghi")},
+				{false, mkSrc(3, "jkl", "mno")},
+				{true, mkSrc(5, "pqr")},
+				{false, mkSrc(6, "stu")}, // truncated final group
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []Run
+			tc.src.ForEachRun(tc.classify, func(block source, isMatch bool) {
+				got = append(got, Run{isMatch, block})
+			})
+			checkDiff(t, "ForEachRun", got, tc.want)
+		})
+	}
+}
+
+func TestSplit(t *testing.T) {
+	t.Parallel()
+
+	lines := mkSrc(0,
+		"// comment",
+		"abc",
+		"",
+		"// other",
+		"def",
+		"",
+		"// end",
+		"ghi",
+	)
+
+	exact := func(s string) func(source) bool {
+		return func(line source) bool {
+			return line.Text() == s
+		}
+	}
+	prefix := func(s string) func(source) bool {
+		return func(line source) bool {
+			return strings.HasPrefix(line.Text(), s)
+		}
+	}
+
+	tests := []struct {
+		name string
+		src  source
+		fn   func(source) bool
+		want []source
+	}{
+		{
+			name: "simple",
+			src:  lines,
+			fn:   exact("abc"),
+			want: []source{
+				mkSrc(0, "// comment"),
+				mkSrc(2, "", "// other", "def", "", "// end", "ghi"),
+			},
+		},
+		{
+			name: "start",
+			src:  lines,
+			fn:   exact("// comment"),
+			want: []source{
+				mkSrc(1, "abc", "", "// other", "def", "", "// end", "ghi"),
+			},
+		},
+		{
+			name: "end",
+			src:  lines,
+			fn:   exact("ghi"),
+			want: []source{
+				mkSrc(0, "// comment", "abc", "", "// other", "def", "", "// end"),
+			},
+		},
+		{
+			name: "no_match",
+			src:  lines,
+			fn:   exact("xyz"),
+			want: []source{
+				mkSrc(0, "// comment", "abc", "", "// other", "def", "", "// end", "ghi"),
+			},
+		},
+		{
+			name: "prefix",
+			src:  lines,
+			fn:   prefix("ab"),
+			want: []source{
+				mkSrc(0, "// comment"),
+				mkSrc(2, "", "// other", "def", "", "// end", "ghi"),
+			},
+		},
+		{
+			name: "prefix_comment",
+			src:  lines,
+			fn:   prefix("// "),
+			want: []source{
+				mkSrc(1, "abc", ""),
+				mkSrc(4, "def", ""),
+				mkSrc(7, "ghi"),
+			},
+		},
+
+		{
+			name: "empty",
+			src:  mkSrc(0),
+			fn:   exact("xyz"),
+			want: []source{},
+		},
+		{
+			name: "empty_split_blank",
+			src:  mkSrc(0),
+			fn:   exact(""),
+			want: []source{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.src.Split(tc.fn)
+			checkDiff(t, "Split", got, tc.want)
+		})
+	}
+}
+
+func TestCut(t *testing.T) {
+	t.Parallel()
+
+	exact := func(s string) func(source) bool {
+		return func(line source) bool {
+			return line.Text() == s
+		}
+	}
+	prefix := func(s string) func(source) bool {
+		return func(line source) bool {
+			return strings.HasPrefix(line.Text(), s)
+		}
+	}
+
+	tests := []struct {
+		name         string
+		src          source
+		fn           func(source) bool
+		before, rest source
+		found        bool
+	}{
+		{
+			name:   "simple",
+			src:    mkSrc(0, "abc", "def", "ghi"),
+			fn:     exact("def"),
+			before: mkSrc(0, "abc"),
+			rest:   mkSrc(1, "def", "ghi"),
+			found:  true,
+		},
+		{
+			name: "cut_on_first",
+			src: mkSrc(0,
+				"abc",
+				"// def",
+				"ghi",
+				"// jkl",
+				"mno",
+			),
+			fn:     prefix("// "),
+			before: mkSrc(0, "abc"),
+			rest:   mkSrc(1, "// def", "ghi", "// jkl", "mno"),
+			found:  true,
+		},
+		{
+			name:   "no_match",
+			src:    mkSrc(0, "abc", "def", "ghi"),
+			fn:     exact("xyz"),
+			before: mkSrc(0, "abc", "def", "ghi"),
+			rest:   source{},
+			found:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBefore, gotRest, gotFound := tc.src.Cut(tc.fn)
+			checkDiff(t, "Cut() before", gotBefore, tc.before)
+			checkDiff(t, "Cut() after", gotRest, tc.rest)
+			if gotFound != tc.found {
+				t.Errorf("Cut() found=%v, want %v", gotFound, tc.found)
+			}
+		})
+	}
+}
+
+func mkSrc(offset int, lines ...string) source {
+	return source{
+		lineOffset: offset,
+		lines:      lines,
+	}
+}
+
+func checkDiff(t *testing.T, whatIsBeingDiffed string, got, want any) {
+	t.Helper()
+	if diff := cmp.Diff(got, want, cmp.AllowUnexported(source{})); diff != "" {
+		t.Errorf("%s is wrong (-got+want):\n%s", whatIsBeingDiffed, diff)
+	}
+}


### PR DESCRIPTION
This splits up the parser logic: a lower level helper breaks up the input bytes in useful ways and tracks source information for error reports. The main parser uses the helper, so that it can focus on the "business logic" of checking the format and linting, without being polluted with tracking offsets and partial state and stuff.

The PR is in 2 commits, each one is ~50% of the change: the first adds the new helper without using it, in `text.go` and `text_test.go`. The second commit updates `parser.go` to use the helper.

The helper has a bunch more unit tests, but the parser functionality is unchanged, and all pre-existing tests pass without modification. Later PRs (see [todo](https://gist.github.com/danderson/f2d5a7a7e0400ea2a7c9dff18058615c#file-psl-todo-md)) will add missing features, this is just a cleanup to prepare for that.