### PR TITLE
AWS Submissions to the Public Suffix List - Q3 2024

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11556,7 +11556,7 @@ emrstudio-prod.us-west-2.amazonaws.com
 
 // Amazon S3
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: cd5c8b3a-67b7-4b40-9236-c87ce81a3d10
+// Reference: ada5c9df-55e1-4195-a1ce-732d6c81e357
 s3.dualstack.cn-north-1.amazonaws.com.cn
 s3-accesspoint.dualstack.cn-north-1.amazonaws.com.cn
 s3-website.dualstack.cn-north-1.amazonaws.com.cn
@@ -11614,6 +11614,7 @@ s3-object-lambda.ap-south-1.amazonaws.com
 s3-website.ap-south-1.amazonaws.com
 s3.dualstack.ap-south-2.amazonaws.com
 s3-accesspoint.dualstack.ap-south-2.amazonaws.com
+s3-website.dualstack.ap-south-2.amazonaws.com
 s3.ap-south-2.amazonaws.com
 s3-accesspoint.ap-south-2.amazonaws.com
 s3-object-lambda.ap-south-2.amazonaws.com
@@ -11634,16 +11635,26 @@ s3-object-lambda.ap-southeast-2.amazonaws.com
 s3-website.ap-southeast-2.amazonaws.com
 s3.dualstack.ap-southeast-3.amazonaws.com
 s3-accesspoint.dualstack.ap-southeast-3.amazonaws.com
+s3-website.dualstack.ap-southeast-3.amazonaws.com
 s3.ap-southeast-3.amazonaws.com
 s3-accesspoint.ap-southeast-3.amazonaws.com
 s3-object-lambda.ap-southeast-3.amazonaws.com
 s3-website.ap-southeast-3.amazonaws.com
 s3.dualstack.ap-southeast-4.amazonaws.com
 s3-accesspoint.dualstack.ap-southeast-4.amazonaws.com
+s3-website.dualstack.ap-southeast-4.amazonaws.com
 s3.ap-southeast-4.amazonaws.com
 s3-accesspoint.ap-southeast-4.amazonaws.com
 s3-object-lambda.ap-southeast-4.amazonaws.com
 s3-website.ap-southeast-4.amazonaws.com
+s3.dualstack.ap-southeast-5.amazonaws.com
+s3-accesspoint.dualstack.ap-southeast-5.amazonaws.com
+s3-website.dualstack.ap-southeast-5.amazonaws.com
+s3.ap-southeast-5.amazonaws.com
+s3-accesspoint.ap-southeast-5.amazonaws.com
+s3-deprecated.ap-southeast-5.amazonaws.com
+s3-object-lambda.ap-southeast-5.amazonaws.com
+s3-website.ap-southeast-5.amazonaws.com
 s3.dualstack.ca-central-1.amazonaws.com
 s3-accesspoint.dualstack.ca-central-1.amazonaws.com
 s3-accesspoint-fips.dualstack.ca-central-1.amazonaws.com
@@ -11664,6 +11675,7 @@ s3.ca-west-1.amazonaws.com
 s3-accesspoint.ca-west-1.amazonaws.com
 s3-accesspoint-fips.ca-west-1.amazonaws.com
 s3-fips.ca-west-1.amazonaws.com
+s3-object-lambda.ca-west-1.amazonaws.com
 s3-website.ca-west-1.amazonaws.com
 s3.dualstack.eu-central-1.amazonaws.com
 s3-accesspoint.dualstack.eu-central-1.amazonaws.com
@@ -11674,6 +11686,7 @@ s3-object-lambda.eu-central-1.amazonaws.com
 s3-website.eu-central-1.amazonaws.com
 s3.dualstack.eu-central-2.amazonaws.com
 s3-accesspoint.dualstack.eu-central-2.amazonaws.com
+s3-website.dualstack.eu-central-2.amazonaws.com
 s3.eu-central-2.amazonaws.com
 s3-accesspoint.eu-central-2.amazonaws.com
 s3-object-lambda.eu-central-2.amazonaws.com
@@ -11693,6 +11706,7 @@ s3-object-lambda.eu-south-1.amazonaws.com
 s3-website.eu-south-1.amazonaws.com
 s3.dualstack.eu-south-2.amazonaws.com
 s3-accesspoint.dualstack.eu-south-2.amazonaws.com
+s3-website.dualstack.eu-south-2.amazonaws.com
 s3.eu-south-2.amazonaws.com
 s3-accesspoint.eu-south-2.amazonaws.com
 s3-object-lambda.eu-south-2.amazonaws.com
@@ -11720,12 +11734,14 @@ s3-object-lambda.eu-west-3.amazonaws.com
 s3-website.eu-west-3.amazonaws.com
 s3.dualstack.il-central-1.amazonaws.com
 s3-accesspoint.dualstack.il-central-1.amazonaws.com
+s3-website.dualstack.il-central-1.amazonaws.com
 s3.il-central-1.amazonaws.com
 s3-accesspoint.il-central-1.amazonaws.com
 s3-object-lambda.il-central-1.amazonaws.com
 s3-website.il-central-1.amazonaws.com
 s3.dualstack.me-central-1.amazonaws.com
 s3-accesspoint.dualstack.me-central-1.amazonaws.com
