### PR TITLE
remove `servers.run`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14152,10 +14152,6 @@ loginline.site
 // Submitted by Heiki Lõhmus <hostmaster at lohmus dot me>
 lohmus.me
 
-// Lokalized : https://lokalized.nl
-// Submitted by Noah Taheij <noah@lokalized.nl>
-servers.run
-
 // LubMAN UMCS Sp. z o.o : https://lubman.pl/
 // Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
 krasnik.pl


### PR DESCRIPTION
Original PR #1390

Reasons for removal:
- Organisation domain (lokalized.nl) does not exist any more.
- When searching for subdomains on https://subdomainfinder.c99.nl/ there are no results.
- http://servers.run does not load, even though there is an A record defined
- When searching `site:servers.run` on Google, no results are returned.

The `_psl` TXT record does still exist however there does not seem to be any evidence of usage for what the original submitter said in the original PR:

> Needed for Cookie Security due to the different websites (with "subdomains") on the hosting. Due to having multiple websites hosted by different people, we want to make it as secure as possible, therefore needing the PSL which will make the sites less vulnerable for same-site attacks.

Specifically, they said there would be different websites using subdomains however there is no evidence of any subdomains existing. I believe the hosting service shut down, however they kept renewing this domain.