### PR TITLE
Update legacy registry links

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -715,7 +715,7 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: https://www.iana.org/domains/root/db/gc.html.ca
+// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
 // see also: http://registry.gc.ca/en/SubdomainFAQ
 gc.ca
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -18,7 +18,7 @@ net.ac
 mil.ac
 org.ac
 
-// ad : https://en.wikipedia.org/wiki/.ad
+// ad : https://www.iana.org/domains/root/db/ad.html
 ad
 nom.ad
 
@@ -172,7 +172,7 @@ commune.am
 net.am
 org.am
 
-// ao : https://en.wikipedia.org/wiki/.ao
+// ao : https://www.iana.org/domains/root/db/ao.html
 // http://www.dns.ao/REGISTR.DOC
 ao
 ed.ao
@@ -182,7 +182,7 @@ co.ao
 pb.ao
 it.ao
 
-// aq : https://en.wikipedia.org/wiki/.aq
+// aq : https://www.iana.org/domains/root/db/aq.html
 aq
 
 // ar : https://nic.ar/es/nic-argentina/normativa
@@ -202,7 +202,7 @@ org.ar
 senasa.ar
 tur.ar
 
-// arpa : https://en.wikipedia.org/wiki/.arpa
+// arpa : https://www.iana.org/domains/root/db/arpa.html
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 arpa
 e164.arpa
@@ -212,14 +212,14 @@ iris.arpa
 uri.arpa
 urn.arpa
 
-// as : https://en.wikipedia.org/wiki/.as
+// as : https://www.iana.org/domains/root/db/as.html
 as
 gov.as
 
-// asia : https://en.wikipedia.org/wiki/.asia
+// asia : https://www.iana.org/domains/root/db/asia.html
 asia
 
-// at : https://en.wikipedia.org/wiki/.at
+// at : https://www.iana.org/domains/root/db/at.html
 // Confirmed by registry <it@nic.at> 2008-06-17
 at
 ac.at
@@ -228,7 +228,7 @@ gv.at
 or.at
 sth.ac.at
 
-// au : https://en.wikipedia.org/wiki/.au
+// au : https://www.iana.org/domains/root/db/au.html
 // http://www.auda.org.au/
 au
 // 2LDs
@@ -275,14 +275,14 @@ wa.gov.au
 // education.tas.edu.au - Removed at the request of the Department of Education Tasmania
 schools.nsw.edu.au
 
-// aw : https://en.wikipedia.org/wiki/.aw
+// aw : https://www.iana.org/domains/root/db/aw.html
 aw
 com.aw
 
-// ax : https://en.wikipedia.org/wiki/.ax
+// ax : https://www.iana.org/domains/root/db/ax.html
 ax
 
-// az : https://en.wikipedia.org/wiki/.az
+// az : https://www.iana.org/domains/root/db/az.html
 az
 com.az
 net.az
@@ -306,7 +306,7 @@ mil.ba
 net.ba
 org.ba
 
-// bb : https://en.wikipedia.org/wiki/.bb
+// bb : https://www.iana.org/domains/root/db/bb.html
 bb
 biz.bb
 co.bb
@@ -319,19 +319,19 @@ org.bb
 store.bb
 tv.bb
 
-// bd : https://en.wikipedia.org/wiki/.bd
+// bd : https://www.iana.org/domains/root/db/bd.html
 *.bd
 
-// be : https://en.wikipedia.org/wiki/.be
+// be : https://www.iana.org/domains/root/db/be.html
 // Confirmed by registry <tech@dns.be> 2008-06-08
 be
 ac.be
 
-// bf : https://en.wikipedia.org/wiki/.bf
+// bf : https://www.iana.org/domains/root/db/bf.html
 bf
 gov.bf
 
-// bg : https://en.wikipedia.org/wiki/.bg
+// bg : https://www.iana.org/domains/root/db/bg.html
 // https://www.register.bg/user/static/rules/en/index.html
 bg
 a.bg
@@ -371,7 +371,7 @@ z.bg
 8.bg
 9.bg
 
-// bh : https://en.wikipedia.org/wiki/.bh
+// bh : https://www.iana.org/domains/root/db/bh.html
 bh
 com.bh
 edu.bh
@@ -379,7 +379,7 @@ net.bh
 org.bh
 gov.bh
 
-// bi : https://en.wikipedia.org/wiki/.bi
+// bi : https://www.iana.org/domains/root/db/bi.html
 // http://whois.nic.bi/
 bi
 co.bi
