### PR TITLE
tool/internal/parser: sanitize input to clean, valid UTF-8

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,4 +2,7 @@ module github.com/publicsuffix/list/tools
 
 go 1.21
 
-require github.com/google/go-cmp v0.6.0
+require (
+	github.com/google/go-cmp v0.6.0
+	golang.org/x/text v0.16.0
+)

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
+golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=

--- a/tools/govalidate/govalidate.go
+++ b/tools/govalidate/govalidate.go
@@ -30,7 +30,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	psl := parser.Parse(string(bs))
+	psl := parser.Parse(bs)
 
 	for _, err := range psl.Errors {
 		fmt.Println(err)

--- a/tools/internal/parser/errors.go
+++ b/tools/internal/parser/errors.go
@@ -4,6 +4,61 @@ import (
 	"fmt"
 )
 
+// InvalidEncodingError reports that the input is encoded with
+// something other than UTF-8.
+type InvalidEncodingError struct {
+	Encoding string
+}
+
+func (e InvalidEncodingError) Error() string {
+	return fmt.Sprintf("file uses invalid character encoding %s", e.Encoding)
+}
+
+// UTF8BOMError reports that the input has an unnecessary UTF-8 byte
+// order mark (BOM) at the start.
+type UTF8BOMError struct{}
+
+func (e UTF8BOMError) Error() string {
+	return "file starts with an unnecessary UTF-8 BOM (byte order mark)"
+}
+
+// InvalidUTF8Error reports that a line contains bytes that are not
+// valid UTF-8.
+type InvalidUTF8Error struct {
+	Line Source
+}
+
+func (e InvalidUTF8Error) Error() string {
+	return fmt.Sprintf("found non UTF-8 bytes at %s", e.Line.LocationString())
+}
+
+// DOSNewlineError reports that a line has a DOS style line ending.
+type DOSNewlineError struct {
+	Line Source
+}
+
+func (e DOSNewlineError) Error() string {
+	return fmt.Sprintf("%s has a DOS line ending (\\r\\n instead of just \\n)", e.Line.LocationString())
+}
+
+// TrailingWhitespaceError reports that a line has trailing whitespace.
+type TrailingWhitespaceError struct {
+	Line Source
+}
+
+func (e TrailingWhitespaceError) Error() string {
+	return fmt.Sprintf("%s has trailing whitespace", e.Line.LocationString())
+}
+
+// LeadingWhitespaceError reports that a line has leading whitespace.
+type LeadingWhitespaceError struct {
+	Line Source
+}
+
+func (e LeadingWhitespaceError) Error() string {
+	return fmt.Sprintf("%s has leading whitespace", e.Line.LocationString())
+}
+
 // UnclosedSectionError reports that a file section was not closed
 // properly before EOF.
 type UnclosedSectionError struct {

--- a/tools/internal/parser/parser.go
+++ b/tools/internal/parser/parser.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Parse parses src as a PSL file and returns the parse result.
+// Parse parses bs as a PSL file and returns the parse result.
 //
 // The parser tries to keep going when it encounters errors. Parse and
 // validation errors are accumulated in the Errors field of the
@@ -19,15 +19,19 @@ import (
 // submission guidelines
 // (https://github.com/publicsuffix/list/wiki/Guidelines). A File with
 // errors should not be used to calculate public suffixes for FQDNs.
-func Parse(src string) *File {
-	return parseWithExceptions(src, downgradeToWarning)
+func Parse(bs []byte) *File {
+	return parseWithExceptions(bs, downgradeToWarning)
 }
 
-func parseWithExceptions(src string, downgradeToWarning func(error) bool) *File {
+func parseWithExceptions(bs []byte, downgradeToWarning func(error) bool) *File {
+	src, errs := newSource(bs)
 	p := parser{
 		downgradeToWarning: downgradeToWarning,
 	}
-	p.Parse(newSource(src))
+	for _, err := range errs {
+		p.addError(err)
+	}
+	p.Parse(src)
 	p.Validate()
 	return &p.File
 }

--- a/tools/internal/parser/parser_test.go
+++ b/tools/internal/parser/parser_test.go
@@ -27,19 +27,19 @@ func TestParser(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		psl                string
+		psl                []byte
 		downgradeToWarning func(error) bool
 		want               File
 	}{
 		{
 			name: "empty",
-			psl:  "",
+			psl:  byteLines(""),
 			want: File{},
 		},
 
 		{
 			name: "just_comments",
-			psl: lines(
+			psl: byteLines(
 				"// This is an empty PSL file.",
 				"",
 				"// Here is a second comment.",
@@ -54,7 +54,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "just_suffixes",
-			psl: lines(
+			psl: byteLines(
 				"example.com",
 				"other.example.com",
 				"*.example.org",
@@ -87,7 +87,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "empty_sections",
-			psl: lines(
+			psl: byteLines(
 				"// ===BEGIN IMAGINARY DOMAINS===",
 				"",
 				"// ===END IMAGINARY DOMAINS===",
@@ -118,7 +118,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "missing_section_end",
-			psl: lines(
+			psl: byteLines(
 				"// ===BEGIN ICANN DOMAINS===",
 			),
 			want: File{
@@ -141,7 +141,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "nested_sections",
-			psl: lines(
+			psl: byteLines(
 				"// ===BEGIN ICANN DOMAINS===",
 				"// ===BEGIN SECRET DOMAINS===",
 				"// ===END SECRET DOMAINS===",
@@ -188,7 +188,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			name: "mismatched_sections",
-			psl: lines(
+			psl: byteLines(
 				"// ===BEGIN ICANN DOMAINS===",
 				"",
 				"// ===END PRIVATE DOMAINS===",
@@ -221,7 +221,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "unknown_section_header",
-			psl: lines(
+			psl: byteLines(
 				"// ===TRANSFORM DOMAINS===",
 			),
 			want: File{
@@ -240,7 +240,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "suffixes_with_unstructured_header",
-			psl: lines(
+			psl: byteLines(
 				"// Unstructured header.",
 				"// I'm just going on about random things.",
 				"example.com",
@@ -271,7 +271,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "suffixes_with_canonical_private_header",
-			psl: lines(
+			psl: byteLines(
 				"// DuckCorp Inc: https://example.com",
 				"// Submitted by Not A Duck <duck@example.com>",
 				"// Seriously, not a duck",
@@ -307,7 +307,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "suffixes_with_entity_and_submitter",
-			psl: lines(
+			psl: byteLines(
 				"// DuckCorp Inc: submitted by Not A Duck <duck@example.com>",
 				"example.com",
 			),
@@ -333,7 +333,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "suffixes_with_all_separate_lines",
-			psl: lines(
+			psl: byteLines(
 				"// DuckCorp Inc",
 				"// https://example.com",
 				"// Submitted by Not A Duck <duck@example.com>",
@@ -366,7 +366,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "suffixes_standard_header_submitter_first",
-			psl: lines(
+			psl: byteLines(
 				"// Submitted by Not A Duck <duck@example.com>",
 				"// DuckCorp Inc: https://example.com",
 				"example.com",
@@ -396,7 +396,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "suffixes_standard_header_leading_unstructured",
-			psl: lines(
+			psl: byteLines(
 				"// This is an unstructured comment.",
 				"// DuckCorp Inc: https://example.com",
 				"// Submitted by Not A Duck <duck@example.com>",
@@ -429,7 +429,7 @@ func TestParser(t *testing.T) {
 
 		{
 			name: "legacy_error_downgrade",
-			psl: lines(
+			psl: byteLines(
 				"// https://example.com",
 				"example.com",
 			),
@@ -476,7 +476,7 @@ func TestParser(t *testing.T) {
 			// Regression test for Future Versatile Group, who use a
 			// unicode fullwidth colon in their header.
 			name: "unicode_colon",
-			psl: lines(
+			psl: byteLines(
 				"// Future Versatile Group：https://example.org",
 				"example.com",
 			),
@@ -501,7 +501,7 @@ func TestParser(t *testing.T) {
 			// Regression test for a few blocks that start with "name
 			// (url)" instead of the more common "name: url".
 			name: "url_in_parens",
-			psl: lines(
+			psl: byteLines(
 				"// Parens Appreciation Society (https://example.org)",
 				"example.com",
 			),
@@ -527,7 +527,7 @@ func TestParser(t *testing.T) {
 			// (url)" style don't have a scheme on their URL, so
 			// require a bit more fudging to parse.
 			name: "url_in_parens_no_scheme",
-			psl: lines(
+			psl: byteLines(
 				"// Parens Appreciation Society (hostyhosting.com)",
 				"example.com",
 				"",
@@ -569,7 +569,7 @@ func TestParser(t *testing.T) {
 			// lines, or you might overwrite the correct answer with
 			// someething else that happens to have the right shape.
 			name: "accept_first_valid_entity",
-			psl: lines(
+			psl: byteLines(
 				"// cd : https://en.wikipedia.org/wiki/.cd",
 				"// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1",
 				"cd",
@@ -645,7 +645,7 @@ func TestParseRealList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f := Parse(string(bs))
+	f := Parse(bs)
 
 	for _, err := range f.Errors {
 		t.Errorf("Parse error: %v", err)
@@ -661,7 +661,7 @@ func TestRoundtripRealList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := Parse(string(bs))
+	f := Parse(bs)
 
 	if len(f.Errors) > 0 {
 		t.Fatal("Parse errors, not attempting to roundtrip")
@@ -700,7 +700,7 @@ func TestRoundtripRealListDetailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f := Parse(string(bs))
+	f := Parse(bs)
 
 	if len(f.Errors) > 0 {
 		t.Fatal("Parse errors, not attempting to roundtrip")
@@ -761,7 +761,7 @@ func TestExceptionsStillNecessary(t *testing.T) {
 		defer func() { missingEmail = old }()
 		missingEmail = trimmed
 
-		f := Parse(string(bs))
+		f := Parse(bs)
 		if len(f.Errors) == 0 {
 			t.Errorf("missingEmail exception no longer necessary:\n%s", omitted)
 		}

--- a/tools/internal/parser/text.go
+++ b/tools/internal/parser/text.go
@@ -1,8 +1,14 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding"
+	xunicode "golang.org/x/text/encoding/unicode"
 )
 
 // Source is a piece of source text with location information.
@@ -12,11 +18,28 @@ import (
 // behave the same as in Go slices, and select the half-open interval
 // [start:end).
 type Source struct {
-	// The lines of source text.
+	// The lines of source text, sanitized to valid UTF-8 and with
+	// leading and trailing whitespace removed.
 	lines []string
 	// lineOffset is how many lines are before the beginning of lines,
 	// for sources that represent a subset of the input.
 	lineOffset int
+}
+
+// newSource returns a source for bs, along with a preliminary set of
+// input validation errors.
+//
+// source always returns a usable, non-nil result, even when it
+// returns errors.
+func newSource(bs []byte) (Source, []error) {
+	lines, errs := normalizeToUTF8Lines(bs)
+
+	ret := Source{
+		lines:      lines,
+		lineOffset: 0,
+	}
+
+	return ret, errs
 }
 
 // Text returns the source text of s as a string.
@@ -48,14 +71,6 @@ func (s Source) LocationString() string {
 		return fmt.Sprintf("line %d", start)
 	}
 	return fmt.Sprintf("lines %d-%d", start, end)
-}
-
-// newSource returns a Source for src.
-func newSource(src string) Source {
-	return Source{
-		lines:      strings.Split(src, "\n"),
-		lineOffset: 0,
-	}
 }
 
 // slice returns the slice of s between startLine and endLine.
@@ -147,4 +162,172 @@ func (s Source) forEachRun(classify func(line Source) bool, processBlock func(bl
 	if currentBlock != len(s.lines) {
 		processBlock(s.slice(currentBlock, len(s.lines)), currentVal)
 	}
+}
+
+const (
+	bomUTF8    = "\xEF\xBB\xBF"
+	bomUTF16BE = "\xFE\xFF"
+	bomUTF16LE = "\xFF\xFE"
+)
+
+// The transformers that normalizeToUTF8Lines can use to process input
+// into valid UTF-8, and that guessUTFVariant can return.
+var (
+	utf8Transform              = xunicode.UTF8BOM
+	utf16LittleEndianTransform = xunicode.UTF16(xunicode.LittleEndian, xunicode.UseBOM)
+	utf16BigEndianTransform    = xunicode.UTF16(xunicode.BigEndian, xunicode.UseBOM)
+)
+
+// normalizeToUTF8Lines slices bs into one string per line.
+//
+// All returned strings contain only valid UTF-8. Invalid byte
+// sequences are replaced with the unicode replacement character
+// (\uFFFD).
+//
+// The canonical PSL encoding is a file consisting entirely of valid
+// UTF-8, with no leading BOM or unicode replacement characters. In an
+// effort to report useful errors for common mangling caused by older
+// Windows software, normalizeToUTF8Lines accepts input encoded as
+// UTF-8, UTF-16LE or UTF-16BE, with or without a leading BOM.
+//
+// normalizeToUTF8Lines returns the normalized lines of bs, as well as
+// errors that report deviations from the canonical encoding, if any.
+func normalizeToUTF8Lines(bs []byte) ([]string, []error) {
+	var errs []error
+
+	enc := utf8Transform
+	switch {
+	case bytes.HasPrefix(bs, []byte(bomUTF8)):
+		errs = append(errs, UTF8BOMError{})
+	case bytes.HasPrefix(bs, []byte(bomUTF16BE)):
+		enc = utf16BigEndianTransform
+		errs = append(errs, InvalidEncodingError{"UTF-16BE"})
+	case bytes.HasPrefix(bs, []byte(bomUTF16LE)):
+		enc = utf16LittleEndianTransform
+		errs = append(errs, InvalidEncodingError{"UTF-16LE"})
+	default:
+		enc = guessUTFVariant(bs)
+		switch enc {
+		case utf16BigEndianTransform:
+			errs = append(errs, InvalidEncodingError{"UTF-16BE (guessed)"})
+		case utf16LittleEndianTransform:
+			errs = append(errs, InvalidEncodingError{"UTF-16LE (guessed)"})
+		}
+	}
+
+	bs, err := enc.NewDecoder().Bytes(bs)
+	if err != nil {
+		// The decoder shouldn't error out, if it does we can't really
+		// proceed, just return the errors we've found so far.
+		errs = append(errs, err)
+		return []string{}, errs
+	}
+
+	if len(bs) == 0 {
+		return []string{}, errs
+	}
+
+	ret := strings.Split(string(bs), "\n")
+	for i, line := range ret {
+		// capture source info before we tidy up the line starts/ends,
+		// so that input normalization errors show the problem being
+		// described.
+		//
+		// However, we still provide post-sanitization UTF-8 bytes,
+		// not the raw input. The raw input is unlikely to display
+		// correctly in terminals and logs, and because the unicode
+		// replacement character is a distinctive shape that stands
+		// out, it should provide enough hints as to where any invalid
+		// byte sequences are.
+		src := Source{
+			lineOffset: i,
+			lines:      []string{line},
+		}
+		if strings.ContainsRune(line, utf8.RuneError) {
+			errs = append(errs, InvalidUTF8Error{src})
+		}
+		line, ok := strings.CutSuffix(line, "\r")
+		if ok {
+			ret[i] = line
+			errs = append(errs, DOSNewlineError{src})
+		}
+		if ln := strings.TrimRightFunc(line, unicode.IsSpace); ln != line {
+			line = ln
+			ret[i] = line
+			errs = append(errs, TrailingWhitespaceError{src})
+		}
+		if ln := strings.TrimLeftFunc(line, unicode.IsSpace); ln != line {
+			line = ln
+			ret[i] = line
+			errs = append(errs, LeadingWhitespaceError{src})
+		}
+	}
+
+	return ret, errs
+}
+
+// guessUTFVariant guesses the encoding of bs.
+//
+// Returns the transformer to use on bs, one of utf8Transform,
+// utf16LittleEndianTransform or utf16BigEndianTransform.
+func guessUTFVariant(bs []byte) encoding.Encoding {
+	// Only scan a few hundred bytes. Assume UTF-8 if we don't see
+	// anything odd before that.
+	const checkLimit = 200 // 100 UTF-16 characters
+	if len(bs) > checkLimit {
+		bs = bs[:checkLimit]
+	}
+
+	// This is a crude but effective trick to detect UTF-16: we assume
+	// that the input contains at least some ascii, and that the
+	// decoded input does not contain Unicode \u0000 codepoints
+	// (legacy ascii null).
+	//
+	// If this is true, then valid UTF-8 text does not have any zero
+	// bytes, because UTF-8 never produces a zero byte except when it
+	// encodes the \u0000 codepoint.
+	//
+	// On the other hand, UTF-16 encodes all codepoints a pair of
+	// bytes, and that means an ascii string in UTF-16 a zero byte
+	// every 2 bytes. We can use the presence of zero bytes to
+	// identify UTF-16, and the position of the zero (even or odd
+	// offset) tells us what endianness to use.
+	evenZeros, oddZeros := 0, 0
+	for i, b := range bs {
+		if b != 0 {
+			continue
+		}
+
+		if i%2 == 0 {
+			evenZeros++
+		} else {
+			oddZeros++
+		}
+
+		const (
+			// Wait for a few zero bytes to accumulate, because if
+			// this is just UTF-8 with a few \u0000 codepoints,
+			// decoding as UTF-16 will be complete garbage. So, wait
+			// until we see a suspicious number of zeros, and require
+			// a strong bias towards even/odd before we guess
+			// UTF-16. Otherwise, UTF-8 gives us the best chance of
+			// producing coherent errors.
+			decisionThreshold = 20
+			utf16Threshold    = 15
+		)
+		if evenZeros+oddZeros < decisionThreshold {
+			continue
+		}
+		if evenZeros > utf16Threshold {
+			return utf16BigEndianTransform
+		} else if oddZeros > utf16Threshold {
+			return utf16LittleEndianTransform
+		}
+		// Lots of zeros, but no strong bias. No idea what's going on,
+		// UTF-8 is a safe fallback.
+		return utf8Transform
+	}
+
+	// Didn't find enough zeros, probably UTF-8.
+	return utf8Transform
 }


### PR DESCRIPTION
The PSL's canonical is valid UTF-8 with no BOM. However, to try and report useful lint errors, the parser tries to detect and normalize all forms of UTF-16, as well as UTF-8 with BOM. Anything other than the specified canonical encoding is reported in validation errors.

---

The upcoming PR that implements validation of block ordering needs to compare block names, which requires comparing with a Unicode collation. Collation is already confusing enough by itself, without also feeding it invalid UTF-8 :). So, this is a best-effort attempt to normalize non-compliant inputs into clean UTF-8, so that we report those errors early and the rest of the parser can assume strings don't contain garbage, at least at the encoding level.