### PR TITLE
remove cloudcontrol.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12405,11 +12405,6 @@ cloudaccess.host
 freesite.host
 cloudaccess.net
 
-// cloudControl : https://www.cloudcontrol.com/
-// Submitted by Tobias Wilken <tw@cloudcontrol.com>
-cloudcontrolapp.com
-cloudcontrolled.com
-
 // Cloudera, Inc. : https://www.cloudera.com/
 // Submitted by Kedarnath Waikar <security@cloudera.com>
 *.cloudera.site


### PR DESCRIPTION
Introduced in 56cd84e -- the domain is no longer a public suffix.

`_psl` records do not exist.