@@ -388,7 +388,7 @@ edu.bi
 or.bi
 org.bi
 
-// biz : https://en.wikipedia.org/wiki/.biz
+// biz : https://www.iana.org/domains/root/db/biz.html
 biz
 
 // bj : https://nic.bj/bj-suffixes.txt
@@ -657,7 +657,7 @@ org.bs
 edu.bs
 gov.bs
 
-// bt : https://en.wikipedia.org/wiki/.bt
+// bt : https://www.iana.org/domains/root/db/bt.html
 bt
 com.bt
 edu.bt
@@ -669,14 +669,14 @@ org.bt
 // Submitted by registry <jarle@uninett.no>
 bv
 
-// bw : https://en.wikipedia.org/wiki/.bw
+// bw : https://www.iana.org/domains/root/db/bw.html
 // http://www.gobin.info/domainname/bw.doc
 // list of other 2nd level tlds ?
 bw
 co.bw
 org.bw
 
-// by : https://en.wikipedia.org/wiki/.by
+// by : https://www.iana.org/domains/root/db/by.html
 // http://tld.by/rules_2006_en.html
 // list of other 2nd level tlds ?
 by
@@ -689,7 +689,7 @@ com.by
 // http://hoster.by/
 of.by
 
-// bz : https://en.wikipedia.org/wiki/.bz
+// bz : https://www.iana.org/domains/root/db/bz.html
 // http://www.belizenic.bz/
 bz
 com.bz
@@ -698,7 +698,7 @@ org.bz
 edu.bz
 gov.bz
 
-// ca : https://en.wikipedia.org/wiki/.ca
+// ca : https://www.iana.org/domains/root/db/ca.html
 ca
 // ca geographical names
 ab.ca
@@ -715,31 +715,31 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
+// gc.ca: https://www.iana.org/domains/root/db/gc.html.ca
 // see also: http://registry.gc.ca/en/SubdomainFAQ
 gc.ca
 
-// cat : https://en.wikipedia.org/wiki/.cat
+// cat : https://www.iana.org/domains/root/db/cat.html
 cat
 
-// cc : https://en.wikipedia.org/wiki/.cc
+// cc : https://www.iana.org/domains/root/db/cc.html
 cc
 
-// cd : https://en.wikipedia.org/wiki/.cd
+// cd : https://www.iana.org/domains/root/db/cd.html
 // see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1
 cd
 gov.cd
 
-// cf : https://en.wikipedia.org/wiki/.cf
+// cf : https://www.iana.org/domains/root/db/cf.html
 cf
 
-// cg : https://en.wikipedia.org/wiki/.cg
+// cg : https://www.iana.org/domains/root/db/cg.html
 cg
 
-// ch : https://en.wikipedia.org/wiki/.ch
+// ch : https://www.iana.org/domains/root/db/ch.html
 ch
 
-// ci : https://en.wikipedia.org/wiki/.ci
+// ci : https://www.iana.org/domains/root/db/ci.html
 // http://www.nic.ci/index.php?page=charte
 ci
 org.ci
@@ -758,7 +758,7 @@ presse.ci
 md.ci
 gouv.ci
 
-// ck : https://en.wikipedia.org/wiki/.ck
+// ck : https://www.iana.org/domains/root/db/ck.html
 *.ck
 !www.ck
 
@@ -770,14 +770,14 @@ gob.cl
 gov.cl
 mil.cl
 
-// cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
+// cm : https://www.iana.org/domains/root/db/cm.html plus bug 981927
 cm
 co.cm
 com.cm
 gov.cm
 net.cm
 
-// cn : https://en.wikipedia.org/wiki/.cn
+// cn : https://www.iana.org/domains/root/db/cn.html
 // Submitted by registry <tanyaling@cnnic.cn>
 cn
 ac.cn
@@ -826,7 +826,7 @@ hk.cn
 mo.cn
 tw.cn
 
-// co : https://en.wikipedia.org/wiki/.co
+// co : https://www.iana.org/domains/root/db/co.html
 // Submitted by registry <tecnico@uniandes.edu.co>
 co
 arts.co
@@ -843,10 +843,10 @@ org.co
 rec.co
 web.co
 
-// com : https://en.wikipedia.org/wiki/.com
+// com : https://www.iana.org/domains/root/db/com.html
 com
 
