### PR TITLE
Add missing URL schemes to URLs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13824,7 +13824,7 @@ sch.so
 // Submitted by Bohdan Dub <support@hostfly.com.ua>
 ie.ua
 
-// HostyHosting (hostyhosting.com)
+// HostyHosting (https://hostyhosting.com)
 hostyhosting.io
 
 // Hypernode B.V. : https://www.hypernode.com/
@@ -15437,7 +15437,7 @@ beta.tailscale.net
 ts.net
 *.c.ts.net
 
-// TASK geographical domains (www.task.gda.pl/uslugi/dns)
+// TASK geographical domains (https://www.task.gda.pl/uslugi/dns)
 gda.pl
 gdansk.pl
 gdynia.pl


### PR DESCRIPTION
URL schemes are mandatory for HTTP/S in the RFC, although some parsers interpret a scheme-less URL as a relative path with no scheme or host. There are 2 such URLs in the PSL, which require workarounds when parsing owner metadata for suffixes.