### PR TITLE
Add closing chevron to contact email address.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15484,7 +15484,7 @@ azimuth.network
 tlon.network
 
 // Tor Project, Inc. : https://torproject.org
-// Submitted by Antoine Beaupré <anarcat@torproject.org
+// Submitted by Antoine Beaupré <anarcat@torproject.org>
 torproject.net
 pages.torproject.net
 


### PR DESCRIPTION
Conventionally, contact info in the PSL is in RFC 5322 email address format, aka "Name of Person <email@example.com>". Many entries omit the chevrons around the email, so parsers need to be robust to that. But Tor is the only one that is halfway between the two, so it makes sense to fix it.