### PR TITLE
remove `localzone.xyz`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14145,10 +14145,6 @@ ggff.net
 // Submitted by Lann Martin <security@localcert.dev>
 *.user.localcert.dev
 
-// localzone.xyz
-// Submitted by Kenny Niehage <hello@yahe.sh>
-localzone.xyz
-
 // Log'in Line : https://www.loginline.com/
 // Submitted by Rémi Mach <remi.mach@loginline.com>
 loginline.app


### PR DESCRIPTION
`localzone.xyz` was added in https://github.com/publicsuffix/list/pull/915 with the intention to introduce a domain that can be used for internal services across different organizations without the risk of collisions.

With the latest [board decision of the ICANN](https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-29-07-2024-en#section2.a) to finally reserve the `.internal` TLD for this specific use-case, `localzone.xyz` is no longer needed and the use of `.internal` is recommended instead.

I therefore intend to have `localzone.xyz` lapse in the future. I already removed the corresponding `_psl` record to indicate that this PSL entry should be removed.

Sorry for the rollback and thank you very much for your hard work. 🙏