### PR TITLE
remove `pcloud.host`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14594,10 +14594,6 @@ pointto.us
 // Submitted by Konstantin Nosov <Nosov@nodeart.io>
 stage.nodeart.io
 
-// Nucleos Inc. : https://nucleos.com
-// Submitted by Piotr Zduniak <piotr@nucleos.com>
-pcloud.host
-
 // NYC.mn : http://www.information.nyc.mn
 // Submitted by Matthew Brown <mattbrown@nyc.mn>
 nyc.mn


### PR DESCRIPTION
This domain returns a for sale page, which is against the PSL's terms of service.

![image](https://github.com/user-attachments/assets/65bc4fd3-d4d9-4303-bcff-fc3eacf3404b)
