### PR TITLE
Add v0.build and vusercontent.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15592,12 +15592,12 @@ express.val.run
 web.val.run
 
 // Vercel, Inc : https://vercel.com/
-// Submitted by Connor Davis <security@vercel.com>
+// Submitted by Max Leiter <security@vercel.com>
 vercel.app
-vercel.dev
-now.sh
-vusercontent.net
 v0.build
+vercel.dev
+vusercontent.net
+now.sh
 
 // VeryPositive SIA : http://very.lv
 // Submitted by Danko Aleksejevs <danko@very.lv>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15596,6 +15596,8 @@ web.val.run
 vercel.app
 vercel.dev
 now.sh
+vusercontent.net
+v0.build
 
 // VeryPositive SIA : http://very.lv
 // Submitted by Danko Aleksejevs <danko@very.lv>


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
  * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)


<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [x] This request was _not_ submitted with the objective of working around other third-party limits


  * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

  * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [x]  The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---

[x] Description of Organization
====
I'm on the AI team at Vercel building v0.dev. It allows you to generate React components and chat with the v0 LLM. Outputs generated by the LLM can be shared and published on v0.dev to the v0.build subdomain. The vusercontent domain is where we host the user-submitted content. 

For both domains, we intend to add user-customizable subdomains similar to GitHub Pages.

Organization Website: 
vercel.com <-- parent company (already in the PSL)
v0.dev <-- this particular PR

[x] Reason for PSL Inclusion
====

- We want our users' sites/subdomains to be isolated for other customers (cookies, suffix highlighting, etc)

You can see our previous (accepted) request for vercel.app here: https://github.com/publicsuffix/list/pull/1019

Number of users this request is being made to serve:
<!--
Identify if this is current or an estimate.
-->


[x] DNS Verification via dig
=======

```bash
> dig +short TXT _psl.vusercontent.net
"https://github.com/publicsuffix/list/pull/2121"

> dig +short TXT _psl.v0.build
"https://github.com/publicsuffix/list/pull/2121"
```

[x] Results of Syntax Checker (`make test`)
=========

```
Results of Syntax Checker (`make test`)
=========

============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