-// coop : https://en.wikipedia.org/wiki/.coop
+// coop : https://www.iana.org/domains/root/db/coop.html
 coop
 
 // cr : http://www.nic.cr/niccr_publico/showRegistroDominiosScreen.do
@@ -859,7 +859,7 @@ go.cr
 or.cr
 sa.cr
 
-// cu : https://en.wikipedia.org/wiki/.cu
+// cu : https://www.iana.org/domains/root/db/cu.html
 cu
 com.cu
 edu.cu
@@ -868,7 +868,7 @@ net.cu
 gov.cu
 inf.cu
 
-// cv : https://en.wikipedia.org/wiki/.cv
+// cv : https://www.iana.org/domains/root/db/cv.html
 // cv : http://www.dns.cv/tldcv_portal/do?com=DS;5446457100;111;+PAGE(4000018)+K-CAT-CODIGO(RDOM)+RCNT(100); <- registration rules
 cv
 com.cv
@@ -885,7 +885,7 @@ edu.cw
 net.cw
 org.cw
 
-// cx : https://en.wikipedia.org/wiki/.cx
+// cx : https://www.iana.org/domains/root/db/cx.html
 // list of other 2nd level tlds ?
 cx
 gov.cx
@@ -907,22 +907,22 @@ press.cy
 pro.cy
 tm.cy
 
-// cz : https://en.wikipedia.org/wiki/.cz
+// cz : https://www.iana.org/domains/root/db/cz.html
 cz
 
-// de : https://en.wikipedia.org/wiki/.de
+// de : https://www.iana.org/domains/root/db/de.html
 // Confirmed by registry <ops@denic.de> (with technical
 // reservations) 2008-07-01
 de
 
-// dj : https://en.wikipedia.org/wiki/.dj
+// dj : https://www.iana.org/domains/root/db/dj.html
 dj
 
-// dk : https://en.wikipedia.org/wiki/.dk
+// dk : https://www.iana.org/domains/root/db/dk.html
 // Confirmed by registry <robert@dk-hostmaster.dk> 2008-06-17
 dk
 
-// dm : https://en.wikipedia.org/wiki/.dm
+// dm : https://www.iana.org/domains/root/db/dm.html
 dm
 com.dm
 net.dm
@@ -930,7 +930,7 @@ org.dm
 edu.dm
 gov.dm
 
-// do : https://en.wikipedia.org/wiki/.do
+// do : https://www.iana.org/domains/root/db/do.html
 do
 art.do
 com.do
@@ -972,7 +972,7 @@ gov.ec
 gob.ec
 mil.ec
 
-// edu : https://en.wikipedia.org/wiki/.edu
+// edu : https://www.iana.org/domains/root/db/edu.html
 edu
 
 // ee : http://www.eenet.ee/EENet/dom_reeglid.html#lisa_B
@@ -988,7 +988,7 @@ aip.ee
 org.ee
 fie.ee
 
-// eg : https://en.wikipedia.org/wiki/.eg
+// eg : https://www.iana.org/domains/root/db/eg.html
 eg
 com.eg
 edu.eg
@@ -1000,7 +1000,7 @@ net.eg
 org.eg
 sci.eg
 
-// er : https://en.wikipedia.org/wiki/.er
+// er : https://www.iana.org/domains/root/db/er.html
 *.er
 
 // es : https://www.nic.es/site_ingles/ingles/dominios/index.html
@@ -1011,7 +1011,7 @@ org.es
 gob.es
 edu.es
 
-// et : https://en.wikipedia.org/wiki/.et
+// et : https://www.iana.org/domains/root/db/et.html
 et
 com.et
 gov.et
@@ -1022,7 +1022,7 @@ name.et
 info.et
 net.et
 
-// eu : https://en.wikipedia.org/wiki/.eu
+// eu : https://www.iana.org/domains/root/db/eu.html
 eu
 
 // fi : https://www.iana.org/domains/root/db/fi.html
@@ -1047,17 +1047,17 @@ net.fj
 org.fj
 pro.fj
 
-// fk : https://en.wikipedia.org/wiki/.fk
+// fk : https://www.iana.org/domains/root/db/fk.html
 *.fk
 
-// fm : https://en.wikipedia.org/wiki/.fm
+// fm : https://www.iana.org/domains/root/db/fm.html
 com.fm
 edu.fm
 net.fm
 org.fm
 fm
 
