### PR TITLE
Remove `publishproxy.com` (#294)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13598,7 +13598,6 @@ codespot.com
 googleapis.com
 googlecode.com
 pagespeedmobilizer.com
-publishproxy.com
 withgoogle.com
 withyoutube.com
 blogspot.cv


### PR DESCRIPTION
[Confirmed](https://github.com/publicsuffix/list/pull/294#issuecomment-2249938664) by the initial PR submitter in #294