### PR TITLE
remove `blogsite.xyz`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13010,7 +13010,6 @@ freeddns.org
 mywire.org
 webredirect.org
 myddns.rocks
-blogsite.xyz
 
 // dynv6 : https://dynv6.com
 // Submitted by Dominik Menke <dom@digineo.de>


### PR DESCRIPTION
This domain was originally added in #447, which was made in 2017. Upon checking the registration date of `blogsite.xyz` via a WHOIS lookup, it says it was registered on `2021-10-25`, which likely means the registration lapsed and another registrant registered it.

When searching for a TXT record under `_psl.blogsite.xyz`, it simply returns an SPF record, which is just a wildcard record across all subdomains:
```
v=spf1 -all
```

Also, the name servers of the domain name point to the following, which is just a parking page service:
```
ns1.fp261.parklogic.com
ns2.fp261.parklogic.com
```

It is evident the registration has lapsed, where another registrant has registered it and this domain name is no longer eligible for PSL status.

Upon attempting to reach both the HTTPS and HTTP versions of the site, it did not load and the connection just timed out.