### PR TITLE
chore: update contact info + revert wildcard change for `wdh.app`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15667,9 +15667,9 @@ toolforge.org
 wmcloud.org
 wmflabs.org
 
-// William Harrison : https://wdh.gg
-// Submitted by William Harrison <domains@wdh.gg>
-*.wdh.app
+// William Harrison : https://wdharrison.com
+// Submitted by William Harrison <publicsuffix@wdharrison.com>
+wdh.app
 
 // WISP : https://wisp.gg
 // Submitted by Stepan Fedotov <stepan@wisp.gg>


### PR DESCRIPTION
Original PRs #2067 and #2094

Reasons for changes:
- Changed from a redirect domain (wdh.gg) to the website itself (wdharrison.com)
- Reverted wildcard change made in #2094 due to some behaviour that was not intended

I promise this will be the last PR for this domain, sorry about this!

I will update the `_psl.wdh.app` TXT record once I get the PR number.