### PR TITLE
tools/internal/parser: detect and report section markers within suffix blocks

### DIFF
--- a/tools/internal/parser/errors.go
+++ b/tools/internal/parser/errors.go
@@ -59,6 +59,16 @@ func (e LeadingWhitespaceError) Error() string {
 	return fmt.Sprintf("%s has leading whitespace", e.Line.LocationString())
 }
 
+// SectionInSuffixBlock reports that a comment within a block of
+// suffixes contains a section delimiter.
+type SectionInSuffixBlock struct {
+	Line Source
+}
+
+func (e SectionInSuffixBlock) Error() string {
+	return fmt.Sprintf("section delimiters are not allowed in suffix block comment at %s", e.Line.LocationString())
+}
+
 // UnclosedSectionError reports that a file section was not closed
 // properly before EOF.
 type UnclosedSectionError struct {


### PR DESCRIPTION
Small extra validation that I remembered while I was implementing the big text/utf-8 bits that have now been merged.

Note this PR does not pass the tests in tools/internal/parser as-is, because it trips over the expired exemptions that get fixed in #2010. This doesn't break PSL CI right now since tools/internal/parser isn't run there, but I recommend merging #2010 first and then this. The two changes are touching different parts of the codebase, so they should rebase cleanly in either direction.