### PR TITLE
Add `p.tawk.email` and `p.tawkto.email` domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15432,6 +15432,11 @@ mytabit.com
 mytabit.co.il
 tabitorder.co.il
 
+// tawk.to, Inc : https://www.tawk.to
+// Submitted by tawk.to developer team <dev-accounts@tawk.to>
+p.tawk.email
+p.tawkto.email
+
 // TAIFUN Software AG : http://taifun-software.de
 // Submitted by Bjoern Henke <dev-server@taifun-software.de>
 taifun-dns.de

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15432,11 +15432,6 @@ mytabit.com
 mytabit.co.il
 tabitorder.co.il
 
-// tawk.to, Inc : https://www.tawk.to
-// Submitted by tawk.to developer team <dev-accounts@tawk.to>
-p.tawk.email
-p.tawkto.email
-
 // TAIFUN Software AG : http://taifun-software.de
 // Submitted by Bjoern Henke <dev-server@taifun-software.de>
 taifun-dns.de
@@ -15453,6 +15448,11 @@ gdansk.pl
 gdynia.pl
 med.pl
 sopot.pl
+
+// tawk.to, Inc : https://www.tawk.to
+// Submitted by tawk.to developer team <dev-accounts@tawk.to>
+p.tawk.email
+p.tawkto.email
 
 // team.blue https://team.blue
 // Submitted by Cedric Dubois <cedric.dubois@team.blue>


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is
https://github.com/publicsuffix/list/pull/1591, although
the organization and description were not as substantial
as desired, which required maintainers time to visit the
requestors website to further research.
Having more robust org/desc improves the PR processing
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615,
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__

  * [x] We are listing *any* third-party limits that we seek to work around in our rationale
    - Rate-limiting on top-level domain for our user-specific subdomains

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

  * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

tawk.to is a business communication platform that offers features such as live-chat and ticketing.


Organization Website: www.tawk.to

Reason for PSL Inclusion
====

As part of our offering, we provide an email sub-domain for each of our users properties (organizations/projects) to send and receive ticket notifications and transactional emails from their own domain. We currently serve over 14 million active properties on our platform, each of which has a unique sub-domain.

We are submitting this request to have our sub-domains (`p.tawk.email` and `p.tawkto.email`) added to the PSL to ensure that each of these property specific sub-domains are treated as separate entities and do not affect each other as they are mutually-untrusting parties.

Being a part of PSL would provide the following benefits:

- Segmentation of spam checks and reputation: Each client has their own domain and reputation associated with it
- Segmentation of domain based rate-limiting: PSL listing would ensure that domain based rate-limiting can be applied on a per-customer basis

We are currently using `<client-subdomain>.p.tawk.email` for notification emails and `<client-subdomain>.p.tawkto.email` for transactional emails. Marketing and promotional emails are not sent from these domains.

`tawk.email` expires in 2028-06-26
`tawkto.email` expires in 2026-11-22

Number of users this request is being made to serve:
- Over 9 million registered users with over 14 million properties (projects), each with it's own sub-domain


DNS Verification via dig
=======

```
> dig +short TXT _psl.p.tawkto.email
"https://github.com/publicsuffix/list/pull/2016"
```

```
> dig +short TXT _psl.p.tawkto.email
"https://github.com/publicsuffix/list/pull/2016"
```

Results of Syntax Checker (`make test`)
=========

```
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       common.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```
