### PR TITLE
Remove `mintere.site` to rollback #993 (expired domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14368,10 +14368,6 @@ servicebus.windows.net
 // Submitted by Robert Böttinger <r@minion.systems>
 csx.cc
 
-// Mintere : https://mintere.com/
-// Submitted by Ben Aubin <security@mintere.com>
-mintere.site
-
 // MobileEducation, LLC : https://joinforte.com
 // Submitted by Grayson Martin <grayson.martin@mobileeducation.us>
 forte.id


### PR DESCRIPTION
See [latest comments](https://github.com/publicsuffix/list/pull/993#issuecomment-2195028494) from the original requester @benaubin in #993 
