### PR TITLE
remove `bitbridge.net`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12713,9 +12713,6 @@ duckdns.org
 // Submitted by Joel Kennedy <joel@bip.sh>
 bip.sh
 
-// bitbridge.net : Submitted by Craig Welch, abeliidev@gmail.com
-bitbridge.net
-
 // dy.fi : http://dy.fi/
 // Submitted by Heikki Hannikainen <hessu@hes.iki.fi>
 dy.fi


### PR DESCRIPTION
Reasons for removal:
- Domain is sitting at a parking page
![image](https://github.com/user-attachments/assets/a45fb386-72f6-498f-b5c0-6f068e4a2d36)
- `_psl.bitbridge.net` TXT record does not exist

Original PR was #1000 opened by @bitsii.