### PR TITLE
Remove `mozilla-iot.org`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14380,10 +14380,6 @@ forte.id
 // Submitted by Elizabeth Southwell <elizabeth@modx.com>
 modx.dev
 
-// Mozilla Corporation : https://mozilla.com
-// Submitted by Ben Francis <bfrancis@mozilla.com>
-mozilla-iot.org
-
 // Mozilla Foundation : https://mozilla.org/
 // Submitted by glob <glob@mozilla.com>
 bmoattachments.org


### PR DESCRIPTION
Creating this PR to remove `mozilla-iot.org` because Mozilla has retired its IoT products. 

- [An Important Update on Mozilla WebThings](https://discourse.mozilla.org/t/an-important-update-on-mozilla-webthings/67764)

The project has been renamed from “Mozilla WebThings” to “WebThings” and has moved to a new home at `webthings.io` that is operated by a different entity, no longer under Mozilla.

Mozilla let the domain expire :( , and in November 2023, I noticed this and registered `mozilla-iot.org` on 2023-11-20 to prevent potential exploitations. This was to avoid someone else taking it over and potentially intercepting traffic from customers using the old Mozilla IoT devices. I then reported this to Mozilla and transferred the domain to them. 

This process was documented in [Bugzilla **Bug 1865791** ](https://bugzilla.mozilla.org/show_bug.cgi?id=1865791)by the security team and the domain was successfully transferred to Mozilla on 2024-01-23. Perhaps @simon-friedberger can somehow request access to the bug internally to confirm.

I just realized that `mozilla-iot.org` is also in the PSL, so perhaps it should be removed as it is no longer in use, hence creating this PR.

This PR might need to come from Mozilla rather than me, so let me know if I'm proceeding incorrectly! I also added new comments in the Bugzilla thread, so hopefully someone there can comment here to confirm.