### PR TITLE
Remove `shiftcrypto.dev` and `shiftcrypto.io` 

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15187,11 +15187,6 @@ as.sh.cn
 // Submitted by Nyoom <admin@sheezy.art>
 sheezy.games
 
-// Shift Crypto AG : https://shiftcrypto.ch
-// Submitted by alex <alex@shiftcrypto.ch>
-shiftcrypto.dev
-shiftcrypto.io
-
 // ShiftEdit : https://shiftedit.net/
 // Submitted by Adam Jimenez <adam@shiftcreate.com>
 shiftedit.io


### PR DESCRIPTION
Remove both shiftcrypto.dev and shiftcrypto.io domains from PSL. Respective `_psl` records have been removed. 

The domains were initially added to the list via #1236 and at the time the assumption was that some subdomains might be used by third parties. This was never the case and all subdomain were exclusively operated by Shift Crypto and never granted to 3rd parties. Main workloads were also moved to bitbox.swiss which is the rebranding of shiftcrypto. 

Requesting the PR from the original repository pertaining to #1236 . If additional validation is needed, please let me know.
