### PR TITLE
update contact for dweb.link and libp2p.direct

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13912,6 +13912,10 @@ iopsys.se
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
 
+// IPFS Project : https://ipfs.tech/
+// Submitted by Interplanetary Shipyard <domains@ipshipyard.com>
+*.dweb.link
+
 // ir.md : https://nic.ir.md
 // Submitted by Ali Soizi <info@nic.ir.md>
 ir.md
@@ -14103,7 +14107,7 @@ lpusercontent.com
 lelux.site
 
 // libp2p project : https://libp2p.io
-// Submitted by Interplanetary Shipyard <psl@ipshipyard.com>
+// Submitted by Interplanetary Shipyard <domains@ipshipyard.com>
 libp2p.direct
 
 // Libre IT Ltd : https://libre.nz
@@ -14768,10 +14772,6 @@ xen.prgmr.com
 // priv.at : http://www.nic.priv.at/
 // Submitted by registry <lendl@nic.at>
 priv.at
-
-// Protocol Labs : https://protocol.ai/
-// Submitted by Michael Burns <noc@protocol.ai>
-*.dweb.link
 
 // Protonet GmbH : http://protonet.io
 // Submitted by Martin Meier <admin@protonet.io>


### PR DESCRIPTION
This PR is updating contact information for `dweb.link` and `libp2p.direct` entries.
Interplanetary Shipyard took maintenance of public good utilities for [IPFS](https://ipfs.tech/) and [Libp2p](https://libp2p.io/) ecosystems
(https://docs.ipfs.tech/concepts/public-utilities/)

Original PRs: https://github.com/publicsuffix/list/pull/766 & https://github.com/publicsuffix/list/pull/2084