### PR TITLE
remove Revitalised Limited section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14928,11 +14928,6 @@ devices.resinstaging.io
 // Submitted by Chris Kastorff <info@rethinkdb.com>
 hzc.io
 
-// Revitalised Limited : http://www.revitalised.co.uk
-// Submitted by Jack Price <jack@revitalised.co.uk>
-wellbeingzone.eu
-wellbeingzone.co.uk
-
 // Rico Developments Limited : https://adimo.co
 // Submitted by Colin Brown <hello@adimo.co>
 adimo.co.uk


### PR DESCRIPTION
Both domains were added in #300, however since their service has shutdown and one of the domain names expired nearly a month ago and I believe they are going to let the other one expire as well.

## wellbeingzone.co.uk
This domain expired 2024-07-13, 28 days ago as of writing this.

It seems like they are not going to renew it as it has been that long since and the WHOIS server returns `Renewal required.`

When looking up the domain on Google using `site:wellbeingzone.co.uk`, all that is returned is:
![image](https://github.com/user-attachments/assets/08ebca4f-60a3-4051-a534-1db6ba801d70)

## wellbeingzone.eu
The registry does not seem to return the domain expiry date for this domain via a WHOIS lookup, however I would estimate it will expire fairly soon.

When going to the site it shows a service shutdown page:
![image](https://github.com/user-attachments/assets/7d8b5896-2f56-410c-b9f5-61dffdd55831)

Running a subdomain scan returns no results: https://subdomainfinder.c99.nl/scans/2024-08-11/wellbeingzone.eu

When searching `site:wellbeingzone.eu` on Google, this is al that is returned:
![image](https://github.com/user-attachments/assets/f850cf76-ae5b-4df5-b5af-6445cea872c3)

The second result returns a 403 error for me:
![image](https://github.com/user-attachments/assets/a0d910e1-acbb-46c0-a8fd-70342b5b03b2)

I believe on these grounds both domain names should be eligible for removal as it seems neither of them are in use and once of which has expired.