### PR TITLE
remove `graphox.us`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11210,10 +11210,6 @@ aaa.vodka
 a2hosted.com
 cpserver.com
 
-// Aaron Marais' Gitlab pages: https://lab.aaronleem.co.za
-// Submitted by Aaron Marais <its_me@aaronleem.co.za>
-graphox.us
-
 // accesso Technology Group, plc. : https://accesso.com/
 // Submitted by accesso Team <accessoecommerce@accesso.com>
 *.devcdnaccesso.com


### PR DESCRIPTION
Reasons for removal:
- graphox.us returns a default web server page:
![image](https://github.com/user-attachments/assets/99b57dc2-0aad-4e21-b0bf-1b6b1a6a03fb)
- Main website https://lab.aaronleem.co.za times out
![image](https://github.com/user-attachments/assets/8a0a444d-badf-4625-8297-cef640f6a142)
- `_psl.graphox.us` TXT record is missing
- After looking at the WHOIS records, the graphox.us domain name was registered on 2022-04-15 however the original PR was made 2020-02-10, so I believe the domain most likely lapsed and was picked up by someone else.

Original PR was #960 opened by @gear4s.