### PR TITLE
Add missing spaces after '//' on prequalifyme.today block

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14797,8 +14797,8 @@ pstmn.io
 mock.pstmn.io
 httpbin.org
 
-//prequalifyme.today : https://prequalifyme.today
-//Submitted by DeepakTiwari deepak@ivylead.io
+// prequalifyme.today : https://prequalifyme.today
+// Submitted by DeepakTiwari deepak@ivylead.io
 prequalifyme.today
 
 // prgmr.com : https://prgmr.com/


### PR DESCRIPTION
All other comments in the file begin with '// ', this just makes the data more regular for parsing.

In particular I wanted to add a lint for this the Go parser/linter, and this is the only current violation of that convention in the PSL file. It seems easier to adjust the canonical file than to burn this one exception to the rule into code.

This is a whitespace-only change that does not alter any suffixes, so a lot of the PSL checklist is N/A. Relevant items:
 - I'm not the owner of the block being edited, but I'm also not changing suffixes or contact info.
 - I ran `make test`, it reports no failures.
 - I ran `cd tools && go run ./govalidate ../public_suffix_list.dat` and verified that there are no parse/lint errors there either.