### PR TITLE
remove `611.to`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11198,9 +11198,6 @@ cc.ua
 inf.ua
 ltd.ua
 
-// 611coin : https://611project.org/
-611.to
-
 // AAA workspace : https://aaa.vodka
 // Submitted by Kirill Rezraf <admin@aaa.vodka>
 aaa.vodka


### PR DESCRIPTION
Reasons for removal:
- Main website [611project.org](https://611project.org) returns a for sale page.
- 611.to root does not resolve.
- `_psl.611.to` TXT record does not exist

Original PR was #1037 submitted by @611project