+s3-website.dualstack.me-central-1.amazonaws.com
 s3.me-central-1.amazonaws.com
 s3-accesspoint.me-central-1.amazonaws.com
 s3-object-lambda.me-central-1.amazonaws.com
@@ -11794,6 +11810,7 @@ s3.dualstack.us-east-2.amazonaws.com
 s3-accesspoint.dualstack.us-east-2.amazonaws.com
 s3-accesspoint-fips.dualstack.us-east-2.amazonaws.com
 s3-fips.dualstack.us-east-2.amazonaws.com
+s3-website.dualstack.us-east-2.amazonaws.com
 s3.us-east-2.amazonaws.com
 s3-accesspoint.us-east-2.amazonaws.com
 s3-accesspoint-fips.us-east-2.amazonaws.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11330,7 +11330,7 @@ myamaze.net
 
 // Amazon API Gateway
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 9e37648f-a66c-4655-9ab1-5981f8737197
+// Reference: 6a4f5a95-8c7d-4077-a7af-9cf1abec0a53
 execute-api.cn-north-1.amazonaws.com.cn
 execute-api.cn-northwest-1.amazonaws.com.cn
 execute-api.af-south-1.amazonaws.com
@@ -11344,6 +11344,7 @@ execute-api.ap-southeast-1.amazonaws.com
 execute-api.ap-southeast-2.amazonaws.com
 execute-api.ap-southeast-3.amazonaws.com
 execute-api.ap-southeast-4.amazonaws.com
+execute-api.ap-southeast-5.amazonaws.com
 execute-api.ca-central-1.amazonaws.com
 execute-api.ca-west-1.amazonaws.com
 execute-api.eu-central-1.amazonaws.com


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.


### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example) 
 _AWS does not submit suffixes to the Public Suffix List to work around rate-limits of any third-party products or tooling._

 * [X] This request was _not_ submitted with the objective of working around other third-party limits
 _Please see the Reason section below for objectives in this pull request._

* [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms

* [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies etc. and the rollback timing, etc is acceptable. *Proceed*.

---

Description of Organization
====

Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopted cloud, offering over 200 fully featured services from data centers globally. 
More information about AWS is available on our website:
[What is AWS?](https://aws.amazon.com/what-is-aws/)

**Organization Website:** 
[AWS Homepage](https://aws.amazon.com)

Reason for PSL Inclusion
====

These features/services have been identified by AWS Security and AWS service
teams as supporting different distinct customers/resources across shared
DNS suffixes. Adding these suffixes to the PSL is expected to improve the
security posture of customers using our services. This may include:

- impact to the Same-Origin Policy in modern browsers (cookies + others)
- representation of these domains to the CA/Browser Forum
- any other use-cases of the PSL which may benefit from updated information about multi-tenant AWS services

**Number of users this request is being made to serve:**

These changes are expected to impact all customers using these AWS services.
This includes both AWS-internal and external customers. Specific user counts
for these listed features/services are not publicly available.

Services/Features in PR:
====

Amazon API Gateway
Amazon S3

DNS Verification via dig
=======

<details>
<summary>DNS query results</summary>

```
execute-api.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.execute-api.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.ap-south-2.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.ap-south-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.ap-southeast-3.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.ap-southeast-3.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.ap-southeast-4.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.ap-southeast-4.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3.dualstack.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3.dualstack.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-accesspoint.dualstack.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3-accesspoint.dualstack.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-accesspoint.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3-accesspoint.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-deprecated.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3-deprecated.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-object-lambda.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3-object-lambda.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.ap-southeast-5.amazonaws.com: dig +short -t TXT _psl.s3-website.ap-southeast-5.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-object-lambda.ca-west-1.amazonaws.com: dig +short -t TXT _psl.s3-object-lambda.ca-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.eu-central-2.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.eu-central-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.eu-south-2.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.eu-south-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.il-central-1.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.il-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.me-central-1.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.me-central-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"



s3-website.dualstack.us-east-2.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.us-east-2.amazonaws.com
"https://github.com/publicsuffix/list/pull/2032"
```

</details>

Results of Syntax Checker (`make test`)
=========

<details>
<summary>Test results</summary>

```
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC:
OK
-n test_allowedchars:
OK
-n test_dots:
OK
-n test_duplicate:
OK
-n test_exception:
OK
-n test_punycode:
OK
-n test_section1:
OK
-n test_section2:
OK
-n test_section3:
OK
-n test_section4:
OK
-n test_spaces:
OK
-n test_wildcard:
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
	  cd libpsl;                                                                    \
	  git pull;                                                                     \
	  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
	  echo "CLEANFILES =" >> gtk-doc.make;                                          \
	  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/__fake__/public_suffix_list.dat --with-psl-testfile=/__fake__/tests/tests.txt && make -s clean && make -s check -j4
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
Making clean in fuzz
Making clean in tests
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_dafsa_fuzzer.o
  CC       libpsl_load_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       common.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-all
  CCLD     test-is-public-builtin
  CCLD     test-registrable-domain
PASS: test-is-public
PASS: test-is-public-all
PASS: test-is-public-builtin
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

</details>