### PR TITLE
Remove `fireweb.app`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13293,10 +13293,6 @@ filegear.me
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
-// Firewebkit : https://www.firewebkit.com
-// Submitted by Majid Qureshi <mqureshi@amrayn.com>
-fireweb.app
-
 // FLAP : https://www.flap.cloud
 // Submitted by Louis Chemineau <louis@chmn.me>
 flap.id


### PR DESCRIPTION
- See the comments under https://github.com/publicsuffix/list/pull/1181#issuecomment-2246797225 for the confirmation process.
- The domain fireweb.app was registered on 2023-07-30T21:51:15Z, which is after the date of its initial inclusion. It seems the domain lapsed and was then picked up by another party. Interestingly the TXT record exists at `_psl.fireweb.app`.
- The organization website https://firewebkit.com provided in the initial request is not working.
- An attempt was made to contact the submitter via GitHub on July 23, 2024, but no response was received.
- An inquiry email was sent to the submitter's email addresses on September 3, 2024. However, the email address of the initial submitter is invalid. `<mqureshi@amrayn.com>: host route1.mx.cloudflare.net[162.159.205.13] said: 550 5.1.1 Address does not exist. jsaXKlBJoYOE (in reply to RCPT TO command)`, hence creating this PR to remove it.