### PR TITLE
Add gob.cu nat.cu (#1695)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -863,12 +863,12 @@ sa.cr
 cu
 com.cu
 edu.cu
-org.cu
-net.cu
 gob.cu
 gov.cu
 inf.cu
 nat.cu
+net.cu
+org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
 // cv : http://www.dns.cv/tldcv_portal/do?com=DS;5446457100;111;+PAGE(4000018)+K-CAT-CODIGO(RDOM)+RCNT(100); <- registration rules

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -865,8 +865,10 @@ com.cu
 edu.cu
 org.cu
 net.cu
+gob.cu
 gov.cu
 inf.cu
+nat.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
 // cv : http://www.dns.cv/tldcv_portal/do?com=DS;5446457100;111;+PAGE(4000018)+K-CAT-CODIGO(RDOM)+RCNT(100); <- registration rules


### PR DESCRIPTION
To address #1695 

Source: https://www.nic.cu/docum_det.php?doc_id=2&opt=1

> com.cu: para personas jurídicas con actividades comerciales de bienes y servicios con fines de lucro;
> edu.cu: para definir centros del sistema de Educación;
> gob.cu: para órganos y organismos de la Administración Central del Estado y otras estructuras de Gobierno;
> inf.cu: para entidades relacionadas con la actividad de información científica y proveedores de información o contenidos; 
> nat.cu: para personas naturales residentes en el país.
> net.cu: para Proveedores Públicos de Telecomunicaciones;
> org.cu: para Organizaciones no gubernamentales y sin fines de lucro;

Although gov.cu is not listed by the registry and may have been mistakenly included as a legacy entry, this PR preserves it for now out of caution. However, maintainers are free to edit and remove gov.cu at their discretion, as there is no live example of its use, only gob.cu.