### PR TITLE
tools/internal/parser: rework metadata extraction for more accurate reformatting

### DIFF
--- a/tools/govalidate/govalidate.go
+++ b/tools/govalidate/govalidate.go
@@ -95,15 +95,18 @@ func debugPrintRec(b parser.Block, indent string) {
 		}
 		f("}")
 	case *parser.Suffixes:
-		items := []string{loc}
+		items := []string{loc, fmt.Sprintf("editable=%v", v.Info.MachineEditable)}
 		if v.Info.Name != "" {
 			items = append(items, fmt.Sprintf("name=%q", v.Info.Name))
 		}
-		if v.Info.URL != nil {
-			items = append(items, fmt.Sprintf("url=%q", v.Info.URL))
+		for _, u := range v.Info.URLs {
+			items = append(items, fmt.Sprintf("url=%q", u))
 		}
-		if v.Info.Submitter != nil {
-			items = append(items, fmt.Sprintf("contact=%q", v.Info.Submitter))
+		for _, e := range v.Info.Maintainers {
+			items = append(items, fmt.Sprintf("contact=%q", e))
+		}
+		for _, o := range v.Info.Other {
+			items = append(items, fmt.Sprintf("other=%q", o))
 		}
 
 		f("SuffixBlock(%s) {", strings.Join(items, fmt.Sprintf(",\n%s            ", indent)))

--- a/tools/govalidate/govalidate.go
+++ b/tools/govalidate/govalidate.go
@@ -58,12 +58,8 @@ func main() {
 
 // debugPrint prints out a PSL syntax tree in a private, subject to
 // change text format.
-func debugPrint(p *parser.List) {
-	fmt.Println("List {")
-	for _, b := range p.Blocks {
-		debugPrintRec(b, "    ")
-	}
-	fmt.Println("}")
+func debugPrint(b parser.Block) {
+	debugPrintRec(b, "")
 }
 
 func debugPrintRec(b parser.Block, indent string) {
@@ -78,6 +74,12 @@ func debugPrintRec(b parser.Block, indent string) {
 	}
 
 	switch v := b.(type) {
+	case *parser.List:
+		f("List(%s) {", loc)
+		for _, b := range v.Blocks {
+			debugPrintRec(b, nextIndent)
+		}
+		f("}")
 	case *parser.Blank:
 		f("Blank(%s)", loc)
 	case *parser.Comment:

--- a/tools/govalidate/govalidate.go
+++ b/tools/govalidate/govalidate.go
@@ -96,14 +96,14 @@ func debugPrintRec(b parser.Block, indent string) {
 		f("}")
 	case *parser.Suffixes:
 		items := []string{loc}
-		if v.Entity != "" {
-			items = append(items, fmt.Sprintf("name=%q", v.Entity))
+		if v.Info.Name != "" {
+			items = append(items, fmt.Sprintf("name=%q", v.Info.Name))
 		}
-		if v.URL != nil {
-			items = append(items, fmt.Sprintf("url=%q", v.URL))
+		if v.Info.URL != nil {
+			items = append(items, fmt.Sprintf("url=%q", v.Info.URL))
 		}
-		if v.Submitter != nil {
-			items = append(items, fmt.Sprintf("contact=%q", v.Submitter))
+		if v.Info.Submitter != nil {
+			items = append(items, fmt.Sprintf("contact=%q", v.Info.Submitter))
 		}
 
 		f("SuffixBlock(%s) {", strings.Join(items, fmt.Sprintf(",\n%s            ", indent)))

--- a/tools/internal/parser/file.go
+++ b/tools/internal/parser/file.go
@@ -87,42 +87,50 @@ func (s *Section) Children() []Block { return s.Blocks }
 // unstructured inline comments.
 type Suffixes struct {
 	SourceRange
-	// Entity is the name of the entity responsible for this block of
-	// suffixes.
-	//
-	// For ICANN suffixes, this is typically the TLD name or the NIC
-	// that controls the TLD.
-	//
-	// For private domains this is the name of the legal entity (most
-	// commonly a company) that owns all domains in the block.
-	//
-	// In a well-formed PSL file, Entity is non-empty for all suffix
-	// blocks.
-	Entity string
-	// URL is a link to further information about the suffix block and
-	// its managing entity.
-	//
-	// For ICANN domains this is typically the NIC's information page
-	// for the TLD, or failing that a general information page such as
-	// a Wikipedia entry.
-	//
-	// For private domains this is usually the responsible company's
-	// website.
-	//
-	// May be nil when the block header doesn't have a URL.
-	URL *url.URL
-	// Submitter is the contact name and email address of the person
-	// or people responsible for this block of suffixes.
-	//
-	// This field may be nil if the block header doesn't have email
-	// contact information.
-	Submitter *mail.Address
+
+	// Info is information about the authoritative maintainers for
+	// this set of suffixes.
+	Info MaintainerInfo
 
 	// Blocks are the child blocks contained within the section.
 	Blocks []Block
 }
 
 func (s *Suffixes) Children() []Block { return s.Blocks }
+
+type MaintainerInfo struct {
+	// Name is the name of the entity responsible for maintaining a
+	// set of suffixes.
+	//
+	// For ICANN suffixes, this is typically the TLD name, or the name
+	// of NIC that controls the TLD.
+	//
+	// For private domains this is the name of the legal entity
+	// (usually a company, sometimes an individual) that owns all
+	// domains in the block.
+	//
+	// In a well-formed PSL file, Name is non-empty for all suffix
+	// blocks.
+	Name string
+	// URL is a link to further information about the suffix block's
+	// domains and its maintainer.
+	//
+	// For ICANN domains this is typically the NIC's information page
+	// for the TLD, or failing that a general information page such as
+	// a Wikipedia entry.
+	//
+	// For private domains this is usually the website for the owner
+	// of the domains.
+	//
+	// May be nil when the block header doesn't have a URL.
+	URL *url.URL
+	// Submitter is the contact name and email address of the person
+	// or people responsible for maintaining PSL entries.
+	//
+	// This field may be nil if the block header doesn't have email
+	// contact information.
+	Submitter *mail.Address
+}
 
 // Suffix is one public suffix, represented in the standard domain
 // name format.

--- a/tools/internal/parser/file.go
+++ b/tools/internal/parser/file.go
@@ -26,6 +26,26 @@ type Block interface {
 	Children() []Block
 }
 
+// BlocksOfType recursively collects and returns all blocks of
+// concrete type T in the given parse tree.
+//
+// For example, BlocksOfType[*parser.Comment](ast) returns all comment
+// nodes in ast.
+func BlocksOfType[T Block](tree Block) []T {
+	var ret []T
+	blocksOfTypeRec(tree, &ret)
+	return ret
+}
+
+func blocksOfTypeRec[T Block](tree Block, out *[]T) {
+	if v, ok := tree.(T); ok {
+		*out = append(*out, v)
+	}
+	for _, child := range tree.Children() {
+		blocksOfTypeRec(child, out)
+	}
+}
+
 // Blank is a set of one or more consecutive blank lines.
 type Blank struct {
 	SourceRange

--- a/tools/internal/parser/metadata.go
+++ b/tools/internal/parser/metadata.go
@@ -99,8 +99,6 @@ const submittedBy = "submitted by"
 //     omit https://.
 //   - "<entity name>: Submitted by <email address>", where the second
 //     part is any variant accepted by getSubmitter.
-//   - The canonical form, but with a unicode fullwidth colon (U+FF1A)
-//     instead of a regular colon.
 //   - Any amount of whitespace on either side of the colon (or
 //     fullwidth colon).
 func splitNameish(line string) (name string, url *url.URL, submitter *mail.Address) {

--- a/tools/internal/parser/metadata.go
+++ b/tools/internal/parser/metadata.go
@@ -9,74 +9,64 @@ import (
 // extractMaintainerInfo extracts structured maintainer metadata from
 // comment.
 func extractMaintainerInfo(comment *Comment) MaintainerInfo {
-	var ret MaintainerInfo
+	if comment == nil || len(comment.Text) == 0 {
+		return MaintainerInfo{MachineEditable: true}
+	}
 
-	// Try to find an entity name in the header. There are a few
-	// possible ways this can appear, but the canonical is a first
-	// header line of the form "<name>: <url>".
-	//
-	// If the canonical form is missing, a number of other variations
-	// are tried in order to maximize the information we can extract
-	// from the real PSL. Non-canonical representations may produce
-	// validation errors in future, but currently do not.
-	//
-	// See splitNameish for a list of accepted alternate forms.
-	for _, line := range comment.Text {
-		name, url, contact := splitNameish(line)
-		if name == "" {
-			continue
+	var (
+		ret = MaintainerInfo{
+			MachineEditable: true,
 		}
+		lines             = comment.Text
+		firstUnusableLine = -1
+	)
 
+	// The first line of metadata usually follows a standard
+	// form. Handle that first, then scan through the rest of the
+	// comment to find any further stuff.
+	name, siteURL, email, ok := splitNameish(lines[0])
+	if ok {
 		ret.Name = name
-		if url != nil {
-			ret.URL = url
+		if siteURL != nil {
+			ret.URLs = append(ret.URLs, siteURL)
 		}
-		if contact != nil {
-			ret.Submitter = contact
+		if email != nil {
+			ret.Maintainers = append(ret.Maintainers, email)
 		}
-		break
-	}
-	if ret.Name == "" {
-		// Assume the first line is the entity name, if it's not
-		// obviously something else.
-		first := comment.Text[0]
-		// "see also" is the first line of a number of ICANN TLD
-		// sections.
-		if getSubmitter(first) == nil && getURL(first) == nil && first != "see also" {
-			ret.Name = first
-		}
+		lines = lines[1:]
 	}
 
-	// Try to find contact info, if the previous step didn't find
-	// any. The only remaining formats we understand is a line with
-	// "Submitted by <contact>", or failing that a parseable RFC5322
-	// email on a line by itself.
-	if ret.Submitter == nil {
-		for _, line := range comment.Text {
-			if submitter := getSubmitter(line); submitter != nil {
-				ret.Submitter = submitter
-				break
+	// Aside from the special first line, remaining lines could be
+	// maintainer emails in a few formats, or URLs, or something
+	// else. We accumulate everything we can parse, but also keep
+	// track of whether the information is laid out such that we could
+	// write the information back out without data loss (although not
+	// necessarily in the exact same format).
+	for i, line := range lines {
+		lineUsed := false
+		if emails := getSubmitters(line); len(emails) > 0 {
+			ret.Maintainers = append(ret.Maintainers, emails...)
+			lineUsed = true
+		} else if email, err := mail.ParseAddress(line); err == nil {
+			ret.Maintainers = append(ret.Maintainers, email)
+			lineUsed = true
+		} else if u := getURL(line); u != nil {
+			ret.URLs = append(ret.URLs, u)
+			lineUsed = true
+		} else if i == 0 && ret.Name == "" {
+			ret.Name = line
+			lineUsed = true
+		} else {
+			ret.Other = append(ret.Other, line)
+			if firstUnusableLine < 0 {
+				firstUnusableLine = i + 1
 			}
 		}
-	}
-	if ret.Submitter == nil {
-		for _, line := range comment.Text {
-			if submitter, err := mail.ParseAddress(line); err == nil {
-				ret.Submitter = submitter
-				break
-			}
-		}
-	}
 
-	// Try to find a URL, if the previous step didn't find one. The
-	// only remaining format we understand is a line with a URL by
-	// itself.
-	if ret.URL == nil {
-		for _, line := range comment.Text {
-			if u := getURL(line); u != nil {
-				ret.URL = u
-				break
-			}
+		if lineUsed && firstUnusableLine >= 0 {
+			// Parseable lines after non-parseable lines, we cannot
+			// confidently write the data back out without dataloss.
+			ret.MachineEditable = false
 		}
 	}
 
@@ -105,23 +95,23 @@ const submittedBy = "submitted by"
 //     part is any variant accepted by getSubmitter.
 //   - Any amount of whitespace on either side of the colon (or
 //     fullwidth colon).
-func splitNameish(line string) (name string, url *url.URL, submitter *mail.Address) {
+func splitNameish(line string) (name string, url *url.URL, submitter *mail.Address, ok bool) {
 	if strings.HasPrefix(strings.ToLower(line), submittedBy) {
 		// submitted-by lines are handled separately elsewhere, and
 		// can be misinterpreted as entity names.
-		return "", nil, nil
+		return "", nil, nil, false
 	}
 
 	// Some older entries are of the form "entity name (url)".
 	if strings.HasSuffix(line, ")") {
 		if name, url, ok := splitNameAndURLInParens(line); ok {
-			return name, url, nil
+			return name, url, nil, true
 		}
 	}
 
 	name, rest, ok := strings.Cut(line, ":")
 	if !ok {
-		return "", nil, nil
+		return "", nil, nil, false
 	}
 
 	// Clean up whitespace either side of the colon.
@@ -129,11 +119,11 @@ func splitNameish(line string) (name string, url *url.URL, submitter *mail.Addre
 	rest = strings.TrimSpace(rest)
 
 	if u := getURL(rest); u != nil {
-		return name, u, nil
-	} else if contact := getSubmitter(rest); contact != nil {
-		return name, nil, contact
+		return name, u, nil, true
+	} else if emails := getSubmitters(rest); len(emails) == 1 {
+		return name, nil, emails[0], true
 	}
-	return "", nil, nil
+	return "", nil, nil, false
 }
 
 // splitNameAndURLInParens tries to parse line in the form:
@@ -193,19 +183,32 @@ func getURL(line string) *url.URL {
 //
 // Returns the parsed RFC 5322 address, or nil if line does not
 // conform to the expected shape.
-func getSubmitter(line string) *mail.Address {
-	if !strings.HasPrefix(strings.ToLower(line), submittedBy) {
-		return nil
+func getSubmitters(line string) []*mail.Address {
+	if strings.HasPrefix(strings.ToLower(line), submittedBy) {
+		line = line[len(submittedBy):]
 	}
-	line = line[len(submittedBy):]
 	// Some entries read "Submitted by: ..." with an extra colon.
 	line = strings.TrimLeft(line, ":")
 	line = strings.TrimSpace(line)
 	// Some ICANN domains lead with "Submitted by registry".
-	line = strings.TrimLeft(line, "registry ")
+	line = strings.TrimPrefix(line, "registry ")
 
-	if addr, err := mail.ParseAddress(line); err == nil {
-		return addr
+	var ret []*mail.Address
+	emailStrs := strings.Split(line, " and ")
+
+	fullyParsed := true
+	for _, emailStr := range emailStrs {
+		addr, err := mail.ParseAddress(emailStr)
+		if err != nil {
+			fullyParsed = false
+			continue
+		}
+		ret = append(ret, addr)
+	}
+
+	if fullyParsed {
+		// Found a way to consume the entire input, we're done.
+		return ret
 	}
 
 	// One current entry uses old school email obfuscation to foil
@@ -216,7 +219,7 @@ func getSubmitter(line string) *mail.Address {
 		cleaned := strings.Replace(line, " at ", "@", 1)
 		cleaned = strings.Replace(cleaned, " dot ", ".", 1)
 		if addr, err := mail.ParseAddress(cleaned); err == nil {
-			return addr
+			return []*mail.Address{addr}
 		}
 	}
 
@@ -228,7 +231,7 @@ func getSubmitter(line string) *mail.Address {
 			name := strings.Join(fs[:len(fs)-1], " ")
 			name = strings.Trim(name, " ,:")
 			addr.Name = name
-			return addr
+			return []*mail.Address{addr}
 		}
 	}
 

--- a/tools/internal/parser/metadata_test.go
+++ b/tools/internal/parser/metadata_test.go
@@ -1,0 +1,281 @@
+package parser
+
+import (
+	"net/mail"
+	"net/url"
+	"testing"
+)
+
+func TestMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *Comment
+		want MaintainerInfo
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: MaintainerInfo{
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "canonical",
+			in: comment(0,
+				"DuckCo : https://example.com",
+				"Submitted by Duck <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "canonical_no_space_around_colon",
+			in: comment(0,
+				"DuckCo:https://example.com",
+				"Submitted by Duck <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "canonical_url_in_parens",
+			in: comment(0,
+				"DuckCo (https://example.com)",
+				"Submitted by Duck <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "canonical_by_registry",
+			in: comment(0,
+				"DuckCo : https://example.com",
+				"Submitted by registry <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "name_and_email_first",
+			in: comment(0,
+				"DuckCo : Duck <duck@example.com>",
+				"https://example.com",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "name_and_naked_email",
+			in: comment(0,
+				"DuckCo : duck@example.com",
+				"https://example.com",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "one_per_line",
+			in: comment(0,
+				"DuckCo",
+				"https://example.com",
+				"Submitted by Duck <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "no_name",
+			in: comment(0,
+				"https://example.com",
+				"Submitted by Duck <duck@example.com>",
+				"Other notes here",
+			),
+			want: MaintainerInfo{
+				Name:            "",
+				URLs:            urls("https://example.com"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				Other:           []string{"Other notes here"},
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "http_url_and_bare_email",
+			in: comment(0,
+				"http://example.com",
+				"duck@example.com",
+			),
+			want: MaintainerInfo{
+				Name:            "",
+				URLs:            urls("http://example.com"),
+				Maintainers:     emails("", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "multiple_urls",
+			in: comment(0,
+				"DuckCo : https://example.com",
+				"https://example.org/details",
+				"Submitted by Duck <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:            "DuckCo",
+				URLs:            urls("https://example.com", "https://example.org/details"),
+				Maintainers:     emails("Duck", "duck@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "multiple_emails",
+			in: comment(0,
+				"DuckCo : https://example.com",
+				"Submitted by Duck <duck@example.com> and Goat <goat@example.com>",
+				"llama@example.com",
+			),
+			want: MaintainerInfo{
+				Name: "DuckCo",
+				URLs: urls("https://example.com"),
+				Maintainers: emails(
+					"Duck", "duck@example.com",
+					"Goat", "goat@example.com",
+					"", "llama@example.com"),
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "multiple_everything_and_end_notes",
+			in: comment(0,
+				"DuckCo : https://example.com",
+				"http://example.org",
+				"https://example.net/more",
+				"Submitted by Duck <duck@example.com> and Goat <goat@example.com>",
+				"llama@example.com",
+				`"Owl" <owl@example.net>`,
+				"Duck is theoretically in charge, but Owl has influence",
+				"Goat is not to be trusted, don't know about llama yet",
+			),
+			want: MaintainerInfo{
+				Name: "DuckCo",
+				URLs: urls("https://example.com", "http://example.org", "https://example.net/more"),
+				Maintainers: emails(
+					"Duck", "duck@example.com",
+					"Goat", "goat@example.com",
+					"", "llama@example.com",
+					"Owl", "owl@example.net"),
+				Other: []string{
+					"Duck is theoretically in charge, but Owl has influence",
+					"Goat is not to be trusted, don't know about llama yet",
+				},
+				MachineEditable: true,
+			},
+		},
+
+		{
+			name: "info_after_extra_notes",
+			in: comment(0,
+				"DuckCo",
+				"Duck is in charge",
+				"https://example.com",
+				"Submitted by Duck <duck@example.com>",
+			),
+			want: MaintainerInfo{
+				Name:        "DuckCo",
+				URLs:        urls("https://example.com"),
+				Maintainers: emails("Duck", "duck@example.com"),
+				Other: []string{
+					"Duck is in charge",
+				},
+				MachineEditable: false,
+			},
+		},
+
+		{
+			name: "obfuscated_email",
+			in: comment(0,
+				"lohmus",
+				"someone at lohmus dot me",
+			),
+			want: MaintainerInfo{
+				Name:            "lohmus",
+				Maintainers:     emails("", "someone@lohmus.me"),
+				MachineEditable: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		got := extractMaintainerInfo(tc.in)
+		checkDiff(t, "maintainer info", got, tc.want)
+	}
+}
+
+func urls(us ...string) []*url.URL {
+	var ret []*url.URL
+	for _, s := range us {
+		ret = append(ret, mustURL(s))
+	}
+	return ret
+}
+
+func mustURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func emails(elts ...string) []*mail.Address {
+	var ret []*mail.Address
+	for i := 0; i < len(elts); i += 2 {
+		ret = append(ret, email(elts[i], elts[i+1]))
+	}
+	return ret
+}
+
+func email(name, email string) *mail.Address {
+	return &mail.Address{
+		Name:    name,
+		Address: email,
+	}
+}

--- a/tools/internal/parser/parser.go
+++ b/tools/internal/parser/parser.go
@@ -302,7 +302,7 @@ func (p *parser) parseSuffixBlock(initialComment *Comment) *Suffixes {
 
 	if initialComment != nil {
 		emit(initialComment)
-		enrichSuffixes(ret, initialComment)
+		ret.Info = extractMaintainerInfo(initialComment)
 	}
 
 	for {

--- a/tools/internal/parser/parser.go
+++ b/tools/internal/parser/parser.go
@@ -297,12 +297,13 @@ func (p *parser) parseCommentOrSuffixBlock() Block {
 // parseSuffixBlock parses a suffix block, starting with the provided
 // optional initial comment.
 func (p *parser) parseSuffixBlock(initialComment *Comment) *Suffixes {
-	ret := &Suffixes{}
+	ret := &Suffixes{
+		Info: extractMaintainerInfo(initialComment),
+	}
 	emit := blockEmitter(&ret.Blocks, &ret.SourceRange)
 
 	if initialComment != nil {
 		emit(initialComment)
-		ret.Info = extractMaintainerInfo(initialComment)
 	}
 
 	for {

--- a/tools/internal/parser/parser_test.go
+++ b/tools/internal/parser/parser_test.go
@@ -75,16 +75,13 @@ func TestParser(t *testing.T) {
 			name: "empty_sections",
 			psl: byteLines(
 				"// ===BEGIN IMAGINARY DOMAINS===",
-				"",
 				"// ===END IMAGINARY DOMAINS===",
 				"// ===BEGIN FAKE DOMAINS===",
 				"// ===END FAKE DOMAINS===",
 			),
 			want: list(
-				section(0, 3, "IMAGINARY DOMAINS", // TEST RIGHT, CODE WRONG
-					blank(1, 2),
-				),
-				section(3, 5, "FAKE DOMAINS"),
+				section(0, 2, "IMAGINARY DOMAINS"),
+				section(2, 4, "FAKE DOMAINS"),
 			),
 		},
 

--- a/tools/internal/parser/parser_test.go
+++ b/tools/internal/parser/parser_test.go
@@ -395,22 +395,24 @@ func section(start, end int, name string, blocks ...Block) *Section {
 func suffixes(start, end int, entity string, urlStr string, email string, blocks ...Block) *Suffixes {
 	ret := &Suffixes{
 		SourceRange: mkSrc(start, end),
-		Entity:      entity,
-		Blocks:      blocks,
+		Info: MaintainerInfo{
+			Name: entity,
+		},
+		Blocks: blocks,
 	}
 	if urlStr != "" {
 		u, err := url.Parse(urlStr)
 		if err != nil {
 			panic(err)
 		}
-		ret.URL = u
+		ret.Info.URL = u
 	}
 	if email != "" {
 		e, err := mail.ParseAddress(email)
 		if err != nil {
 			panic(err)
 		}
-		ret.Submitter = e
+		ret.Info.Submitter = e
 	}
 	return ret
 }

--- a/tools/internal/parser/parser_test.go
+++ b/tools/internal/parser/parser_test.go
@@ -385,13 +385,6 @@ func comment(start int, lines ...string) *Comment {
 }
 
 func section(start, end int, name string, blocks ...Block) *Section {
-	if len(blocks) == 0 {
-		return &Section{
-			SourceRange: mkSrc(start, end),
-			Name:        name,
-		}
-	}
-
 	return &Section{
 		SourceRange: mkSrc(start, end),
 		Name:        name,

--- a/tools/internal/parser/validate.go
+++ b/tools/internal/parser/validate.go
@@ -34,7 +34,7 @@ func validateEntityMetadata(block *Section) []error {
 			ret = append(ret, ErrMissingEntityName{
 				Suffixes: block,
 			})
-		} else if block.Info.Submitter == nil && !exemptFromContactInfo(block.Info.Name) {
+		} else if len(block.Info.Maintainers) == 0 && !exemptFromContactInfo(block.Info.Name) {
 			ret = append(ret, ErrMissingEntityEmail{
 				Suffixes: block,
 			})

--- a/tools/internal/parser/validate.go
+++ b/tools/internal/parser/validate.go
@@ -30,11 +30,11 @@ func ValidateOffline(l *List) []error {
 func validateEntityMetadata(block *Section) []error {
 	var ret []error
 	for _, block := range BlocksOfType[*Suffixes](block) {
-		if block.Entity == "" {
+		if block.Info.Name == "" {
 			ret = append(ret, ErrMissingEntityName{
 				Suffixes: block,
 			})
-		} else if block.Submitter == nil && !exemptFromContactInfo(block.Entity) {
+		} else if block.Info.Submitter == nil && !exemptFromContactInfo(block.Info.Name) {
 			ret = append(ret, ErrMissingEntityEmail{
 				Suffixes: block,
 			})
@@ -93,8 +93,8 @@ func validatePrivateSectionOrder(block *Section) error {
 			if inAmazonSuperblock {
 				last := len(blocks) - 1
 				blocks[last].Suffixes = append(blocks[last].Suffixes, v)
-			} else if !exemptFromSorting(v.Entity) {
-				blocks = append(blocks, superblock{v.Entity, []*Suffixes{v}})
+			} else if !exemptFromSorting(v.Info.Name) {
+				blocks = append(blocks, superblock{v.Info.Name, []*Suffixes{v}})
 			}
 		}
 	}
@@ -180,7 +180,7 @@ func validatePrivateSectionOrder(block *Section) error {
 		insertAfter := ""
 		if targetIdx > 0 {
 			suffixesOfPrev := fixed[targetIdx-1].Suffixes
-			insertAfter = suffixesOfPrev[len(suffixesOfPrev)-1].Entity
+			insertAfter = suffixesOfPrev[len(suffixesOfPrev)-1].Info.Name
 		}
 
 		// Superblocks can contain many suffixes. Move entire
@@ -193,7 +193,7 @@ func validatePrivateSectionOrder(block *Section) error {
 		} else {
 			block := toMove.Suffixes[0]
 			err.EditScript = append(err.EditScript, MoveSuffixBlock{
-				Name:        block.Entity,
+				Name:        block.Info.Name,
 				InsertAfter: insertAfter,
 			})
 		}

--- a/tools/internal/parser/validate.go
+++ b/tools/internal/parser/validate.go
@@ -12,7 +12,7 @@ import (
 func ValidateOffline(l *List) []error {
 	var ret []error
 
-	for _, block := range blocksOfType[*Section](l) {
+	for _, block := range BlocksOfType[*Section](l) {
 		if block.Name == "PRIVATE DOMAINS" {
 			ret = append(ret, validateEntityMetadata(block)...)
 			if err := validatePrivateSectionOrder(block); err != nil {
@@ -29,7 +29,7 @@ func ValidateOffline(l *List) []error {
 // kind of entity name.
 func validateEntityMetadata(block *Section) []error {
 	var ret []error
-	for _, block := range blocksOfType[*Suffixes](block) {
+	for _, block := range BlocksOfType[*Suffixes](block) {
 		if block.Entity == "" {
 			ret = append(ret, ErrMissingEntityName{
 				Suffixes: block,
@@ -204,33 +204,4 @@ func validatePrivateSectionOrder(block *Section) error {
 	}
 
 	return err
-}
-
-// A childrener can return a list of its children.
-// Yes, the interface name sounds a bit silly, but it's the
-// conventional Go name given what it does.
-type childrener interface {
-	Children() []Block
-}
-
-// blocksOfType recursively walks the subtree rooted at c and returns
-// all tree nodes of concrete block type T.
-//
-// For example, blocksOfType[*Comment](n) returns all comment nodes
-// under n.
-func blocksOfType[T Block](c childrener) []T {
-	var ret []T
-
-	var rec func(childrener)
-	rec = func(c childrener) {
-		if v, ok := c.(T); ok {
-			ret = append(ret, v)
-		}
-		for _, child := range c.Children() {
-			rec(child)
-		}
-	}
-	rec(c)
-
-	return ret
 }

--- a/tools/internal/parser/validate_test.go
+++ b/tools/internal/parser/validate_test.go
@@ -5,15 +5,15 @@ import (
 )
 
 func TestRequireSortedPrivateSection(t *testing.T) {
-	aaa := suffixes(0, 1, "AAA Corp", "", "", suffix(0, "aaa.com"))
-	bbb := suffixes(0, 1, "BBB Inc", "", "", suffix(0, "bbb.net"))
-	ccc := suffixes(0, 1, "CCC Ltd", "", "", suffix(0, "ccc.org"))
-	dddLeadingDot := suffixes(0, 1, ".DDD GmbH", "", "", suffix(0, "ddd.de"))
-	aaaUmlaut := suffixes(0, 1, "AÄA", "", "", suffix(0, "aaa.de"))
-	aaaUmlautShort := suffixes(0, 1, "AÄ", "", "", suffix(0, "aaa.ee"))
-	aaaUmlautLong := suffixes(0, 1, "AÄAA", "", "", suffix(0, "aaa.sk"))
-	a3b := suffixes(0, 1, "a3b", "", "", suffix(0, "a3b.com"))
-	a24b := suffixes(0, 1, "a24b", "", "", suffix(0, "a24b.com"))
+	aaa := suffixes(0, 1, info("AAA Corp", nil, nil, nil, true), suffix(0, "aaa.com"))
+	bbb := suffixes(0, 1, info("BBB Inc", nil, nil, nil, true), suffix(0, "bbb.net"))
+	ccc := suffixes(0, 1, info("CCC Ltd", nil, nil, nil, true), suffix(0, "ccc.org"))
+	dddLeadingDot := suffixes(0, 1, info(".DDD GmbH", nil, nil, nil, true), suffix(0, "ddd.de"))
+	aaaUmlaut := suffixes(0, 1, info("AÄA", nil, nil, nil, true), suffix(0, "aaa.de"))
+	aaaUmlautShort := suffixes(0, 1, info("AÄ", nil, nil, nil, true), suffix(0, "aaa.ee"))
+	aaaUmlautLong := suffixes(0, 1, info("AÄAA", nil, nil, nil, true), suffix(0, "aaa.sk"))
+	a3b := suffixes(0, 1, info("a3b", nil, nil, nil, true), suffix(0, "a3b.com"))
+	a24b := suffixes(0, 1, info("a24b", nil, nil, nil, true), suffix(0, "a24b.com"))
 
 	tests := []struct {
 		name string
@@ -114,18 +114,18 @@ func TestRequireSortedPrivateSection(t *testing.T) {
 		{
 			name: "amazon_superblock",
 			in: section(0, 23, "",
-				suffixes(2, 4, "AA Ltd", "", "", suffix(3, "aa.com")),
+				suffixes(2, 4, info("AA Ltd", nil, nil, nil, true), suffix(3, "aa.com")),
 
 				comment(5, "Amazon : https://www.amazon.com", "several blocks follow"),
 				// Note, incorrect sort, but ignored because it's in
 				// the Amazon superblock.
-				suffixes(8, 10, "eero", "", "", suffix(9, "eero.com")),
-				suffixes(11, 13, "AWS", "", "", suffix(12, "aws.com")),
+				suffixes(8, 10, info("eero", nil, nil, nil, true), suffix(9, "eero.com")),
+				suffixes(11, 13, info("AWS", nil, nil, nil, true), suffix(12, "aws.com")),
 				comment(14, "concludes Amazon"),
 
-				suffixes(16, 18, "Altavista", "", "", suffix(17, "altavista.com")),
+				suffixes(16, 18, info("Altavista", nil, nil, nil, true), suffix(17, "altavista.com")),
 
-				suffixes(19, 21, "BB Ltd", "", "", suffix(20, "bb.com")),
+				suffixes(19, 21, info("BB Ltd", nil, nil, nil, true), suffix(20, "bb.com")),
 			),
 			want: ErrSuffixBlocksInWrongPlace{
 				EditScript: []MoveSuffixBlock{

--- a/tools/internal/parser/validate_test.go
+++ b/tools/internal/parser/validate_test.go
@@ -32,8 +32,8 @@ func TestRequireSortedPrivateSection(t *testing.T) {
 			want: ErrSuffixBlocksInWrongPlace{
 				EditScript: []MoveSuffixBlock{
 					{
-						Name:        bbb.Entity,
-						InsertAfter: aaa.Entity,
+						Name:        bbb.Info.Name,
+						InsertAfter: aaa.Info.Name,
 					},
 				},
 			},
@@ -46,12 +46,12 @@ func TestRequireSortedPrivateSection(t *testing.T) {
 			want: ErrSuffixBlocksInWrongPlace{
 				EditScript: []MoveSuffixBlock{
 					{
-						Name:        ccc.Entity,
-						InsertAfter: aaa.Entity,
+						Name:        ccc.Info.Name,
+						InsertAfter: aaa.Info.Name,
 					},
 					{
-						Name:        bbb.Entity,
-						InsertAfter: aaa.Entity,
+						Name:        bbb.Info.Name,
+						InsertAfter: aaa.Info.Name,
 					},
 				},
 			},
@@ -64,7 +64,7 @@ func TestRequireSortedPrivateSection(t *testing.T) {
 			want: ErrSuffixBlocksInWrongPlace{
 				EditScript: []MoveSuffixBlock{
 					{
-						Name:        dddLeadingDot.Entity,
+						Name:        dddLeadingDot.Info.Name,
 						InsertAfter: "",
 					},
 				},
@@ -78,16 +78,16 @@ func TestRequireSortedPrivateSection(t *testing.T) {
 			want: ErrSuffixBlocksInWrongPlace{
 				EditScript: []MoveSuffixBlock{
 					{
-						Name:        aaaUmlaut.Entity,
+						Name:        aaaUmlaut.Info.Name,
 						InsertAfter: "",
 					},
 					{
-						Name:        aaaUmlautShort.Entity,
+						Name:        aaaUmlautShort.Info.Name,
 						InsertAfter: "",
 					},
 					{
-						Name:        aaaUmlautLong.Entity,
-						InsertAfter: aaa.Entity,
+						Name:        aaaUmlautLong.Info.Name,
+						InsertAfter: aaa.Info.Name,
 					},
 				},
 			},
@@ -100,12 +100,12 @@ func TestRequireSortedPrivateSection(t *testing.T) {
 			want: ErrSuffixBlocksInWrongPlace{
 				EditScript: []MoveSuffixBlock{
 					{
-						Name:        aaa.Entity,
-						InsertAfter: a24b.Entity,
+						Name:        aaa.Info.Name,
+						InsertAfter: a24b.Info.Name,
 					},
 					{
-						Name:        a3b.Entity,
-						InsertAfter: a24b.Entity,
+						Name:        a3b.Info.Name,
+						InsertAfter: a24b.Info.Name,
 					},
 				},
 			},


### PR DESCRIPTION
Several commits, each one is self-contained.

I promise the formatting is coming soon, this rework is making the metadata extraction more precise, so that we can look at options for reformatting the suffix block headers into some canonical form.

I added some tests specifically for metadata parsing, to cover the layouts that exist in the PSL. I also removed a couple of parser tests that were just exercising metadata parsing, and were testing behavior for formats that aren't actually present in the real PSL :facepalm: 

Next PR after this one is `pslfmt` with sorting of suffixes and suffix blocks, and possibly metadata reformatting if we find a format that we like.