### PR TITLE
chore: remove 6 domains from Now-DNS section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14538,12 +14538,8 @@ dnsking.ch
 mypi.co
 n4t.co
 001www.com
-ddnslive.com
 myiphost.com
 forumz.info
-16-b.it
-32-b.it
-64-b.it
 soundcast.me
 tcp4.me
 dnsup.net
@@ -14557,8 +14553,6 @@ x443.pw
 now-dns.top
 ntdll.top
 freeddns.us
-crafting.xyz
-zapto.xyz
 
 // nsupdate.info : https://www.nsupdate.info/
 // Submitted by Thomas Waldmann <info@nsupdate.info>


### PR DESCRIPTION
All domains were originally added in #560.

Reasons for removal:
- ddnslive.com
	- Registration date was `2023-06-05` according to a WHOIS lookup, which suggests the domain registration lapsed and was picked up by another party.
	- When searching `site:ddnslive.com` on Google, only 3 results come up which are all "for sale" subdomains on dan.com
- 16-b.it
	- Registration date was `2023-08-05` according to a WHOIS lookup, which suggests the domain registration lapsed and was picked up by another party.
	- No results when searching `site:16-b.it`' on Google.
- 32-b.it
	- Registration date was `2023-08-05` according to a WHOIS lookup, which suggests the domain registration lapsed and was picked up by another party.
	- 2 results when searching `site:32-b.it`' on Google, both of which do not resolve.
- 64-b.it
	- Registration date was `2023-09-17` according to a WHOIS lookup, which suggests the domain registration lapsed and was picked up by another party.
	- 1 result when searching `site:64-b.it`, which does not resolve.
- crafting.xyz
	- Registration date was `2024-06-27` according to a WHOIS lookup, which suggests the domain registration lapsed and was picked up by another party.
	- When going to http://crafting.xyz it redirects to an Afternic for sale page.
	- No other sites found when searching `site:crafting.xyz`
- zapto.xyz
	- Registration date was `2022-02-04` according to a WHOIS lookup, which suggests the domain registration lapsed and was picked up by another party.
	- The nameservers point to a parking page service, therefore showing the domain is not actively in use.

This seems to be a case of a "set and forget" entry, hence the lapsed domains.