-// fo : https://en.wikipedia.org/wiki/.fo
+// fo : https://www.iana.org/domains/root/db/fo.html
 fo
 
 // fr : https://www.afnic.fr/ https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf
@@ -1074,14 +1074,14 @@ cci.fr
 greta.fr
 huissier-justice.fr
 
-// ga : https://en.wikipedia.org/wiki/.ga
+// ga : https://www.iana.org/domains/root/db/ga.html
 ga
 
 // gb : This registry is effectively dormant
 // Submitted by registry <Damien.Shaw@ja.net>
 gb
 
-// gd : https://en.wikipedia.org/wiki/.gd
+// gd : https://www.iana.org/domains/root/db/gd.html
 edu.gd
 gov.gd
 gd
@@ -1096,7 +1096,7 @@ mil.ge
 net.ge
 pvt.ge
 
-// gf : https://en.wikipedia.org/wiki/.gf
+// gf : https://www.iana.org/domains/root/db/gf.html
 gf
 
 // gg : http://www.channelisles.net/register-domains/
@@ -1106,7 +1106,7 @@ co.gg
 net.gg
 org.gg
 
-// gh : https://en.wikipedia.org/wiki/.gh
+// gh : https://www.iana.org/domains/root/db/gh.html
 // see also: http://www.nic.gh/reg_now.php
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
@@ -1126,7 +1126,7 @@ mod.gi
 edu.gi
 org.gi
 
-// gl : https://en.wikipedia.org/wiki/.gl
+// gl : https://www.iana.org/domains/root/db/gl.html
 // http://nic.gl
 gl
 co.gl
@@ -1148,7 +1148,7 @@ gov.gn
 org.gn
 net.gn
 
-// gov : https://en.wikipedia.org/wiki/.gov
+// gov : https://www.iana.org/domains/root/db/gov.html
 gov
 
 // gp : http://www.nic.gp/index.php?lang=en
@@ -1160,7 +1160,7 @@ edu.gp
 org.gp
 asso.gp
 
-// gq : https://en.wikipedia.org/wiki/.gq
+// gq : https://www.iana.org/domains/root/db/gq.html
 gq
 
 // gr : https://grweb.ics.forth.gr/english/1617-B-2005.html
@@ -1172,7 +1172,7 @@ net.gr
 org.gr
 gov.gr
 
-// gs : https://en.wikipedia.org/wiki/.gs
+// gs : https://www.iana.org/domains/root/db/gs.html
 gs
 
 // gt : https://www.gt/sitio/registration_policy.php?lang=en
@@ -1198,11 +1198,11 @@ net.gu
 org.gu
 web.gu
 
-// gw : https://en.wikipedia.org/wiki/.gw
+// gw : https://www.iana.org/domains/root/db/gw.html
 // gw : https://nic.gw/regras/
 gw
 
-// gy : https://en.wikipedia.org/wiki/.gy
+// gy : https://www.iana.org/domains/root/db/gy.html
 // http://registry.gy/
 gy
 co.gy
@@ -1237,7 +1237,7 @@ org.hk
 組織.hk
 組织.hk
 
-// hm : https://en.wikipedia.org/wiki/.hm
+// hm : https://www.iana.org/domains/root/db/hm.html
 hm
 
 // hn : http://www.nic.hn/politicas/ps02,,05.html
@@ -1326,7 +1326,7 @@ ponpes.id
 sch.id
 web.id
 
-// ie : https://en.wikipedia.org/wiki/.ie
+// ie : https://www.iana.org/domains/root/db/ie.html
 ie
 gov.ie
 
@@ -1366,7 +1366,7 @@ plc.co.im
 tt.im
 tv.im
 
-// in : https://en.wikipedia.org/wiki/.in
+// in : https://www.iana.org/domains/root/db/in.html
 // see also: https://registry.in/policies
 // Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
@@ -1413,10 +1413,10 @@ uk.in
 up.in
 us.in
 
-// info : https://en.wikipedia.org/wiki/.info
+// info : https://www.iana.org/domains/root/db/info.html
 info
 
-// int : https://en.wikipedia.org/wiki/.int
+// int : https://www.iana.org/domains/root/db/int.html
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 int
 eu.int
@@ -1461,7 +1461,7 @@ gov.is
 org.is
 int.is
 
-// it : https://en.wikipedia.org/wiki/.it
+// it : https://www.iana.org/domains/root/db/it.html
 it
 gov.it
 edu.it
@@ -1895,10 +1895,10 @@ gov.jo
 mil.jo
 name.jo
 
