### PR TITLE
Remove `autocode.dev` (Rollback #1617)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12154,10 +12154,6 @@ cdn.prod.atlassian-dev.net
 // Submitted by Lukas Reschke <lukas@authentick.net>
 translated.page
 
-// Autocode : https://autocode.com
-// Submitted by Jacob Lee <jacob@autocode.com>
-autocode.dev
-
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.link


### PR DESCRIPTION
confirmed by initial requestor: https://github.com/publicsuffix/list/pull/1617#discussion_r1746319262