### PR TITLE
Remove `pagefrontapp.com` (expired domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14744,10 +14744,6 @@ oy.lc
 // Submitted by Derek Myers <derek@pagefog.com>
 pgfog.com
 
-// Pagefront : https://www.pagefronthq.com/
-// Submitted by Jason Kriss <jason@pagefronthq.com>
-pagefrontapp.com
-
 // PageXL : https://pagexl.com
 // Submitted by Yann Guichard <yann@pagexl.com>
 pagexl.com


### PR DESCRIPTION
Creating this PR to remove `pagefrontapp.com` for a combination of the following reasons:

- WHOIS shows the domain had expired, was likely registered by a different party, and then expired again for an extended period.
- The _psl TXT record no longer exists (NXDOMAIN).
- The organization website https://www.pagefronthq.com/ is defunct.
- No subdomains have been discovered at `pagefrontapp.com`.
- A [Google search](https://www.google.com/search?q=site%3Apagefrontapp.com&ie=UTF-8) indicates no active site in use.

```
Domain Name: PAGEFRONTAPP.COM
Registry Domain ID: 2779174757_DOMAIN_COM-VRSN
Registrar WHOIS Server: whois.web.com
Registrar URL: http://www.networksolutions.com/
Updated Date: 2024-07-22T11:03:17Z
Creation Date: 2023-05-08T18:11:17Z
Registry Expiry Date: 2024-05-08T18:11:17Z
Registrar: ZigZagNames.com LLC
Registrar IANA ID: 1235
Registrar Abuse Contact Email: [abuse@web.com](mailto:abuse@web.com)
Registrar Abuse Contact Phone: +1.8003337680
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Domain Status: pendingDelete https://icann.org/epp#pendingDelete
```