-// jobs : https://en.wikipedia.org/wiki/.jobs
+// jobs : https://www.iana.org/domains/root/db/jobs.html
 jobs
 
-// jp : https://en.wikipedia.org/wiki/.jp
+// jp : https://www.iana.org/domains/root/db/jp.html
 // http://jprs.co.jp/en/jpdomain.html
 // Submitted by registry <info@jprs.jp>
 jp
@@ -3732,7 +3732,7 @@ gov.ki
 info.ki
 com.ki
 
-// km : https://en.wikipedia.org/wiki/.km
+// km : https://www.iana.org/domains/root/db/km.html
 // http://www.domaine.km/documents/charte.doc
 km
 org.km
@@ -3745,7 +3745,7 @@ mil.km
 ass.km
 com.km
 // These are only mentioned as proposed suggestions at domaine.km, but
-// https://en.wikipedia.org/wiki/.km says they're available for registration:
+// https://www.iana.org/domains/root/db/km.html says they're available for registration:
 coop.km
 asso.km
 presse.km
@@ -3755,7 +3755,7 @@ pharmaciens.km
 veterinaire.km
 gouv.km
 
-// kn : https://en.wikipedia.org/wiki/.kn
+// kn : https://www.iana.org/domains/root/db/kn.html
 // http://www.dot.kn/domainRules.html
 kn
 net.kn
@@ -3772,7 +3772,7 @@ org.kp
 rep.kp
 tra.kp
 
-// kr : https://en.wikipedia.org/wiki/.kr
+// kr : https://www.iana.org/domains/root/db/kr.html
 // see also: http://domain.nida.or.kr/eng/registration.jsp
 kr
 ac.kr
@@ -3825,7 +3825,7 @@ edu.ky
 net.ky
 org.ky
 
-// kz : https://en.wikipedia.org/wiki/.kz
+// kz : https://www.iana.org/domains/root/db/kz.html
 // see also: http://www.nic.kz/rules/index.jsp
 kz
 org.kz
@@ -3835,7 +3835,7 @@ gov.kz
 mil.kz
 com.kz
 
-// la : https://en.wikipedia.org/wiki/.la
+// la : https://www.iana.org/domains/root/db/la.html
 // Submitted by registry <gavin.brown@nic.la>
 la
 int.la
@@ -3847,7 +3847,7 @@ per.la
 com.la
 org.la
 
-// lb : https://en.wikipedia.org/wiki/.lb
+// lb : https://www.iana.org/domains/root/db/lb.html
 // Submitted by registry <randy@psg.com>
 lb
 com.lb
@@ -3856,7 +3856,7 @@ gov.lb
 net.lb
 org.lb
 
-// lc : https://en.wikipedia.org/wiki/.lc
+// lc : https://www.iana.org/domains/root/db/lc.html
 // see also: http://www.nic.lc/rules.htm
 lc
 com.lc
@@ -3866,7 +3866,7 @@ org.lc
 edu.lc
 gov.lc
 
-// li : https://en.wikipedia.org/wiki/.li
+// li : https://www.iana.org/domains/root/db/li.html
 li
 
 // lk : https://www.nic.lk/index.php/domain-registration/lk-domain-naming-structure
@@ -3909,7 +3909,7 @@ net.ls
 org.ls
 sc.ls
 
-// lt : https://en.wikipedia.org/wiki/.lt
+// lt : https://www.iana.org/domains/root/db/lt.html
 lt
 // gov.lt : http://www.gov.lt/index_en.php
 gov.lt
@@ -3941,7 +3941,7 @@ med.ly
 org.ly
 id.ly
 
-// ma : https://en.wikipedia.org/wiki/.ma
+// ma : https://www.iana.org/domains/root/db/ma.html
 // http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
 ma
 co.ma
@@ -3956,10 +3956,10 @@ mc
 tm.mc
 asso.mc
 
-// md : https://en.wikipedia.org/wiki/.md
+// md : https://www.iana.org/domains/root/db/md.html
 md
 
-// me : https://en.wikipedia.org/wiki/.me
+// me : https://www.iana.org/domains/root/db/me.html
 me
 co.me
 net.me
@@ -3982,13 +3982,13 @@ mil.mg
 com.mg
 co.mg
 
-// mh : https://en.wikipedia.org/wiki/.mh
+// mh : https://www.iana.org/domains/root/db/mh.html
 mh
 
