### PR TITLE
Add caddr.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12257,6 +12257,10 @@ uk0.bigv.io
 dh.bytemark.co.uk
 vm.bytemark.co.uk
 
+// Content Addressed Origin : https://caddr.org/
+// Submitted by Kevin Kwok <antimatter15@gmail.com>
+caddr.org
+
 // Caf.js Labs LLC : https://www.cafjs.com
 // Submitted by Antonio Lain <antlai@cafjs.com>
 cafjs.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12258,7 +12258,7 @@ dh.bytemark.co.uk
 vm.bytemark.co.uk
 
 // Content Addressed Origin : https://caddr.org/
-// Submitted by Kevin Kwok <antimatter15@gmail.com>
+// Submitted by Kevin Kwok <dns@caddr.org>
 caddr.org
 
 // Caf.js Labs LLC : https://www.cafjs.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12257,10 +12257,6 @@ uk0.bigv.io
 dh.bytemark.co.uk
 vm.bytemark.co.uk
 
-// Content Addressed Origin : https://caddr.org/
-// Submitted by Kevin Kwok <dns@caddr.org>
-caddr.org
-
 // Caf.js Labs LLC : https://www.cafjs.com
 // Submitted by Antonio Lain <antlai@cafjs.com>
 cafjs.com
@@ -12495,6 +12491,10 @@ co.no
 // Submitted by Thomas Wouters <thomas.wouters@combellgroup.com>
 webhosting.be
 hosting-cluster.nl
+
+// Content Addressed Origin : https://caddr.org/
+// Submitted by Kevin Kwok <dns@caddr.org>
+caddr.org
 
 // Convex : https://convex.dev/
 // Submitted by James Cowling <security@convex.dev>


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _PSL entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. Submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

  * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

caddr.org is a "content-addressed origin" and is meant to be a piece of web infrastructure that enables the decentralized interoperability of web applications. A typical example URL using caddr might be `https://jyhensccrcfgezcf6f46ea6fxbrc7ul44kzlc2vrx63od64a47jq.caddr.org/?src=https://caddr-origin.github.io/examples/hello-world/demo.js`. The caddr server returns a static HTML document for any of its subdomains including a `<script>` tag with the `integrity` attribute set to the base64-encoded subdomain, and a `src` attribute configured to whatever query string is passed in. That means that while the site can load a script from any source- its contents are always strictly constrained to match the hash in the subdomain. 

One example of how this system could be used is to create a kind of "wallet" for OpenAI API Keys. Rather than having to paste API keys into stranger's websites and have them leaked, there could be a small interface hosted on *.caddr.org which could store the API Keys in localStorage and proxy all calls to the OpenAI server so that the credentials aren't leaked. It can also track usage and prevent an application from exceeding a given quota. Since the hosting of the "OpenAI wallet" is decoupled from the management of the origin, the developer of a given web application doesn't have to worry about the possiblity of the service being hijacked. 

I am submitting as the creator and registrant of caddr.org, but eventually would like to see the project adopted by a responsible internet infrastructure organization. The goal is for resolvers to be implemented natively within browsers so the public website merely becomes a polyfill for older user agents.

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Organization Website: 
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->

https://caddr.org/ 

Reason for PSL Inclusion
====

caddr.org was registered in 2022 and has been registered for a 10 year term expiring in 2032. The ultimate goal is for its resolution to be hard-coded into the implementation of web browsers, with the web version only maintained as a polyfill. 

This request is not an attempt to work around any third party limits. It has fairly constrained operating requirements (i.e. all pages on all subdomains return the same HTML) that make it unlikely to be particularly relevant to iOS or Facebook restrictions. 

The concept of a content-addressed origin requires a certain degree of isolation between neighboring scripts in the hash space.   As such it's beneficial for browsers to not group multiple subdomains in dialogs such as "Clear Browsing Data". Different subdomains should not be able to configure top-level cookie properties. The ability for different subdomains to be recognized as secure and independent helps establish the neutrality of caddr.org. 

A content-addressed origin is not like a DNS wildcard even though it can load scripts from any domain- as the subdomain very strongly constrains the security properties of a subdomain because of the `script integrity` attribute. 

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Number of users this request is being made to serve: 5,000
<!--
Identify if this is current or an estimate.
-->


Currently there are very few users of caddr.org. I have spoken to and previously collaborated with the team at 0xPARC (https://0xparc.org/) who are developing Zupass which is a conference passport service which has been used as the primary ticketing mechanism for several conferences with over 1000 attendees, and they have expressed interest in switching core components to build on top of caddr.org. 


DNS Verification via dig
=======


```
dig +short TXT _psl.caddr.org
"https://github.com/publicsuffix/list/pull/2033"
```


<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.caddr.org
"https://github.com/publicsuffix/list/pull/2033"
```


Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->

Results of Syntax Checker (`make test`)
=========

Ran `make test` and all the test suites passed.

```
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->


