### PR TITLE
Remove instantcloud.cn

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14862,10 +14862,6 @@ site.rb-hosting.io
 // Submitted by Andrew Farries <andrew.farries@red-gate.com>
 instances.spawn.cc
 
-// Redstar Consultants : https://www.redstarconsultants.com/
-// Submitted by Jons Slemmer <jons@redstarconsultants.com>
-instantcloud.cn
-
 // Russian Academy of Sciences
 // Submitted by Tech Support <support@rasnet.ru>
 ras.ru


### PR DESCRIPTION
The domain got repurposed and should not be listed in the PSL anymore. The `_psl` DNS record was deleted.

Initially, it has been added in https://github.com/publicsuffix/list/pull/696.