### PR TITLE
remove `nyc.mn`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14565,10 +14565,6 @@ zapto.xyz
 nsupdate.info
 nerdpol.ovh
 
-// NYC.mn : http://www.information.nyc.mn
-// Submitted by Matthew Brown <mattbrown@nyc.mn>
-nyc.mn
-
 // O3O.Foundation : https://o3o.foundation/
 // Submitted by the prvcy.page Registry Team <psl@registry.prvcy.page>
 prvcy.page


### PR DESCRIPTION
See #2112 for more information.

Reasons for removal:
- Subdomains are not registrable.
- There are less than 10 SSLs created across the domain in its lifetime, and less than 3 that are currently active: https://crt.sh/?q=nyc.mn
- No subdomains were found when attempting to scan the domain using https://subdomainfinder.c99.nl/
- Only the registry site is found when searching `site:nyc.mn` on Google.

As per what @groundcat said in the issue, I too believe the best course of action would be emailing the entry submitter (mattbrown@nyc.mn) to see if this domain is required on the PSL as the domain's MX records do seem to be active.