### PR TITLE
Remove `cupcake.is` (expired domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12553,10 +12553,6 @@ on.crisp.email
 // Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
 *.cryptonomic.net
 
-// Cupcake : https://cupcake.io/
-// Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
-cupcake.is
-
 // Curv UG : https://curv-labs.de/
 // Submitted by Marvin Wiesner <Marvin@curv-labs.de>
 curv.dev


### PR DESCRIPTION
Creating this PR to remove `cupcake.is` for a combination of the following reasons:

- The organization website https://cupcake.io/ is defunct.
- [No other subdomains have been discovered](https://subdomainfinder.c99.nl/scans/2024-07-23/cupcake.is) besides `www.cupcake.is`, which is just a placeholder or parking page.
- WHOIS shows the domain was likely registered by someone else after it expired, assuming it wasn't re-registered by the original requester's organization after letting it expire.
- The _psl TXT record no longer exists, likely meaning the current registrant has no intention of PSL inclusion anymore.
- [SERP](https://www.google.com/search?q=site%3Acupcake.is) indicates no active site in use.

```
domain: cupcake.is
registrant: DA1212-IS
admin-c: NI231-IS
tech-c: NI231-IS
zone-c: NI231-IS
billing-c: NI230-IS
nserver: dns1.registrar-servers.com
nserver: dns2.registrar-servers.com
dnssec: unsigned delegation
created: September 13 2023
expires: September 13 2024
source: ISNIC
```