### PR TITLE
Remove `impertrix.com` and `impertrixcdn.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13891,11 +13891,6 @@ iki.fi
 ibxos.it
 iliadboxos.it
 
-// Impertrix Solutions : <https://impertrixcdn.com>
-// Submitted by Zhixiang Zhao <csuite@impertrix.com>
-impertrix.com
-impertrixcdn.com
-
 // Incsub, LLC: https://incsub.com/
 // Submitted by Aaron Edwards <sysadmins@incsub.com>
 smushcdn.com


### PR DESCRIPTION
Please refer to recent comments from #1060.

The domains `impertrix.com` and `impertrixcdn.com` likely expired after the project was terminated. The organization website, https://cloud.impertrix.com/, no longer works.

| Domain           | Creation Date       |
|------------------|---------------------|
| impertrix.com    | 2022-07-28T19:26:07Z|
| impertrixcdn.com | 2024-03-28T17:16:20Z|

The current WHOIS data shows both domains were registered after the original PR was submitted and merged.

The domain `impertrixcdn.com` appears to be currently involved in malicious activities, according to VirusTotal [results](https://www.virustotal.com/gui/domain/impertrixcdn.com/community) and also included in [a community report](https://www.virustotal.com/graph/gbf8d6f71f64541d29cc407179aad1fc6670ebf5f57534e2ca422c37ba76fc8ee).

![image](https://github.com/user-attachments/assets/b7b8dcff-2d3d-4c74-90a7-301bc0c01ac5)

The `_psl` TXT record has no entries.

```sh
dig +short TXT _psl.impertrix.com
dig +short TXT _psl.impertrixcdn.com
```
