### PR TITLE
remove `dapps.earth` section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12560,11 +12560,6 @@ localhost.daplie.me
 // Submitted by Abel Boldu / DAppNode Team <community@dappnode.io>
 dyndns.dappnode.io
 
-// dapps.earth : https://dapps.earth/
-// Submitted by Daniil Burdakov <icqkill@gmail.com>
-*.dapps.earth
-*.bzz.dapps.earth
-
 // Dark, Inc. : https://darklang.com
 // Submitted by Paul Biggar <ops@darklang.com>
 builtwithdark.com


### PR DESCRIPTION
Original PR was #708 

Reasons for removal:
- Domain was added to the PSL on 2018-12-28, however the domain's registration date according to a WHOIS lookup is 2023-08-06, which likely means the domain lapsed and a different person registered it.
- Domain has expired as of 2024-08-06.
- No TXT record at `_psl.dapps.earth`
- No results when looking up `site:dapps.earth` on Google, other than a for sale page on the root which no longer loads.
- No active SSL certificates: https://crt.sh/?q=dapps.earth