### PR TITLE
remove `blogspot.mr`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13663,7 +13663,6 @@ blogspot.sg
 blogspot.si
 blogspot.sk
 blogspot.sn
-blogspot.td
 blogspot.com.tr
 blogspot.tw
 blogspot.ug

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13631,6 +13631,7 @@ blogspot.sg
 blogspot.si
 blogspot.sk
 blogspot.sn
+blogspot.td
 blogspot.com.tr
 blogspot.tw
 blogspot.ug

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13643,7 +13643,6 @@ blogspot.lt
 blogspot.lu
 blogspot.md
 blogspot.mk
-blogspot.mr
 blogspot.com.mt
 blogspot.mx
 blogspot.my


### PR DESCRIPTION
## blogspot.mr
I'm not sure where this was originally added in, possibly added pre-GitHub. 

Pretty simple reason for removal; the domain name is expired.

When attempting to lookup the domain via WHOIS, the server returns:
```
$ whois blogspot.mr
Server can't process your request at the moment.
```
And to clarify, I don't believe this is a server issue as looking up, for example, `nic.mr` works perfectly fine and returns the WHOIS data.

When attempting to lookup NS records the server returns `NXDOMAIN`.