-// mil : https://en.wikipedia.org/wiki/.mil
+// mil : https://www.iana.org/domains/root/db/mil.html
 mil
 
-// mk : https://en.wikipedia.org/wiki/.mk
+// mk : https://www.iana.org/domains/root/db/mk.html
 // see also: http://dns.marnet.net.mk/postapka.php
 mk
 com.mk
@@ -4000,7 +4000,7 @@ inf.mk
 name.mk
 
 // ml : http://www.gobin.info/domainname/ml-template.doc
-// see also: https://en.wikipedia.org/wiki/.ml
+// see also: https://www.iana.org/domains/root/db/ml.html
 ml
 com.ml
 edu.ml
@@ -4010,10 +4010,10 @@ net.ml
 org.ml
 presse.ml
 
-// mm : https://en.wikipedia.org/wiki/.mm
+// mm : https://www.iana.org/domains/root/db/mm.html
 *.mm
 
-// mn : https://en.wikipedia.org/wiki/.mn
+// mn : https://www.iana.org/domains/root/db/mn.html
 mn
 gov.mn
 edu.mn
@@ -4027,17 +4027,17 @@ org.mo
 edu.mo
 gov.mo
 
-// mobi : https://en.wikipedia.org/wiki/.mobi
+// mobi : https://www.iana.org/domains/root/db/mobi.html
 mobi
 
 // mp : http://www.dot.mp/
 // Confirmed by registry <dcamacho@saipan.com> 2008-06-17
 mp
 
-// mq : https://en.wikipedia.org/wiki/.mq
+// mq : https://www.iana.org/domains/root/db/mq.html
 mq
 
-// mr : https://en.wikipedia.org/wiki/.mr
+// mr : https://www.iana.org/domains/root/db/mr.html
 mr
 gov.mr
 
@@ -4057,7 +4057,7 @@ edu.mt
 net.mt
 org.mt
 
-// mu : https://en.wikipedia.org/wiki/.mu
+// mu : https://www.iana.org/domains/root/db/mu.html
 mu
 com.mu
 net.mu
@@ -4070,7 +4070,7 @@ or.mu
 // museum : https://welcome.museum/wp-content/uploads/2018/05/20180525-Registration-Policy-MUSEUM-EN_VF-2.pdf https://welcome.museum/buy-your-dot-museum-2/
 museum
 
-// mv : https://en.wikipedia.org/wiki/.mv
+// mv : https://www.iana.org/domains/root/db/mv.html
 // "mv" included because, contra Wikipedia, google.mv exists.
 mv
 aero.mv
@@ -4164,13 +4164,13 @@ nc
 asso.nc
 nom.nc
 
-// ne : https://en.wikipedia.org/wiki/.ne
+// ne : https://www.iana.org/domains/root/db/ne.html
 ne
 
-// net : https://en.wikipedia.org/wiki/.net
+// net : https://www.iana.org/domains/root/db/net.html
 net
 
-// nf : https://en.wikipedia.org/wiki/.nf
+// nf : https://www.iana.org/domains/root/db/nf.html
 nf
 com.nf
 net.nf
@@ -4213,7 +4213,7 @@ nom.ni
 org.ni
 web.ni
 
-// nl : https://en.wikipedia.org/wiki/.nl
+// nl : https://www.iana.org/domains/root/db/nl.html
 //      https://www.sidn.nl/
 //      ccTLD for the Netherlands
 nl
@@ -4999,10 +4999,10 @@ org.nr
 net.nr
 com.nr
 
-// nu : https://en.wikipedia.org/wiki/.nu
+// nu : https://www.iana.org/domains/root/db/nu.html
 nu
 
-// nz : https://en.wikipedia.org/wiki/.nz
+// nz : https://www.iana.org/domains/root/db/nz.html
 // Submitted by registry <jay@nzrs.net.nz>
 nz
 ac.nz
@@ -5022,7 +5022,7 @@ org.nz
 parliament.nz
 school.nz
 
-// om : https://en.wikipedia.org/wiki/.om
+// om : https://www.iana.org/domains/root/db/om.html
 om
 co.om
 com.om
@@ -5037,7 +5037,7 @@ pro.om
 // onion : https://tools.ietf.org/html/rfc7686
 onion
 
-// org : https://en.wikipedia.org/wiki/.org
+// org : https://www.iana.org/domains/root/db/org.html
 org
 
 // pa : http://www.nic.pa/
