### PR TITLE
Remove `awsmppl.com` to rollback #900 (expired domain, malicious)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13749,10 +13749,6 @@ gov.nl
 // Submitted by Matt Yamkowy <info@grayjaysports.ca>
 grayjayleagues.com
 
-// Group 53, LLC : https://www.group53.com
-// Submitted by Tyler Todd <noc@nova53.net>
-awsmppl.com
-
 // GünstigBestellen : https://günstigbestellen.de
 // Submitted by Furkan Akkoc <info@hendelzon.de>
 günstigbestellen.de


### PR DESCRIPTION
Creating this PR to remove `awsmppl.com` (rollback #900) for the following reasons:

# WHOIS

- **Expired domain**: WHOIS shows it was likely registered by someone else after it expired, assuming it wasn't re-registered by the original requester's organization (pending for @AgentTNT in #900 to confirm).

Per whois `Creation Date: 2022-12-28T19:04:02Z` is later than the date of inclusion: `sleevi merged commit 4e84d8b into publicsuffix:master on Dec 5, 2019`

- **`ClientHold` for an extended period**: The registrar has placed the domain on ClientHold for a long time, definitely over three months based on my checker's history.

Please read the original WHOIS records below:

```
   Domain Name: AWSMPPL.COM
   Registry Domain ID: 2747658378_DOMAIN_COM-VRSN
   Registrar WHOIS Server: whois.web.com
   Registrar URL: http://www.networksolutions.com
   Updated Date: 2023-12-26T14:32:45Z
   Creation Date: 2022-12-28T19:04:02Z
   Registry Expiry Date: 2024-12-28T19:04:02Z
   Registrar: Slamdunk Domains LLC
   Registrar IANA ID: 2881
   Registrar Abuse Contact Email: abuse@web.com
   Registrar Abuse Contact Phone: +1.8003337680
   Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
   Domain Status: clientHold https://icann.org/epp#clientHold
   Domain Status: clientRenewProhibited https://icann.org/epp#clientRenewProhibited
   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
   Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
   Name Server: NS1.PARKLOGIC.COM
   Name Server: NS2.PARKLOGIC.COM
   DNSSEC: unsigned
   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of whois database: 2024-07-25T02:41:54Z <<<

For more information on Whois status codes, please visit https://icann.org/epp
```

Sources: whois utility generated at 2024-07-24 22:42:17


# VirusTotal Check

To check for possible security issues, we used VirusTotal and here are the obtained observations:

- **Possibly Malicious**: VirusTotal indicates that **after being registered by the new registrant**, the domain may have been used for malicious practices and is [flagged as malicious by multiple security vendors](https://www.virustotal.com/gui/domain/awsmppl.com/detection). Out of caution, perhaps it should be removed.

![image](https://github.com/user-attachments/assets/67e1f2bb-ed28-4f86-9324-350732dc3f5e)

Sources: 
- [VirusTotal](https://www.virustotal.com/gui/domain/awsmppl.com/detection)
    

# Organization Website and Nature Check

<!-- TODO: Describe the organization website and nature findings -->

- https://www.group53.com works
- unable to verify the use of `awsmppl.com` (pending for @AgentTNT in #900 to confirm)

Sources: 
- Organization website URL from the PSL comments https://www.group53.com

# _psl TXT Record

Responses from multiple DNS servers for the `_psl` TXT record of the domain:

Response from `8.8.8.8`: empty

Response from `1.1.1.1`: empty

Response from `208.67.222.222`: empty

- **_psl TXT record no longer exists**: Likely meaning the current registrant has no intention of PSL inclusion anymore.

Sources: dig command using DNS servers: Google (8.8.8.8), Cloudflare (1.1.1.1), OpenDNS (208.67.222.222)

# Root-level Domain Usage Scan

As a potential indicator of domain usage, we scan the following records:

`NS records (awsmppl.com)` returns empty **NXDOMAIN**

Additionally, we scan the following records for possible website usage at the root level:

`A record (awsmppl.com)` returns empty

`A record (www.awsmppl.com)` returns empty

`MX records (awsmppl.com)` returns empty

<!-- TODO: Describe the domain usage scan findings -->

Sources: `dig` command for A, NS, and MX records

# Search Engine Checks

For possible website usage, we queried multiple different search engines:

<!-- TODO: Perform search engine checks and describe findings -->

![image](https://github.com/user-attachments/assets/4e5bd6e2-9a96-48fa-aedd-65439f0ef5d5)

![image](https://github.com/user-attachments/assets/fe6674a7-0bd4-4133-a018-17c294ea86b0)

![image](https://github.com/user-attachments/assets/767b0a8c-285d-430e-9d63-e6964bd1ae9a)

Found few, but none accessible:

![image](https://github.com/user-attachments/assets/c658a2f0-5189-4885-8204-218028ff64a0)

Sources: 
- [Google](https://www.google.com/search?q=site:awsmppl.com)
- [Bing](https://www.bing.com/search?q=site%3Aawsmppl.com)
- [DuckDuckGo](https://duckduckgo.com/?q=site%3Aawsmppl.com)
- [Yahoo](https://search.yahoo.com/search?p=site%3Aawsmppl.com)
- [Brave](https://search.brave.com/search?q=site%3Aawsmppl.com)

# Subdomain Discovery

For potential usage of subdomains that are not discovered by the search engines, 
we used the following tools and here are the obtained observations:

<!-- TODO: Use subdomain finder tools and describe findings -->

Found 72, but none with IP

![image](https://github.com/user-attachments/assets/084c6349-7e02-4943-9704-967aa68344ab)

Found none:

![image](https://github.com/user-attachments/assets/2f5e0fec-1d32-4666-824b-97eb1e54413e)

Conclusion: possibly none subdomain is in use.

Sources: 
- [Subdomain Finder](https://subdomainfinder.c99.nl)
- [Lookup Tools](https://lookup.tools/subdomain/awsmppl.com)

# crt.sh Certificate Transparency Logs

For potential website usage of subdomains that are not discovered by the search engines, 
we checked the Certificate Transparency Logs and here are the obtained observations:

<!-- TODO: Check crt.sh and describe findings -->

There are SSL certs valid for `1 year` not expired.

![image](https://github.com/user-attachments/assets/4b114797-259f-4c51-87e8-df614fafb139)

Sources: 
- [crt.sh](https://crt.sh/?q=awsmppl.com)
