### PR TITLE
Remove wedeploy domains to rollback #420 and #510

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15636,12 +15636,6 @@ wpsquared.site
 // Submitted by Merlin Glander <hostmaster@webwaddle.com>
 *.wadl.top
 
-// WeDeploy by Liferay, Inc. : https://www.wedeploy.com
-// Submitted by Henrique Vicente <security@wedeploy.com>
-wedeploy.io
-wedeploy.me
-wedeploy.sh
-
 // Western Digital Technologies, Inc : https://www.wdc.com
 // Submitted by Jung Jin <jungseok.jin@wdc.com>
 remotewd.com


### PR DESCRIPTION
This PR is to remvoe wedeploy domains to rollback #420 and #510 submitted by @henvic 

```
Domain Name: wedeploy.io
Registry Domain ID: a36f4b07d2834862944291eeddf614d4-DONUTS
Registrar WHOIS Server: whois.dynadot.com
Registrar URL: http://dynadot.com/
Updated Date: 2024-07-19T13:02:24Z
Creation Date: 2021-07-18T15:32:24Z
Registry Expiry Date: 2025-07-18T15:32:24Z
Registrar: Dynadot Inc
```

- `Creation Date: 2021-07-18T15:32:24Z` > PR date ` Jun 14, 2017` #420
- `_psl.wedeploy.io` has no TXT record, suggesting the current registrant has no intention for PSL inclusion 

```
Domain Name: wedeploy.me
Registry Domain ID: 6a25cf54f8dd4c8c8957d61373575f86-DONUTS
Registrar WHOIS Server: WHOIS.ENOM.COM
Registrar URL: http://www.enom.com/
Updated Date: 2024-07-30T20:02:36Z
Creation Date: 2023-06-18T10:57:30Z
Registry Expiry Date: 2024-06-18T10:57:30Z
Registrar: eNom, LLC
```

- `Creation Date: 2023-06-18T10:57:30Z` > PR date ` Jun 14, 2017` #420
- `_psl.wedeploy.me` has no TXT record, suggesting the current registrant has no intention for PSL inclusion 

```
Domain Name: wedeploy.sh
Registry Domain ID: c942fff81e564680a0e1437a969177c7-DONUTS
Registrar WHOIS Server: whois.namecheap.com
Registrar URL: https://www.namecheap.com/
Updated Date: 2023-11-17T22:18:28Z
Creation Date: 2022-08-14T16:55:28Z
Registry Expiry Date: 2024-08-14T16:55:28Z
Registrar: NameCheap, Inc.
```

- `Creation Date: 2022-08-14T16:55:28Z` > PR date ` Aug 21, 2017` #510
- `_psl.wedeploy.sh` has no TXT record, suggesting the current registrant has no intention for PSL inclusion 
