### PR TITLE
Remove discontinued CentralNic entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14408,7 +14408,6 @@ nimsite.uk
 // No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 ar.com
-hu.com
 kr.com
 no.com
 qc.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14407,7 +14407,6 @@ nimsite.uk
 
 // No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
-ar.com
 qc.com
 
 // No-IP.com : https://noip.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14407,7 +14407,6 @@ nimsite.uk
 
 // No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
-qc.com
 
 // No-IP.com : https://noip.com/
 // Submitted by Deven Reza <publicsuffixlist@noip.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14408,7 +14408,6 @@ nimsite.uk
 // No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 ar.com
-no.com
 qc.com
 
 // No-IP.com : https://noip.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14410,7 +14410,6 @@ nimsite.uk
 ar.com
 no.com
 qc.com
-uy.com
 
 // No-IP.com : https://noip.com/
 // Submitted by Deven Reza <publicsuffixlist@noip.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14408,7 +14408,6 @@ nimsite.uk
 // No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 ar.com
-kr.com
 no.com
 qc.com
 uy.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14405,9 +14405,6 @@ torun.pl
 nh-serv.co.uk
 nimsite.uk
 
-// No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
-// Submitted by Gavin Brown <gavin.brown@centralnic.com>
-
 // No-IP.com : https://noip.com/
 // Submitted by Deven Reza <publicsuffixlist@noip.com>
 mmafan.biz


### PR DESCRIPTION
Confirmed by initial requestor in https://github.com/publicsuffix/list/pull/1089#issuecomment-2331078184

> as you will see from the conversation above, CentralNic sold those domains many years ago, and I left CentralNic last year in any case.
> As discussed with @dnsguru back in 2020, I attempted to contact the owners of the domains but I don't recall ever getting an answer. If the PSL's policy now is to remove entries that lack a DNS proof, then by all means go ahead.

---

**1. ar.com**
- `_psl.ar.com` TXT record does not exist.
- No live website under `ar.com` based on [Google Search](https://www.google.com/search?q=site%3Aar.com) and [Bing Search](https://www.bing.com/search?&q=site%3Aar.com).
- No entries found in [Certificate Transparency (CT) logs](https://crt.sh/?q=ar.com).
- No longer operated by CentralNic as per existing comments.

---

**2. hu.com**
- `_psl.hu.com` TXT record does not exist.
- No live website under `hu.com` based on [Google Search](https://www.google.com/search?q=site%3Ahu.com) and [Bing Search](https://www.bing.com/search?&q=site%3Ahu.com).
- No entries found in [Certificate Transparency (CT) logs](https://crt.sh/?q=hu.com).
- No longer operated by CentralNic as per existing comments.

---

**3. kr.com**
- `_psl.kr.com` TXT record does not exist.
- Only the domain for sale page was found under `kr.com` based on [Google Search](https://www.google.com/search?q=site%3Akr.com) and [Bing Search](https://www.bing.com/search?&q=site%3Akr.com).

![image](https://github.com/user-attachments/assets/0d331999-e02a-4216-908f-c387b3e27eb9)

- A number of entries found in [Certificate Transparency (CT) logs](https://crt.sh/?q=kr.com).
- No longer operated by CentralNic as per existing comments.

---

**4. no.com**
- `_psl.no.com` TXT record does not exist.
- Only 1 crypto company site was found under `no.com` based on [Google Search](https://www.google.com/search?q=site%3Ano.com) and [Bing Search](https://www.bing.com/search?&q=site%3Ano.com).
- 1 live entry found in [Certificate Transparency (CT) logs](https://crt.sh/?q=no.com).
- No longer operated by CentralNic as per existing comments.

---

**5. qc.com**
- `_psl.qc.com` TXT record does not exist.
- No live website (only 1-2 malfunctioning sites) under `qc.com` based on [Google Search](https://www.google.com/search?q=site%3Aqc.com) and [Bing Search](https://www.bing.com/search?&q=site%3Aqc.com).
- No entries found in [Certificate Transparency (CT) logs](https://crt.sh/?q=qc.com).
- No longer operated by CentralNic as per existing comments.

---

**6. uy.com**
- `_psl.uy.com` TXT record does not exist.
- No live website under `uy.com` based on [Google Search](https://www.google.com/search?q=site%3Auy.com) and [Bing Search](https://www.bing.com/search?&q=site%3Auy.com).
- No entries found in [Certificate Transparency (CT) logs](https://crt.sh/?q=uy.com).
- No longer operated by CentralNic as per existing comments.

---

dig output for `_psl` TXT

```
$ for domain in ar.com hu.com kr.com no.com qc.com uy.com; do echo "$domain:"; dig +short TXT _psl.$domain; done
ar.com:
hu.com:
;; communications error to 1.1.1.1#53: timed out
;; communications error to 1.1.1.1#53: timed out
;; communications error to 1.1.1.1#53: timed out
;; communications error to 8.8.8.8#53: timed out
;; no servers could be reached

kr.com:
no.com:
qc.com:
uy.com:
```

These domains do not appear to have active websites or certificates.