### PR TITLE
Delete Rakuten Games, Inc related entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14891,10 +14891,6 @@ vaporcloud.io
 rackmaze.com
 rackmaze.net
 
-// Rakuten Games, Inc : https://dev.viberplay.io
-// Submitted by Joshua Zhang <public-suffix@rgames.jp>
-g.vbrplsbx.io
-
 // Rancher Labs, Inc : https://rancher.com
 // Submitted by Vincent Fiduccia <domains@rancher.com>
 *.on-rancher.cloud


### PR DESCRIPTION
Rakuten Games, Inc. was dissolved in early 2024. And related services are already closed. Due to the organization's domains can be now obtained by any other party (which can be potentially malicious). I want to request the deletion from PSL.

FYI The record was added in https://github.com/publicsuffix/list/pull/994