### PR TITLE
remove Amune section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12079,11 +12079,6 @@ eero-stage.online
 
 // concludes Amazon
 
-// Amune : https://amune.org/
-// Submitted by Team Amune <cert@amune.org>
-t3l3p0rt.net
-tele.amune.org
-
 // Apigee : https://apigee.com/
 // Submitted by Apigee Security Team <security@apigee.com>
 apigee.io


### PR DESCRIPTION
Reasons for removal:
- t3l3p0rt.net root does not resolve
![image](https://github.com/user-attachments/assets/2b6532a2-f4fc-49eb-8d76-5affeba0bd19)
- `_psl.t3l3p0rt.net` TXT record does not exist
- tele.amune.org root does not resolve
![image](https://github.com/user-attachments/assets/7567f276-1720-400e-826d-7cf93bb3582c)
- `_psl.tele.amune.org` TXT record does not exist
- I also checked `_psl.amune.org` in case they had put a TXT record there, however they have not.

Original PR was #357 opened by @mindprotectionkit-admin. That was back in 2016, so chances are they have just shutdown their service and done a "set and forget" type entry on the PSL.