@@ -5072,7 +5072,7 @@ com.pf
 org.pf
 edu.pf
 
-// pg : https://en.wikipedia.org/wiki/.pg
+// pg : https://www.iana.org/domains/root/db/pg.html
 *.pg
 
 // ph : http://www.domains.ph/FAQ2.asp
@@ -5335,7 +5335,7 @@ org.pn
 edu.pn
 net.pn
 
-// post : https://en.wikipedia.org/wiki/.post
+// post : https://www.iana.org/domains/root/db/post.html
 post
 
 // pr : http://www.nic.pr/index.asp?f=1
@@ -5350,7 +5350,7 @@ pro.pr
 biz.pr
 info.pr
 name.pr
-// these aren't mentioned on nic.pr, but on https://en.wikipedia.org/wiki/.pr
+// these aren't mentioned on nic.pr, but on https://www.iana.org/domains/root/db/pr.html
 est.pr
 prof.pr
 ac.pr
@@ -5369,7 +5369,7 @@ law.pro
 med.pro
 recht.pro
 
-// ps : https://en.wikipedia.org/wiki/.ps
+// ps : https://www.iana.org/domains/root/db/ps.html
 // http://www.nic.ps/registration/policy.html#reg
 ps
 edu.ps
@@ -5391,7 +5391,7 @@ publ.pt
 com.pt
 nome.pt
 
-// pw : https://en.wikipedia.org/wiki/.pw
+// pw : https://www.iana.org/domains/root/db/pw.html
 pw
 co.pw
 ne.pw
@@ -5505,7 +5505,7 @@ tv.sd
 gov.sd
 info.sd
 
-// se : https://en.wikipedia.org/wiki/.se
+// se : https://www.iana.org/domains/root/db/se.html
 // Submitted by registry <patrik.wallstrom@iis.se>
 se
 a.se
@@ -5565,14 +5565,14 @@ gov.sh
 org.sh
 mil.sh
 
-// si : https://en.wikipedia.org/wiki/.si
+// si : https://www.iana.org/domains/root/db/si.html
 si
 
 // sj : No registrations at this time.
 // Submitted by registry <jarle@uninett.no>
 sj
 
-// sk : https://en.wikipedia.org/wiki/.sk
+// sk : https://www.iana.org/domains/root/db/sk.html
 // list of 2nd level domains ?
 sk
 
@@ -5585,10 +5585,10 @@ edu.sl
 gov.sl
 org.sl
 
-// sm : https://en.wikipedia.org/wiki/.sm
+// sm : https://www.iana.org/domains/root/db/sm.html
 sm
 
-// sn : https://en.wikipedia.org/wiki/.sn
+// sn : https://www.iana.org/domains/root/db/sn.html
 sn
 art.sn
 com.sn
@@ -5607,7 +5607,7 @@ me.so
 net.so
 org.so
 
-// sr : https://en.wikipedia.org/wiki/.sr
+// sr : https://www.iana.org/domains/root/db/sr.html
 sr
 
 // ss : https://registry.nic.ss/
@@ -5636,7 +5636,7 @@ principe.st
 saotome.st
 store.st
 
-// su : https://en.wikipedia.org/wiki/.su
+// su : https://www.iana.org/domains/root/db/su.html
 su
 
 // sv : http://www.svnet.org.sv/niveldos.pdf
@@ -5647,12 +5647,12 @@ gob.sv
 org.sv
 red.sv
 
-// sx : https://en.wikipedia.org/wiki/.sx
+// sx : https://www.iana.org/domains/root/db/sx.html
 // Submitted by registry <jcvignes@openregistry.com>
 sx
 gov.sx
 
-// sy : https://en.wikipedia.org/wiki/.sy
+// sy : https://www.iana.org/domains/root/db/sy.html
 // see also: http://www.gobin.info/domainname/sy.doc
 sy
 edu.sy
@@ -5662,31 +5662,31 @@ mil.sy
 com.sy
 org.sy
 
-// sz : https://en.wikipedia.org/wiki/.sz
+// sz : https://www.iana.org/domains/root/db/sz.html
 // http://www.sispa.org.sz/
 sz
 co.sz
 ac.sz
 org.sz
 
-// tc : https://en.wikipedia.org/wiki/.tc
+// tc : https://www.iana.org/domains/root/db/tc.html
 tc
 
-// td : https://en.wikipedia.org/wiki/.td
+// td : https://www.iana.org/domains/root/db/td.html
 td
 
