### PR TITLE
merge `wdh.app` entries together using wildcard

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15666,10 +15666,9 @@ toolforge.org
 wmcloud.org
 wmflabs.org
 
-// William Harrison : https://william.net.au
+// William Harrison : https://wdh.gg
 // Submitted by William Harrison <domains@wdh.gg>
-wdh.app
-preview.wdh.app
+*.wdh.app
 
 // WISP : https://wisp.gg
 // Submitted by Stepan Fedotov <stepan@wisp.gg>


### PR DESCRIPTION
I completely forgot about wildcard support in the PSL 😆, so I've consolidated the 2 entries together. This is because I'm likely going to start deploying some more 3rd/4th level subdomains for my hosting service, not just `preview.wdh.app`.

I've also updated my website URL.

I've updated the `_psl.wdh.app` TXT record to this PR as well.