### PR TITLE
Add routingthecloud.com/.net/.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14308,8 +14308,8 @@ servicebus.windows.net
 
 // MikroTik: https://mikrotik.com
 // Submitted by MikroTik SysAdmin Team <support@mikrotik.com>
-sn.mynetname.net
 routingthecloud.com
+sn.mynetname.net
 routingthecloud.net
 routingthecloud.org
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14309,6 +14309,9 @@ servicebus.windows.net
 // MikroTik: https://mikrotik.com
 // Submitted by MikroTik SysAdmin Team <support@mikrotik.com>
 sn.mynetname.net
+routingthecloud.com
+routingthecloud.net
+routingthecloud.org
 
 // minion.systems : http://minion.systems
 // Submitted by Robert Böttinger <r@minion.systems>


### PR DESCRIPTION
### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (make test)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
    - [Letsencrypt](https://letsencrypt.org/docs/rate-limits/)

  * [X] This request was _not_ submitted with the objective of working around other third-party limits

  * [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

  * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


Description of Organization
====

MikroTik is a networking equipment manufacturer that develops various features for their devices, including a DDNS feature that allows to receive a unique (based on device's serial number) DDNS that resolves to the device's WAN IP address. Submitting this as an employee of MikroTik's server administration team.

Organization Website: https://mikrotik.com

Reason for PSL Inclusion
====

Similarly to our recent submission ( https://github.com/publicsuffix/list/pull/2090 ), MikroTik routers provide a DDNS feature that allows each MikroTik router receive a unique DDNS based on the device's serial number. Compared to our previous submission, the listed domains in the PR are simply additional domains that the user can use for their device.
Description about the DDNS feature can be found here: https://help.mikrotik.com/docs/display/ROS/Cloud#Cloud-DDNS

We would like that the listed domains be added to the PSL in order to increase the (cookie) security for our device users since various DNS names (*.routingthecloud.com, *.routingthecloud.net, *.routingthecloud.org) will be available (in a future software update) to MikroTik devices and they are not related to each other. The domain is owned by us for many years and is valid for 3 more years and we intend to hold the domain for many more years.

We are aware that Let's Encrypt does have rate limits, but we already have requested Let's Encrypt to increase the said limits.

Number of users this request is being made to serve:
Currently we serve over 2 million users (DDNS) daily, but since this is going to be a new option for the devices, then it is hard to predict how much users are going to start using it initially.


DNS Verification via dig
=======

```
dig +short TXT _psl.routingthecloud.com
"https://github.com/publicsuffix/list/pull/2107"

dig +short TXT _psl.routingthecloud.net
"https://github.com/publicsuffix/list/pull/2107"

dig +short TXT _psl.routingthecloud.org
"https://github.com/publicsuffix/list/pull/2107"
```

Results of Syntax Checker (`make test`)
=========

```
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```