-// tel: https://en.wikipedia.org/wiki/.tel
+// tel: https://www.iana.org/domains/root/db/tel.html
 // http://www.telnic.org/
 tel
 
 // tf : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf
 tf
 
-// tg : https://en.wikipedia.org/wiki/.tg
+// tg : https://www.iana.org/domains/root/db/tg.html
 // http://www.nic.tg/
 tg
 
-// th : https://en.wikipedia.org/wiki/.th
+// th : https://www.iana.org/domains/root/db/th.html
 // Submitted by registry <krit@thains.co.th>
 th
 ac.th
@@ -5715,10 +5715,10 @@ org.tj
 test.tj
 web.tj
 
-// tk : https://en.wikipedia.org/wiki/.tk
+// tk : https://www.iana.org/domains/root/db/tk.html
 tk
 
-// tl : https://en.wikipedia.org/wiki/.tl
+// tl : https://www.iana.org/domains/root/db/tl.html
 tl
 gov.tl
 
@@ -5750,7 +5750,7 @@ org.tn
 perso.tn
 tourism.tn
 
-// to : https://en.wikipedia.org/wiki/.to
+// to : https://www.iana.org/domains/root/db/to.html
 // Submitted by registry <egullich@colo.to>
 to
 com.to
@@ -5810,12 +5810,12 @@ name.tt
 gov.tt
 edu.tt
 
-// tv : https://en.wikipedia.org/wiki/.tv
+// tv : https://www.iana.org/domains/root/db/tv.html
 // Not listing any 2LDs as reserved since none seem to exist in practice,
 // Wikipedia notwithstanding.
 tv
 
-// tw : https://en.wikipedia.org/wiki/.tw
+// tw : https://www.iana.org/domains/root/db/tw.html
 tw
 edu.tw
 gov.tw
@@ -5944,7 +5944,7 @@ ne.ug
 com.ug
 org.ug
 
-// uk : https://en.wikipedia.org/wiki/.uk
+// uk : https://www.iana.org/domains/root/db/uk.html
 // Submitted by registry <Michael.Daly@nominet.org.uk>
 uk
 ac.uk
@@ -5959,7 +5959,7 @@ plc.uk
 police.uk
 *.sch.uk
 
-// us : https://en.wikipedia.org/wiki/.us
+// us : https://www.iana.org/domains/root/db/us.html
 us
 dni.us
 fed.us
@@ -6227,10 +6227,10 @@ com.uz
 net.uz
 org.uz
 
-// va : https://en.wikipedia.org/wiki/.va
+// va : https://www.iana.org/domains/root/db/va.html
 va
 
-// vc : https://en.wikipedia.org/wiki/.vc
+// vc : https://www.iana.org/domains/root/db/vc.html
 // Submitted by registry <kshah@ca.afilias.info>
 vc
 com.vc
@@ -6264,7 +6264,7 @@ store.ve
 tec.ve
 web.ve
 
-// vg : https://en.wikipedia.org/wiki/.vg
+// vg : https://www.iana.org/domains/root/db/vg.html
 vg
 
 // vi : http://www.nic.vi/newdomainform.htm
@@ -6362,7 +6362,7 @@ vinhlong.vn
 vinhphuc.vn
 yenbai.vn
 
-// vu : https://en.wikipedia.org/wiki/.vu
+// vu : https://www.iana.org/domains/root/db/vu.html
 // http://www.vunic.vu/
 vu
 com.vu
@@ -6373,7 +6373,7 @@ org.vu
 // wf : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf
 wf
 
-// ws : https://en.wikipedia.org/wiki/.ws
+// ws : https://www.iana.org/domains/root/db/ws.html
 // http://samoanic.ws/index.dhtml
 ws
 com.ws


### PR DESCRIPTION
This PR addresses issue #2135 by replacing Wikipedia URLs with IANA page links in the legacy ICANN section comments.

#### Changes:
- Used a regex pattern to find and replace Wikipedia URLs (`https://en.wikipedia.org/wiki/.example`) with the corresponding IANA page links (`https://www.iana.org/domains/root/db/example.html`), where available.
  
#### Validation:
- Utilized Python's `requests` and `beautifulsoup` libraries to validate that all linked IANA pages exist and are valid before replacing.
  - Validation results: [beautifulsoup_validation.txt](https://github.com/user-attachments/files/16900452/beautifulsoup_validation.txt)
