### PR TITLE
update contact email for `is-a.dev`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13940,7 +13940,7 @@ iopsys.se
 ipifony.net
 
 // is-a.dev : https://www.is-a.dev
-// Submitted by William Harrison <admin@maintainers.is-a.dev>
+// Submitted by William Harrison <admin@m.is-a.dev>
 is-a.dev
 
 // ir.md : https://nic.ir.md


### PR DESCRIPTION
Simply updating the contact email for is-a.dev as we have moved to m.is-a.dev for email addresses. I am the original submitter of PR #1949.