### PR TITLE
WIP PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -67,6 +67,13 @@ the PR.
 
   * [ ] This request was _not_ submitted with the objective of working around other third-party limits
 
+
+<!--
+To keep the PSL free of outdated entries it is necessary to be able to remove entries. We may at some point request renewal by e-mail or start to automatically remove entries which do not have DNS validation anymore. The grace period for failures is 4 weeks.
+-->
+  * [ ] The submitter acknowledges that failure to retain the _psl DNS validation entry may result in removal from the PSL.
+  * [ ] The submitter acknowledges that failure to respond to e-mails to the supplied address may result in removal from the PSL.
+
 <!--
 The guidelines describe which section to place the entry, what the 
 order of commented org placement, order of sorting of entries. 
@@ -78,6 +85,7 @@ neither.
 
   * [ ] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
   * [ ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting
+
 
 <!-- 
 Sorting and formatting of the entries is outlined in the guidelines 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -86,7 +86,6 @@ neither.
   * [ ] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
   * [ ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting
 
-
 <!-- 
 Sorting and formatting of the entries is outlined in the guidelines 
 and non-conforming requests are one of the largest sources of delay,

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -67,12 +67,10 @@ the PR.
 
   * [ ] This request was _not_ submitted with the objective of working around other third-party limits
 
-
 <!--
 To keep the PSL free of outdated entries it is necessary to be able to remove entries. We may at some point request renewal by e-mail or start to automatically remove entries which do not have DNS validation anymore. The grace period for failures is 4 weeks.
 -->
-  * [ ] The submitter acknowledges that failure to retain the _psl DNS validation entry may result in removal from the PSL.
-  * [ ] The submitter acknowledges that failure to respond to e-mails to the supplied address may result in removal from the PSL.
+  * [ ] The submitter acknowledges the following **Removal warning (v1)**: Failure to retain the _psl DNS validation entry or failure to respond to e-mails to the supplied address may result in removal from the PSL.
 
 <!--
 The guidelines describe which section to place the entry, what the 


### PR DESCRIPTION
The idea here would be that we add a note like this now and then also require a line saying "Acknowledged Removal Warning (v1)" to the organization header in the .dat file.

For exampled

*Note*
```
<!--
To keep the PSL free of outdated entries it is necessary to be able to remove entries. We may at some point request renewal by e-mail or start to automatically remove entries which do not have DNS validation anymore. The grace period for failures is 4 weeks.
-->
  * [ ] The submitter acknowledges the following **Removal warning (v1)**: Failure to retain the _psl DNS validation entry or failure to respond to e-mails to the supplied address may result in removal from the PSL.
```

*PSL entry*

```
// tawk.to, Inc : https://www.tawk.to
// Submitted by tawk.to developer team <dev-accounts@tawk.to>
// Acknowledged Removal Warning (v1)
p.tawk.email
p.tawkto.email
```

That would give us a known way to remove entries for new additions.

@dnsguru What do you think?
@danderson Do you have opinions on the format?