### PR TITLE
Replace unicode fullwidth colon with a regular ascii colon.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13397,7 +13397,7 @@ freemyip.com
 // Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
 wien.funkfeuer.at
 
-// Future Versatile Group. ：https://www.fvg-on.net/
+// Future Versatile Group. : https://www.fvg-on.net/
 // T.Kabu <webmaster@fvg-on.net>
 daemon.asia
 dix.asia


### PR DESCRIPTION
The PSL file format encourages ascii characters where possible to make parsing easier. This is one comment block with metadata (contact info etc.) that does not use an ascii colon, making parsing more difficult.

Like #2000, this only changes characters in a comment, and doesn't add/edit/delete suffixes. Relevant checklist items:
 - I'm not authoritative for this domain, and not changing suffixes or contact info.
 - I ran `make test`, no errors.
 - I ran `cd tools && go run ./govalidate ../public_suffix_list.dat`, also reports no issues.