### PR TITLE
tools/internal/parser: remove workarounds for fixed PSL blocks

### DIFF
--- a/tools/internal/parser/exceptions.go
+++ b/tools/internal/parser/exceptions.go
@@ -341,7 +341,7 @@ var missingEmail = []string{
 		"hashbang.sh",
 	),
 	lines(
-		"// HostyHosting (hostyhosting.com)",
+		"// HostyHosting (https://hostyhosting.com)",
 		"hostyhosting.io",
 	),
 	lines(
@@ -363,7 +363,7 @@ var missingEmail = []string{
 		"torun.pl",
 	),
 	lines(
-		"// TASK geographical domains (www.task.gda.pl/uslugi/dns)",
+		"// TASK geographical domains (https://www.task.gda.pl/uslugi/dns)",
 		"gda.pl",
 		"gdansk.pl",
 		"gdynia.pl",

--- a/tools/internal/parser/parser.go
+++ b/tools/internal/parser/parser.go
@@ -334,15 +334,6 @@ func splitNameish(line string) (name string, url *url.URL, submitter *mail.Addre
 		}
 	}
 
-	// A single entry uses the unicode fullwidth colon codepoint
-	// (U+FF1A) instead of an ascii colon. Correct that before
-	// attempting a parse.
-	//
-	// TODO: fix the source and delete this hack.
-	if strings.Contains(line, "Future Versatile Group") {
-		line = strings.Replace(line, "\uff1a", ":", -1)
-	}
-
 	name, rest, ok := strings.Cut(line, ":")
 	if !ok {
 		return "", nil, nil
@@ -373,14 +364,6 @@ func splitNameAndURLInParens(line string) (name string, url *url.URL, ok bool) {
 	}
 	name = strings.TrimSpace(line[:idx])
 	urlStr := strings.TrimSpace(line[idx+1 : len(line)-1])
-
-	// Two PSL entries omit the scheme at the front of the URL, which
-	// makes them invalid by getURL's standards.
-	//
-	// TODO: fix the source and delete this hack.
-	if urlStr == "www.task.gda.pl/uslugi/dns" || urlStr == "hostyhosting.com" {
-		urlStr = "https://" + urlStr
-	}
 
 	if u := getURL(urlStr); u != nil {
 		return name, u, true
@@ -438,16 +421,6 @@ func getSubmitter(line string) *mail.Address {
 
 	if addr, err := mail.ParseAddress(line); err == nil {
 		return addr
-	}
-
-	// One current entry is missing the closing chevron on the email,
-	// which makes it an invalid address.
-	//
-	// TODO: fix the source and delete this hack.
-	if strings.HasSuffix(line, "torproject.org") {
-		if addr, err := mail.ParseAddress(line + ">"); err == nil {
-			return addr
-		}
 	}
 
 	// One current entry uses old school email obfuscation to foil


### PR DESCRIPTION
PSL changes e18a520, fb91de8 and 45d3d06 fixed the blocks that required these workarounds.