### PR TITLE
remove `cya.gg`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14615,10 +14615,6 @@ obl.ong
 observablehq.cloud
 static.observableusercontent.com
 
-// Octopodal Solutions, LLC. : https://ulterius.io/
-// Submitted by Andrew Sampson <andrew@ulterius.io>
-cya.gg
-
 // OMG.LOL : <https://omg.lol>
 // Submitted by Adam Newbold <adam@omg.lol>
 omg.lol


### PR DESCRIPTION
This domain is setup to point to a parking page, which I believe is against the ToS:
![image](https://github.com/user-attachments/assets/ac2955d4-1165-4580-b9cb-210124cabc6f)

It was originally added to the PSL in #404 however it seems the domain name registration lapsed and someone else took the domain name as the registration date via a WHOIS lookup shows `Registered on 15th November 2023 at 14:29:51.068`:
![image](https://github.com/user-attachments/assets/ae06f7b6-6481-4282-8bbd-ccd065a4c36d)

The `_psl.cya.gg` TXT record no longer exists either, so that is also reason to believe the domain name has changed registrants. 