### PR TITLE
Add Raidboxes GmbH to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14853,6 +14853,11 @@ cloudsite.builders
 myradweb.net
 servername.us
 
+// Raidboxes GmbH : https://raidboxes.de
+// Submitted by Auke Tembrink <auke@raidboxes.de>
+myrdbx.io
+site.rb-hosting.io
+
 // Redgate Software: https://red-gate.com
 // Submitted by Andrew Farries <andrew.farries@red-gate.com>
 instances.spawn.cc

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14854,7 +14854,7 @@ myradweb.net
 servername.us
 
 // Raidboxes GmbH : https://raidboxes.de
-// Submitted by Auke Tembrink <auke@raidboxes.de>
+// Submitted by Auke Tembrink <hostmaster@raidboxes.de>
 myrdbx.io
 site.rb-hosting.io
 


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example): None

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

Raidboxes is a web hosting company based in Germany, specialized in managed WordPress hosting.
Established in 2015, we focus on providing high traffic capable WordPress instances and 
aim to deliver a secure and user-friendly hosting solution for WordPress professionals. Our headquarter
is located in Münster, Germany but since 2020 we support full remote work for all employees. The basic
idea behind our product is to reduce manual work of WordPress administrators or developers with the help
of automation. For that purpose we are building different infrastructures in the background with different layers
and purposes based on the technical needs of the customers. Technically we are working with a setup involving
VPS and shared hosting architectures.

Also tell us who you (submitter) are:
My role at Raidboxes is leading and being part of the site reliability engineering team. My team and I are developing, maintaining and evolving the backend infrastructure at Raidboxes. That includes also taking care of multiple technical workflows and tasks around technical administration of server deployments, creating/developing the backend solutions for new features. In situations like this I aim to fulfill the communication and supervise such processes to give my team the freedom to concentrate on their preferred core tasks. 


Organization Website: 
https://raidboxes.de

Reason for PSL Inclusion
====

Each hosting account is assigned an alias on myrdbx.io (for example: bauke123.myrdbx.io) and site.rb-hosting.io (for example: bauke123.site.rb-hosting.io) to help customers access their web applications, especially when they don't have an own domain name or are preparing for a migration. It would be useful if browsers and other independent instances correctly recognizes this domain as a suffix to prevent cookies or other evaluations from being shared between customers/websites within the domains.

Please also include the numbers of any past Issue # or PR #: None

Number of users this request is being made to serve:
Currently we are serving about 3.500 (and growing) customer websites using subdomains like mentioned above in the reason to be added to the PSL. As we are finalizing a new infrastructure right now, we will start to migrate about 30.000 already existing websites into this domains in the next weeks.

Both domains (myrdbx.io and rb-hosting.io) have been manually registered for 4 years (currently until 2028) and will be renewed every year at January 10th for another year to ensure that the registration period is always 2+ years. 


DNS Verification via dig
=======

Both DNS records are placed successfully and are well documented as mandatory and to stay in place internally in the company.

```
 ~ dig +short TXT _psl.myrdbx.io
"https://github.com/publicsuffix/list/pull/2004"
```

```
~ dig +short TXT _psl.site.rb-hosting.io
"https://github.com/publicsuffix/list/pull/2004"
```

Results of Syntax Checker (`make test`)
=========

Tests have been made locally with success

```
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```


