### PR TITLE
Remove `onflashdrive.app`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13365,7 +13365,6 @@ flap.id
 
 // FlashDrive : https://flashdrive.io
 // Submitted by Eric Chan <support@flashdrive.io>
-onflashdrive.app
 fldrv.com
 
 // FlutterFlow : https://flutterflow.io


### PR DESCRIPTION
Please refer to recent comments in #1401 

- The domain `onflashdrive.app` expired and was recently registered by a different party on 2024-03-08.
- The original requester @qoddiapps has [confirmed](https://github.com/publicsuffix/list/pull/1401#issuecomment-2198277238) the domain is no longer in use but made changes incorrectly in their own repository [in this commit](https://github.com/qoddiapps/list/commit/47f12084949314b633ab904c188de4650d4be3ea) instead of creating a PR here.
- The domain was [taken over](https://github.com/publicsuffix/list/pull/1401#issuecomment-2193894223) by a different party and is [flagged as malicious by multiple antivirus engines](https://www.virustotal.com/gui/domain/onflashdrive.app). 
- It is currently on `clientHold` by the registrar.

```md
Domain Name: onflashdrive.app
Registry Domain ID: E026F2539-APP
Registrar WHOIS Server: whois.godaddy.com
Registrar URL: https://www.godaddy.com/
Updated Date: 2024-04-29T13:48:26Z
Creation Date: 2024-03-08T12:47:32Z
Registry Expiry Date: 2025-03-08T12:47:32Z
Registrar: GoDaddy.com, LLC
Registrar IANA ID: 146
Registrar Abuse Contact Email: abuse@1godaddy.com
Registrar Abuse Contact Phone: +1.4806242505
Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
Domain Status: clientHold https://icann.org/epp#clientHold
Domain Status: clientRenewProhibited https://icann.org/epp#clientRenewProhibited
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
```

![image](https://github.com/user-attachments/assets/3fac3ac2-2f4a-416e-a8fa-45a43f685cd0)
