### PR TITLE
remove `nid.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14653,10 +14653,6 @@ simplesite.pl
 123paginaweb.pt
 123minsida.se
 
-// One Fold Media : http://www.onefoldmedia.com/
-// Submitted by Eddie Jones <eddie@onefoldmedia.com>
-nid.io
-
 // Open Domains : https://open-domains.net
 // Submitted by William Harrison <admin@open-domains.net>
 is-cool.dev


### PR DESCRIPTION
Domain is up for sale, which is against the PSL terms of service:
![image](https://github.com/user-attachments/assets/39446c39-83fa-4d01-aada-1d2751859468)

Nameservers of `nid.io` point to Afternic:
![image](https://github.com/user-attachments/assets/36e57834-8c7a-42b4-8d07-ab2543a1b70f)

---

I am just trying to clean up some entries on the PSL that are invalid with some spare time I have as I really appreciate this project. Would you guys prefer me make one big PR with changes like these (with evidence for removal of each domain, of course) instead of individual PRs for each domain/section? Thanks :)