### PR TITLE
Remove `backplaneapp.io` to rollback #267 (expired domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12168,10 +12168,6 @@ ecommerce-shop.pl
 // Submitted by Olivier Benz <olivier.benz@b-data.ch>
 b-data.io
 
-// backplane : https://www.backplane.io
-// Submitted by Anthony Voutas <anthony@backplane.io>
-backplaneapp.io
-
 // Balena : https://www.balena.io
 // Submitted by Petros Angelatos <petrosagg@balena.io>
 balena-devices.com


### PR DESCRIPTION
Remove backplaneapp.io to rollback #267 (expired domain)

Creating this PR to remove `backplaneapp.io` for a combination of the following reasons:

- WHOIS shows the domain had expired and was likely registered by a different party, assuming if it's not @voutasaurus the original requester's organization re-registering the same domain after it expired.

```
Domain Name: backplaneapp.io
Registry Domain ID: c7543042354d4534827c58dc5a6cb454-DONUTS
Registrar WHOIS Server: whois.dynadot.com
Registrar URL: http://dynadot.com/
Updated Date: 2024-07-04T00:47:24Z
Creation Date: 2019-08-09T12:55:37Z
Registry Expiry Date: 2024-08-09T12:55:37Z
```

- The _psl TXT record no longer exists, likely meaning the current registrant has no intention of PSL inclusion anymore.
- The organization website https://www.backplane.io is defunct.
- No subdomains have been discovered at `backplaneapp.io` with an existing IP.
- A [Google search](https://www.google.com/search?q=site%3Abackplaneapp.io&ie=UTF-8) indicates no active site in use.

Possibly involved in [malicious activities](https://www.virustotal.com/gui/domain/backplaneapp.io/detection). 

Also seen in [community graph](https://www.virustotal.com/graph/ga876ab82a9b54c47a0ecadf0077ccd7945f2ae743bbd415590b6d042f67b930b) `Phishing Campaign subject "'target domain' Notification" + Impersonation domain fearings.com.vz-ut5.cc`

![image](https://github.com/user-attachments/assets/02a5b7f6-0df7-422a-a7b3-f2415e346d99)


