### PR TITLE
Add cyber_Folks S.A. shared domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12562,6 +12562,10 @@ cyclic.co.in
 cyon.link
 cyon.site
 
+// cyber_Folks S.A. : https://cyberfolks.pl
+// Submitted by Bartlomiej Kida <b.kida@cyberfolks.pl>
+cfolks.pl
+
 // Danger Science Group: https://dangerscience.com/
 // Submitted by Skylar MacDonald <skylar@dangerscience.com>
 platform0.app


### PR DESCRIPTION
### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example): None

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [X] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====
cyber_Folks is a Polish company that offers a variety of IT services, including web hosting, domain registration, email marketing, and SSL certificates. 

**Also tell us who you (submitter) are:**

I am an employee of cyber_Folks S.A. I represent the development department. My role is to prepare and test new solutions for web hosting services, including ensuring the security of hosting solutions.

**Organization Website:** 
https://cyberfolks.pl

Reason for PSL Inclusion
====
The cfolks.pl domain is a free domain offered to customers of the hosting service. Each client can create any domain with cfolks.pl suffix. 

We would like to block cookies between separate customer sites or other reviews between customers/sites that are not related.

**Please also include the numbers of any past Issue # or PR #** : None

**Number of users this request is being made to serve:**
We currently support over 10,000 websites using the cfolks.pl domain.

The domain cfolks.pl has been registered since 2020, currently active until 2031, further renewal is planned so that its validity period is always longer than 2 years.

```
DOMAIN NAME:           cfolks.pl
registrant type:       organization
nameservers:           ns1.cyberfolks.pl. [94.152.254.111]
                       ns2.cyberfolks.pl. [94.152.255.111]
                       ns3.cyberfolks.pl. [94.152.254.161]
created:               2020.02.26 17:45:22
last modified:         2023.11.30 15:54:59
renewal date:          2031.02.26 17:45:22
```

DNS Verification via dig
=======
```
dig +short TXT _psl.cfolks.pl
"https://github.com/publicsuffix/list/pull/2017"

dig @8.8.8.8 +short TXT _psl.cfolks.pl
"https://github.com/publicsuffix/list/pull/2017"

dig @1.1.1.1 TXT _psl.cfolks.pl +short
"https://github.com/publicsuffix/list/pull/2017"
```

Results of Syntax Checker (`make test`)
=========
Tests have been made locally with success.
```
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```


