### PR TITLE
Remove filegear regional domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13344,12 +13344,6 @@ fh-muenster.io
 // Filegear Inc. : https://www.filegear.com
 // Submitted by Jason Zhu <jason@owtware.com>
 filegear.me
-filegear-au.me
-filegear-de.me
-filegear-gb.me
-filegear-ie.me
-filegear-jp.me
-filegear-sg.me
 
 // Firebase, Inc.
 // Submitted by Chris Raynor <chris@firebase.com>


### PR DESCRIPTION
See [comments](https://github.com/publicsuffix/list/pull/713#issuecomment-2244269098) from the original requester @renqiz in #713 

The regional domains listed below had expired and were registered by different parties.

| Domain           | Creation Date          | Registrar Name   | Nameservers                             |
|------------------|------------------------|--------------------------|----------------------------------------|
| filegear-au.me   | 2021-01-27T18:08:42Z   | Key-Systems GmbH         | ns-cloud-e1.googledomains.com, ns-cloud-e2.googledomains.com, ns-cloud-e3.googledomains.com, ns-cloud-e4.googledomains.com |
| filegear-de.me   | 2022-06-08T22:13:07Z   | Danesco Trading Ltd.     | ns1.gm238.parklogic.com, ns2.gm238.parklogic.com |
| filegear-gb.me   | 2021-05-11T16:01:59Z   | NameCheap, Inc.          | dns1.registrar-servers.com, dns2.registrar-servers.com |
| filegear-ie.me   | 2023-08-16T19:52:08Z   | NameCheap, Inc.          | dns1.registrar-servers.com, dns2.registrar-servers.com |
| filegear-jp.me   | 2024-03-16T02:17:05Z   | NameCheap, Inc.          | dns1.registrar-servers.com, dns2.registrar-servers.com |
| filegear-sg.me   | 2024-03-08T10:14:53Z   | NETIM SARL               | nsla01.listen53.net, nsla02.listen53.net |

