### PR TITLE
remove `mc.eu.org`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13109,7 +13109,6 @@ kr.eu.org
 lt.eu.org
 lu.eu.org
 lv.eu.org
-mc.eu.org
 me.eu.org
 mk.eu.org
 mt.eu.org


### PR DESCRIPTION
This domain name I believe was originally added along with all of the other eu.org suffixes (pre moving to GitHub?)

There are no nameservers under this subdomain nor does there seem to be any registered subdomains for it.

If you search Google using `site:mc.eu.org`, there is no results. The domain is not listed on the eu.org registration website either: https://nic.eu.org/opendomains.html

After running a SSL certificate lookup, no certificates were found: https://crt.sh/?q=mc.eu.org

I believe there is enough evidence to support the idea that this subdomain is not used nor is active.