### PR TITLE
PSL Private Section Domains WHOIS Checker

### DIFF
--- a/tools/private_domains_checker/.gitignore
+++ b/tools/private_domains_checker/.gitignore
@@ -1,0 +1,3 @@
+venv
+__pycache__
+data/*.csv

--- a/tools/private_domains_checker/PSLPrivateDomainsProcessor.py
+++ b/tools/private_domains_checker/PSLPrivateDomainsProcessor.py
@@ -1,67 +1,164 @@
 import datetime
 import json
-import os
+import time
+
 import pandas as pd
 import requests
-import whois
+import whoisdomain as whois
+
+
+def make_dns_request(domain, record_type):
+    """
+    Makes DNS requests to both Google and Cloudflare DNS APIs.
+
+    Args:
+        domain (str): The domain to query.
+        record_type (str): The type of DNS record to query.
+
+    Returns:
+        list: A list containing the JSON responses from Google and Cloudflare.
+    """
+    urls = [
+        f"https://dns.google/resolve?name={domain}&type={record_type}",
+        f"https://cloudflare-dns.com/dns-query?name={domain}&type={record_type}"
+    ]
+
+    headers = {
+        "accept": "application/dns-json"
+    }
+
+    responses = []
+    for url in urls:
+        try:
+            response = requests.get(url, headers=headers)
+            if response.status_code == 200:
+                json_response = response.json()
+                # print(f"URL: {url}, Response: {json_response}")
+                responses.append(json_response)
+            else:
+                # print(f"URL: {url}, Status Code: {response.status_code}")
+                responses.append(None)
+        except Exception as e:
+            print(f"URL: {url}, DNS Exception: {e}")
+            responses.append(None)
+
+    return responses
 
 
 def check_dns_status(domain):
+    """
+    Checks the DNS status of a domain using Google and Cloudflare DNS APIs.
+
+    Args:
+        domain (str): The domain to check.
+
+    Returns:
+        str: The DNS status of the domain.
+    """
+
     def make_request():
-        try:
-            url = f"https://dns.google/resolve?name={domain}&type=NS"
-            response = requests.get(url)
-            json_response = response.json()
-            if json_response.get("Status") == 3:
+        responses = make_dns_request(domain, "NS")
+        if None in responses:
+            return "ERROR"
+
+        google_status = responses[0].get("Status")
+        cloudflare_status = responses[1].get("Status")
+
+        print(f"Google Status: {google_status}, Cloudflare Status: {cloudflare_status}")
+
+        if google_status == cloudflare_status:
+            if google_status == 3:
                 return "NXDOMAIN"
             else:
                 return "ok"
-        except Exception as e:
+        else:
+            return "INCONSISTENT"
+
+    for _ in range(5):
+        dns_status = make_request()
+        print(f"Attempt {_ + 1}, DNS Status: {dns_status}")
+        if dns_status not in ["ERROR", "INCONSISTENT"]:
+            return dns_status
+        time.sleep(1)
+    return "INCONSISTENT"
+
+
+def check_psl_txt_record(domain):
+    """
+    Checks the _psl TXT record for a domain using Google and Cloudflare DNS APIs.
+
+    Args:
+        domain (str): The domain to check.
+
+    Returns:
+        str: The _psl TXT record status of the domain.
+    """
+    # Prepare the domain for the TXT check
+    domain = domain.lstrip('*.').lstrip('!').encode('idna').decode('ascii')
+
+    def make_request():
+        responses = make_dns_request(f"_psl.{domain}", "TXT")
+        if None in responses:
             return "ERROR"
 
-    dns_status = make_request()
-    if dns_status == "ERROR":  # Give it another try
-        dns_status = make_request()
-    return dns_status
+        google_txt = responses[0].get("Answer", [])
+        cloudflare_txt = responses[1].get("Answer", [])
+
+        google_txt_records = [record.get("data", "") for record in google_txt]
+        cloudflare_txt_records = [record.get("data", "").strip('"') for record in cloudflare_txt]
+
+        print(
+            f"_psl TXT Records (Google): {google_txt_records},  _psl TXT Records (Cloudflare): {cloudflare_txt_records}")
+
+        if google_txt_records == cloudflare_txt_records:
+            for record in google_txt_records:
+                if "github.com/publicsuffix/list/pull/" in record:
+                    return "valid"
+            return "invalid"
+        else:
+            return "INCONSISTENT"
+
+    for _ in range(5):
+        psl_txt_status = make_request()
+        print(f"Attempt {_ + 1}, PSL TXT Status: {psl_txt_status}")
+        if psl_txt_status not in ["ERROR", "INCONSISTENT"]:
+            return psl_txt_status
+        time.sleep(1)
+    return "INCONSISTENT"
 
 
 def get_whois_data(domain):
+    """
+    Retrieves WHOIS data for a domain using the whoisdomain package.
+
+    Args:
+        domain (str): The domain to query.
+
+    Returns:
+        tuple: A tuple containing WHOIS domain status, expiry date, and WHOIS status.
+    """
     try:
-        w = whois.whois(domain)
-        whois_domain_status = w.status
-        whois_expiry = w.expiration_date
-        if isinstance(whois_expiry, list):
-            whois_expiry = whois_expiry[0]
+        d = whois.query(domain)
+        whois_domain_status = d.statuses
+        whois_expiry = d.expiration_date
         whois_status = "ok"
     except Exception as e:
+        print(f"WHOIS Exception: {e}")
         whois_domain_status = None
         whois_expiry = None
         whois_status = "ERROR"
     return whois_domain_status, whois_expiry, whois_status
 
 
-def check_psl_txt_record(domain):
-    def make_request():
-        try:
-            url = f"https://dns.google/resolve?name=_psl.{domain}&type=TXT"
-            response = requests.get(url)
-            json_response = response.json()
-            txt_records = json_response.get("Answer", [])
-            for record in txt_records:
-                if "github.com/publicsuffix/list/pull/" in record.get("data", ""):
-                    return "valid"
-            return "invalid"
-        except Exception as e:
-            return "ERROR"
-
-    psl_txt_status = make_request()
-    if psl_txt_status == "ERROR":  # Give it another try
-        psl_txt_status = make_request()
-    return psl_txt_status
-
-
 class PSLPrivateDomainsProcessor:
+    """
+    A class to process PSL private section domains, check their status, and save the results.
+    """
+
     def __init__(self):
+        """
+        Initializes the PSLPrivateDomainsProcessor with default values and settings.
+        """
         self.psl_url = "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
         self.psl_icann_marker = "// ===BEGIN ICANN DOMAINS==="
         self.psl_private_marker = "// ===BEGIN PRIVATE DOMAINS==="
@@ -72,12 +169,19 @@ class PSLPrivateDomainsProcessor:
             "whois_status",
             "whois_domain_expiry_date",
             "whois_domain_status",
-            "psl_txt_status"
+            "psl_txt_status",
+            "expiry_check_status"
         ]
         self.df = pd.DataFrame(columns=self.columns)
         self.icann_domains = set()
 
     def fetch_psl_data(self):
+        """
+        Fetches the PSL data from the specified URL.
+
+        Returns:
+            str: The raw PSL data.
+        """
         print("Fetching PSL data from URL...")
         response = requests.get(self.psl_url)
         psl_data = response.text
@@ -85,31 +189,49 @@ class PSLPrivateDomainsProcessor:
         return psl_data
 
     def parse_domain(self, domain):
-        # Remove any leading '*.' parts
-        domain = domain.lstrip('*.')
+        """
+        Parses and normalizes a domain.
 
-        # Split the domain into parts
+        Args:
+            domain (str): The domain to parse.
+
+        Returns:
+            str: The normalized domain.
+
+        Raises:
+            ValueError: If no valid top-level domain is found.
+        """
+        domain = domain.lstrip('*.')  # wildcards (*)
+        domain = domain.lstrip('!')  # bangs (!)
+
         parts = domain.split('.')
 
-        # Traverse the domain parts from the top-level domain upwards
         for i in range(len(parts)):
             candidate = '.'.join(parts[i:])
             if candidate in self.icann_domains:
                 continue
             elif '.'.join(parts[i + 1:]) in self.icann_domains:
-                # convert punycode to ASCII to support IDN domains
                 return candidate.encode('idna').decode('ascii')
 
-        # If no valid domain is found, raise an error
         raise ValueError(f"No valid top-level domain found in the provided domain: {domain}")
 
     def parse_psl_data(self, psl_data):
+        """
+        Parses the fetched PSL data and separates ICANN and private domains.
+
+        Args:
+            psl_data (str): The raw PSL data.
+
+        Returns:
+            tuple: A tuple containing the unparsed private domains and the parsed private domains.
+        """
         print("Parsing PSL data...")
 
         lines = psl_data.splitlines()
         process_icann = False
         process_private = False
-        private_domains = []
+        raw_private_domains = []
+        parsed_private_domains = []
 
         for line in lines:
             stripped_line = line.strip()
@@ -128,30 +250,42 @@ class PSLPrivateDomainsProcessor:
             if process_icann:
                 self.icann_domains.add(stripped_line)
             elif process_private:
-                private_domains.append(stripped_line)
+                raw_private_domains.append(stripped_line)
+                parsed_private_domains.append(stripped_line)
 
-        print(f"Private domains to be processed: {len(private_domains)}\n"
+        print(f"Private domains to be processed: {len(parsed_private_domains)}\n"
               f"ICANN domains: {len(self.icann_domains)}")
 
-        # Parse each domain
-        private_domains = [self.parse_domain(domain) for domain in private_domains]
+        parsed_private_domains = [self.parse_domain(domain) for domain in parsed_private_domains]
+        raw_private_domains = list(set(raw_private_domains))
+        parsed_private_domains = list(set(parsed_private_domains))
+        print("Private domains in the publicly registrable name space: ", len(parsed_private_domains))
 
-        # Remove duplicates
-        private_domains = list(set(private_domains))
-        print("Private domains in the publicly registrable name space: ", len(private_domains))
+        return raw_private_domains, parsed_private_domains
 
-        return private_domains
+    def process_domains(self, raw_domains, domains):
+        """
+        Processes each domain, performing DNS, WHOIS, and _psl TXT record checks.
 
-    def process_domains(self, domains):
+        Args:
+            raw_domains (list): A list of unparsed domains to process.
+            domains (list): A list of domains to process.
+        """
         data = []
-        for domain in domains:
-
+        for raw_domain, domain in zip(raw_domains, domains):
             whois_domain_status, whois_expiry, whois_status = get_whois_data(domain)
             dns_status = check_dns_status(domain)
-            psl_txt_status = check_psl_txt_record(domain)
+            psl_txt_status = check_psl_txt_record(raw_domain)
+
+            if whois_status == "ERROR":
+                expiry_check_status = "ERROR"
+            else:
+                expiry_check_status = "ok" if whois_expiry and whois_expiry >= (
+                        datetime.datetime.utcnow() + datetime.timedelta(days=365 * 2)) else "FAIL_2Y"
 
             print(
-                f"{domain} - DNS Status: {dns_status}, Expiry: {whois_expiry}, PSL TXT Status: {psl_txt_status}")
+                f"{domain} - DNS Status: {dns_status}, Expiry: {whois_expiry}, "
+                f"PSL TXT Status: {psl_txt_status}, Expiry Check: {expiry_check_status}")
 
             data.append({
                 "psl_entry": domain,
@@ -160,45 +294,68 @@ class PSLPrivateDomainsProcessor:
                 "whois_domain_expiry_date": whois_expiry,
                 "whois_status": whois_status,
                 "dns_status": dns_status,
-                "psl_txt_status": psl_txt_status
+                "psl_txt_status": psl_txt_status,
+                "expiry_check_status": expiry_check_status
             })
 
         self.df = pd.DataFrame(data, columns=self.columns)
 
     def save_results(self):
+        """
+        Saves all processed domain data to data/all.csv.
+        """
         sorted_df = self.df.sort_values(by="psl_entry")
         sorted_df.to_csv("data/all.csv", index=False)
 
     def save_invalid_results(self):
-        # Save nxdomain.csv
+        """
+        Saves domains with invalid DNS or expired WHOIS data to data/nxdomain.csv and data/expired.csv.
+        """
         nxdomain_df = self.df[self.df["dns_status"] != "ok"].sort_values(by="psl_entry")
         nxdomain_df.to_csv("data/nxdomain.csv", index=False)
 
-        # Save expired.csv
         today_str = datetime.datetime.utcnow().strftime("%Y-%m-%d")
         expired_df = self.df[
             self.df["whois_domain_expiry_date"].notnull() &
             (self.df["whois_domain_expiry_date"].astype(str).str[:10] < today_str)
-        ].sort_values(by="psl_entry")
+            ].sort_values(by="psl_entry")
         expired_df.to_csv("data/expired.csv", index=False)
 
-        # Save missing_psl_txt.csv
-        missing_psl_txt_df = self.df[self.df["psl_txt_status"] == "invalid"].sort_values(by="psl_entry")
-        missing_psl_txt_df.to_csv("data/missing_psl_txt.csv", index=False)
-
     def save_hold_results(self):
+        """
+        Saves domains with WHOIS status containing any form of "hold" to data/hold.csv.
+        """
         hold_df = self.df[
             self.df["whois_domain_status"].str.contains("hold", case=False, na=False)
         ].sort_values(by="psl_entry")
         hold_df.to_csv("data/hold.csv", index=False)
 
+    def save_missing_psl_txt_results(self):
+        """
+        Saves domains with invalid _psl TXT records to data/missing_psl_txt.csv.
+        """
+        missing_psl_txt_df = self.df[self.df["psl_txt_status"] == "invalid"].sort_values(by="psl_entry")
+        missing_psl_txt_df.to_csv("data/missing_psl_txt.csv", index=False)
+
+    def save_expiry_less_than_2yrs_results(self):
+        """
+        Saves domains with WHOIS expiry date less than 2 years from now to data/expiry_less_than_2yrs.csv.
+        """
+        expiry_less_than_2yrs_df = self.df[self.df["expiry_check_status"] == "FAIL_2Y"].sort_values(by="psl_entry")
+        expiry_less_than_2yrs_df.to_csv("data/expiry_less_than_2yrs.csv", index=False)
+
     def run(self):
+        """
+        Executes the entire processing pipeline.
+        """
         psl_data = self.fetch_psl_data()
-        domains = self.parse_psl_data(psl_data)
-        self.process_domains(domains)
+        raw_domains, domains = self.parse_psl_data(psl_data)
+        self.process_domains(raw_domains, domains)
         self.save_results()
         self.save_invalid_results()
         self.save_hold_results()
+        self.save_missing_psl_txt_results()
+        self.save_expiry_less_than_2yrs_results()
 
 
 if __name__ == "__main__":

--- a/tools/private_domains_checker/PSLPrivateDomainsProcessor.py
+++ b/tools/private_domains_checker/PSLPrivateDomainsProcessor.py
@@ -1,0 +1,165 @@
+import datetime
+import json
+import os
+import pandas as pd
+import requests
+import whois
+
+
+def check_dns_status(domain):
+    def make_request():
+        try:
+            url = f"https://dns.google/resolve?name={domain}&type=NS"
+            response = requests.get(url)
+            json_response = response.json()
+            if json_response.get("Status") == 3:
+                return "NXDOMAIN"
+            else:
+                return "ok"
+        except Exception as e:
+            return "ERROR"
+
+    dns_status = make_request()
+    if dns_status == "ERROR":  # Give it another try
+        dns_status = make_request()
+    return dns_status
+
+
+def get_whois_data(domain):
+    try:
+        w = whois.whois(domain)
+        whois_domain_status = w.status
+        whois_expiry = w.expiration_date
+        if isinstance(whois_expiry, list):
+            whois_expiry = whois_expiry[0]
+        whois_status = "ok"
+    except Exception as e:
+        whois_domain_status = None
+        whois_expiry = None
+        whois_status = "ERROR"
+    return whois_domain_status, whois_expiry, whois_status
+
+
+class PSLPrivateDomainsProcessor:
+    def __init__(self):
+        self.psl_url = "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
+        self.psl_icann_marker = "// ===BEGIN ICANN DOMAINS==="
+        self.psl_private_marker = "// ===BEGIN PRIVATE DOMAINS==="
+        self.columns = [
+            "psl_entry",
+            "top_level_domain",
+            "dns_status",
+            "whois_status",
+            "whois_domain_expiry_date",
+            "whois_domain_status",
+        ]
+        self.df = pd.DataFrame(columns=self.columns)
+        self.icann_domains = set()
+
+    def fetch_psl_data(self):
+        print("Fetching PSL data from URL...")
+        response = requests.get(self.psl_url)
+        psl_data = response.text
+        print("PSL data fetched.")
+        return psl_data
+
+    def parse_domain(self, domain):
+        domain = domain.lstrip('*.')
+        parts = domain.split('.')
+
+        # Traverse the domain parts from the top-level domain upwards
+        for i in range(len(parts)):
+            candidate = '.'.join(parts[i:])
+            if candidate in self.icann_domains:
+                continue
+            elif '.'.join(parts[i + 1:]) in self.icann_domains:
+                # convert punycode to ASCII to support IDN domains
+                return candidate.encode('idna').decode('ascii')
+
+        raise ValueError(f"No valid top-level domain found in the provided domain: {domain}")
+
+    def parse_psl_data(self, psl_data):
+        print("Parsing PSL data...")
+
+        lines = psl_data.splitlines()
+        process_icann = False
+        process_private = False
+        private_domains = []
+
+        for line in lines:
+            stripped_line = line.strip()
+            if stripped_line == self.psl_icann_marker:
+                process_icann = True
+                process_private = False
+                continue
+            elif stripped_line == self.psl_private_marker:
+                process_icann = False
+                process_private = True
+                continue
+
+            if stripped_line.startswith('//') or not stripped_line:
+                continue
+
+            if process_icann:
+                self.icann_domains.add(stripped_line)
+            elif process_private:
+                private_domains.append(stripped_line)
+
+        print(f"Private domains to be processed: {len(private_domains)}\n"
+              f"ICANN domains: {len(self.icann_domains)}")
+
+        private_domains = [self.parse_domain(domain) for domain in private_domains]
+
+        private_domains = list(set(private_domains))
+        print("Private domains in the publicly registrable name space: ", len(private_domains))
+
+        return private_domains
+
+    def process_domains(self, domains):
+        data = []
+        for domain in domains:
+
+            whois_domain_status, whois_expiry, whois_status = get_whois_data(domain)
+            dns_status = check_dns_status(domain)
+
+            print(
+                f"{domain} - DNS Status: {dns_status}, Expiry: {whois_expiry}")
+
+            data.append({
+                "psl_entry": domain,
+                "top_level_domain": domain,
+                "whois_domain_status": json.dumps(whois_domain_status),
+                "whois_domain_expiry_date": whois_expiry,
+                "whois_status": whois_status,
+                "dns_status": dns_status
+            })
+
+        self.df = pd.DataFrame(data, columns=self.columns)
+
+    def save_results(self):
+        self.df.to_csv("data/all.csv", index=False)
+
+    def save_invalid_results(self):
+        # Save nxdomain.csv
+        nxdomain_df = self.df[self.df["dns_status"] != "ok"]
+        nxdomain_df.to_csv("data/nxdomain.csv", index=False)
+
+        # Save expired.csv
+        today_str = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+        expired_df = self.df[
+            self.df["whois_domain_expiry_date"].notnull() &
+            (self.df["whois_domain_expiry_date"].astype(str).str[:10] < today_str)
+        ]
+        expired_df.to_csv("data/expired.csv", index=False)
+
+    def run(self):
+        psl_data = self.fetch_psl_data()
+        domains = self.parse_psl_data(psl_data)
+        self.process_domains(domains)
+        self.save_results()
+        self.save_invalid_results()
+
+
+if __name__ == "__main__":
+    processor = PSLPrivateDomainsProcessor()
+    processor.run()

--- a/tools/private_domains_checker/README.md
+++ b/tools/private_domains_checker/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `PSLPrivateDomainsProcessor` is a Python script designed to fetch data from the Public Suffix List (PSL) and check the domain status and expiry dates of the private section domains. 
+The `PSLPrivateDomainsProcessor` is a Python script designed to fetch data from the Public Suffix List (PSL) and check the domain status, expiry dates, and `_psl` TXT records of the private section domains. 
 
 It performs WHOIS checks on these domains and saves the results into CSV files for manual review.
 
@@ -37,6 +37,7 @@ python PSLPrivateDomainsProcessor.py
 
 - `check_dns_status(domain)`: Checks the DNS status of a domain using Google's DNS API. It attempts to recheck DNS status if the initial check fails.
 - `get_whois_data(domain)`: Retrieves WHOIS data for a domain. Note: WHOIS data parsing handles multiple expiration dates by selecting the first one.
+- `check_psl_txt_record(domain)`: Checks the `_psl` TXT record for a domain using Google's DNS API.
 
 ### Class
 
@@ -45,9 +46,11 @@ python PSLPrivateDomainsProcessor.py
 - `fetch_psl_data()`: Fetches the PSL data from the specified URL.
 - `parse_domain(domain)`: Parses and normalizes a domain.
 - `parse_psl_data(psl_data)`: Parses the fetched PSL data and separates ICANN and private domains.
-- `process_domains(domains)`: Processes each domain, performing DNS and WHOIS checks.
+- `process_domains(domains)`: Processes each domain, performing DNS, WHOIS, and `_psl` TXT record checks.
 - `save_results()`: Saves all processed domain data to `data/all.csv`.
 - `save_invalid_results()`: Saves domains with invalid DNS or expired WHOIS data to `data/nxdomain.csv` and `data/expired.csv`.
+- `save_hold_results()`: Saves domains with WHOIS status containing any form of "hold" to `data/hold.csv`.
+- `save_missing_psl_txt_results()`: Saves domains with invalid `_psl` TXT records to `data/missing_psl_txt.csv`.
 - `run()`: Executes the entire processing pipeline.
 
 ## Output
@@ -57,14 +60,16 @@ The script generates the following CSV files in the `data` directory:
 - `all.csv`: Contains all processed domain data.
 - `nxdomain.csv`: Contains domains that could not be resolved (`NXDOMAIN`).
 - `expired.csv`: Contains domains with expired WHOIS records.
+- `hold.csv`: Contains domains with WHOIS status indicating any kind of "hold".
+- `missing_psl_txt.csv`: Contains domains with invalid `_psl` TXT records.
 
 ## Example
 
 An example CSV entry:
 
-| psl_entry      | top_level_domain | dns_status | whois_status | whois_domain_expiry_date | whois_domain_status |
-| -------------- | ---------------- | ---------- | ------------ | ----------------------- | ------------------- |
-| example.com    | example.com      | ok         | ok           | 2024-12-31              | "clientTransferProhibited" |
+| psl_entry      | top_level_domain | dns_status | whois_status | whois_domain_expiry_date | whois_domain_status          | psl_txt_status |
+| -------------- | ---------------- | ---------- | ------------ | ----------------------- | ---------------------------- | -------------- |
+| example.com    | example.com      | ok         | ok           | 2024-12-31              | "clientTransferProhibited"   | "valid"        |
 
 ## Publicly Registrable Namespace Determination
 

--- a/tools/private_domains_checker/README.md
+++ b/tools/private_domains_checker/README.md
@@ -1,0 +1,97 @@
+# PSL Private Section Domains WHOIS Checker
+
+## Overview
+
+The `PSLPrivateDomainsProcessor` is a Python script designed to fetch data from the Public Suffix List (PSL) and check the domain status and expiry dates of the private section domains. 
+
+It performs WHOIS checks on these domains and saves the results into CSV files for manual review.
+
+## Requirements
+
+- Python 3.x
+- `requests`
+- `pandas`
+- `python-whois`
+
+You can install the required packages using pip:
+
+```sh
+pip install -r requirements.txt
+```
+
+## Usage
+
+`PSLPrivateDomainsProcessor.py`: The main script containing the `PSLPrivateDomainsProcessor` class and functions for DNS and WHOIS checks.
+
+Run the script using Python:
+
+```sh
+cd private_domains_checker
+mkdir data
+python PSLPrivateDomainsProcessor.py
+```
+
+## Main Components
+
+### Functions
+
+- `check_dns_status(domain)`: Checks the DNS status of a domain using Google's DNS API. It attempts to recheck DNS status if the initial check fails.
+- `get_whois_data(domain)`: Retrieves WHOIS data for a domain. Note: WHOIS data parsing handles multiple expiration dates by selecting the first one.
+
+### Class
+
+#### PSLPrivateDomainsProcessor
+
+- `fetch_psl_data()`: Fetches the PSL data from the specified URL.
+- `parse_domain(domain)`: Parses and normalizes a domain.
+- `parse_psl_data(psl_data)`: Parses the fetched PSL data and separates ICANN and private domains.
+- `process_domains(domains)`: Processes each domain, performing DNS and WHOIS checks.
+- `save_results()`: Saves all processed domain data to `data/all.csv`.
+- `save_invalid_results()`: Saves domains with invalid DNS or expired WHOIS data to `data/nxdomain.csv` and `data/expired.csv`.
+- `run()`: Executes the entire processing pipeline.
+
+## Output
+
+The script generates the following CSV files in the `data` directory:
+
+- `all.csv`: Contains all processed domain data.
+- `nxdomain.csv`: Contains domains that could not be resolved (`NXDOMAIN`).
+- `expired.csv`: Contains domains with expired WHOIS records.
+
+## Example
+
+An example CSV entry:
+
+| psl_entry      | top_level_domain | dns_status | whois_status | whois_domain_expiry_date | whois_domain_status |
+| -------------- | ---------------- | ---------- | ------------ | ----------------------- | ------------------- |
+| example.com    | example.com      | ok         | ok           | 2024-12-31              | "clientTransferProhibited" |
+
+## Publicly Registrable Namespace Determination
+
+The script determines the publicly registrable namespace from private domains by using the ICANN section. 
+
+Here's how it works:
+
+1. **ICANN Domains Set**: ICANN domains are stored in a set for quick lookup.
+2. **Domain Parsing**: For each private domain, the script splits the domain into parts. It then checks if any suffix of these parts exists in the ICANN domains set.
+3. **Normalization**: The private domain is normalized to its publicly registrable form using the ICANN domains set.
+
+Examples:
+
+- **Input**: PSL private domain entry `"*.example.com"`
+  - **Process**: 
+    - Remove leading `'*.'`: `"example.com"`
+    - Check `"com"` against the ICANN domains set: Found
+  - **Output**: `"example.com"`
+
+- **Input**: PSL private domain entry `"sub.example.co.uk"`
+  - **Process**:
+    - Check `"example.co.uk"` against the ICANN domains set: Not found
+    - Check `"co.uk"` against the ICANN domains set: Found
+  - **Output**: `"example.co.uk"`
+
+The output is then used for checking WHOIS data.
+
+## License
+
+This tool is licensed under the MIT License.

--- a/tools/private_domains_checker/README.md
+++ b/tools/private_domains_checker/README.md
@@ -11,12 +11,19 @@ It performs WHOIS checks on these domains and saves the results into CSV files f
 - Python 3.x
 - `requests`
 - `pandas`
-- `python-whois`
+- `whoisdomain`
 
 You can install the required packages using pip:
 
 ```sh
 pip install -r requirements.txt
+```
+
+Ensure that `whois` is installed on your operating system.
+
+```sh
+sudo apt install whois  # Debian/Ubuntu
+sudo yum install whois  # Fedora/Centos/Rocky
 ```
 
 ## Usage
@@ -35,9 +42,10 @@ python PSLPrivateDomainsProcessor.py
 
 ### Functions
 
-- `check_dns_status(domain)`: Checks the DNS status of a domain using Google's DNS API. It attempts to recheck DNS status if the initial check fails.
-- `get_whois_data(domain)`: Retrieves WHOIS data for a domain. Note: WHOIS data parsing handles multiple expiration dates by selecting the first one.
-- `check_psl_txt_record(domain)`: Checks the `_psl` TXT record for a domain using Google's DNS API.
+- `make_dns_request(domain, record_type)`: Makes DNS requests to both Google and Cloudflare DNS APIs.
+- `check_dns_status(domain)`: Checks the DNS status of a domain using Google and Cloudflare DNS APIs.
+- `get_whois_data(domain)`: Retrieves WHOIS data for a domain using the whoisdomain package.
+- `check_psl_txt_record(domain)`: Checks the `_psl` TXT record for a domain using Google and Cloudflare DNS APIs.
 
 ### Class
 
@@ -46,11 +54,12 @@ python PSLPrivateDomainsProcessor.py
 - `fetch_psl_data()`: Fetches the PSL data from the specified URL.
 - `parse_domain(domain)`: Parses and normalizes a domain.
 - `parse_psl_data(psl_data)`: Parses the fetched PSL data and separates ICANN and private domains.
-- `process_domains(domains)`: Processes each domain, performing DNS, WHOIS, and `_psl` TXT record checks.
+- `process_domains(raw_domains, domains)`: Processes each domain, performing DNS, WHOIS, and `_psl` TXT record checks.
 - `save_results()`: Saves all processed domain data to `data/all.csv`.
 - `save_invalid_results()`: Saves domains with invalid DNS or expired WHOIS data to `data/nxdomain.csv` and `data/expired.csv`.
 - `save_hold_results()`: Saves domains with WHOIS status containing any form of "hold" to `data/hold.csv`.
 - `save_missing_psl_txt_results()`: Saves domains with invalid `_psl` TXT records to `data/missing_psl_txt.csv`.
+- `save_expiry_less_than_2yrs_results()`: Saves domains with WHOIS expiry date less than 2 years from now to `data/expiry_less_than_2yrs.csv`.
 - `run()`: Executes the entire processing pipeline.
 
 ## Output
@@ -62,14 +71,15 @@ The script generates the following CSV files in the `data` directory:
 - `expired.csv`: Contains domains with expired WHOIS records.
 - `hold.csv`: Contains domains with WHOIS status indicating any kind of "hold".
 - `missing_psl_txt.csv`: Contains domains with invalid `_psl` TXT records.
+- `expiry_less_than_2yrs.csv`: Contains domains with WHOIS expiry date less than 2 years from now.
 
 ## Example
 
 An example CSV entry:
 
-| psl_entry      | top_level_domain | dns_status | whois_status | whois_domain_expiry_date | whois_domain_status          | psl_txt_status |
-| -------------- | ---------------- | ---------- | ------------ | ----------------------- | ---------------------------- | -------------- |
-| example.com    | example.com      | ok         | ok           | 2024-12-31              | "clientTransferProhibited"   | "valid"        |
+| psl_entry      | top_level_domain | dns_status | whois_status | whois_domain_expiry_date | whois_domain_status          | psl_txt_status | expiry_check_status |
+| -------------- | ---------------- | ---------- | ------------ | ----------------------- | ---------------------------- | -------------- | ------------------- |
+| example.com    | example.com      | ok         | ok           | 2024-12-31              | "clientTransferProhibited"   | "valid"        | ok                  |
 
 ## Publicly Registrable Namespace Determination
 

--- a/tools/private_domains_checker/TestPSLPrivateDomainsProcessor.py
+++ b/tools/private_domains_checker/TestPSLPrivateDomainsProcessor.py
@@ -1,0 +1,92 @@
+import unittest
+import uuid
+from unittest.mock import patch
+
+from PSLPrivateDomainsProcessor import PSLPrivateDomainsProcessor, check_dns_status, get_whois_data
+
+
+class TestPSLPrivateDomainsProcessor(unittest.TestCase):
+
+    def setUp(self):
+        self.processor = PSLPrivateDomainsProcessor()
+        # Populate icann_domains for testing
+        self.processor.icann_domains = {
+            "com", "co.uk", "ac.uk", "net", "org"
+        }
+
+    def test_parse_domain_icann_domain(self):
+        # Test cases where domains should be parsed correctly
+        test_cases = [
+            ("*.example.com", "example.com"),
+            ("sub.example.com", "example.com"),
+            ("*.sub.example.com", "example.com"),
+            ("example.com", "example.com"),
+            ("example.co.uk", "example.co.uk"),
+            ("sub.example.co.uk", "example.co.uk"),
+            ("*.example.co.uk", "example.co.uk"),
+            ("*.sub.example.co.uk", "example.co.uk"),
+            ("abc.ac.uk", "abc.ac.uk"),
+            ("a.b.com", "b.com")
+        ]
+
+        for domain, expected in test_cases:
+            with self.subTest(domain=domain):
+                result = self.processor.parse_domain(domain)
+                self.assertEqual(result, expected)
+
+    def test_parse_domain_no_icann(self):
+        # Test case where no valid ICANN domain is found
+        self.processor.icann_domains.remove("com")
+        with self.assertRaises(ValueError):
+            self.processor.parse_domain("example.com")
+
+    def test_parse_domain_edge_cases(self):
+        # Additional edge case testing
+        self.assertEqual(self.processor.parse_domain("sub.example.org"), "example.org")
+        self.assertEqual(self.processor.parse_domain("example.net"), "example.net")
+        self.assertEqual(self.processor.parse_domain("sub.example.ac.uk"), "example.ac.uk")
+
+    def test_parse_domain_invalid(self):
+        # Test invalid domains which should raise ValueError
+        invalid_domains = ["invalid.domain", "*.invalid.domain", "sub.invalid.domain"]
+        for domain in invalid_domains:
+            with self.subTest(domain=domain):
+                with self.assertRaises(ValueError):
+                    self.processor.parse_domain(domain)
+
+    @patch('requests.get')
+    def test_check_dns_status(self, mock_get):
+        mock_response_ok = {
+            "Status": 0,
+            "Answer": [
+                {"name": "example.com."}
+            ]
+        }
+        mock_response_nxdomain = {
+            "Status": 3
+        }
+        mock_get.side_effect = [
+            MockResponse(mock_response_ok, 200),
+            MockResponse(mock_response_nxdomain, 200)
+        ]
+
+        self.assertEqual(check_dns_status("example.com"), "ok")
+        random_domain = "example" + str(uuid.uuid4()) + ".edu"
+        self.assertEqual(check_dns_status(random_domain), "NXDOMAIN")
+
+    def test_get_whois_data(self):
+        whois_data = get_whois_data("example.com")
+        self.assertEqual("ok", whois_data[2])
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/private_domains_checker/requirements.txt
+++ b/tools/private_domains_checker/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 requests
-python-whois
+whoisdomain

--- a/tools/private_domains_checker/requirements.txt
+++ b/tools/private_domains_checker/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+requests
+python-whois


### PR DESCRIPTION
This PR is related to #1996. It introduces the `tools/private_domains_checker`, a Python script created to fetch data from the PSL and check the domain status and expiry dates of the private section domains. It performs WHOIS checks on these domains and saves the results into CSV files for manual review. 

Please feel free to make any edits! 

The [README file](https://github.com/groundcat/PSL-private-domains-checker/blob/main/README.md) has been updated to reflect the usage instructions.

Example CSV outputs from real PSL data:

- [Example datasets](https://github.com/groundcat/PSL-private-domains-checker/tree/main/data)