### PR TITLE
remove static.land from public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15250,12 +15250,6 @@ stackit.zone
 musician.io
 novecore.site
 
-// staticland : https://static.land
-// Submitted by Seth Vincent <sethvincent@gmail.com>
-static.land
-dev.static.land
-sites.static.land
-
 // Storebase : https://www.storebase.io
 // Submitted by Tony Schirmer <tony@storebase.io>
 storebase.store


### PR DESCRIPTION
This removes static.land as requested in https://github.com/publicsuffix/list/pull/255#issuecomment-2246388641

@groundcat 