### PR TITLE
remove `c.la`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12366,9 +12366,6 @@ nz.basketball
 radio.am
 radio.fm
 
-// c.la : http://www.c.la/
-c.la
-
 // certmgr.org : https://certmgr.org
 // Submitted by B. Blechschmidt <hostmaster@certmgr.org>
 certmgr.org


### PR DESCRIPTION
This domain has been put up for sale and is not PSL worthy, see #2042 for more information.