### PR TITLE
Add `co.ss` ccTLD (ICANN section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5614,6 +5614,7 @@ sr
 // Submitted by registry <technical@nic.ss>
 ss
 biz.ss
+co.ss
 com.ss
 edu.ss
 gov.ss


### PR DESCRIPTION
This PR attempts to address issue #2078 

Registrars are [promoting](https://www.101domain.com/co_ss.htm) the launch of .co.ss domains, which are currently in the sunrise period. General availability will begin on November 1, 2024.

Registrar Sources:
- https://www.101domain.com/co_ss.htm
- https://domgate.com/whois-and-domain-registration/.co.ss
- https://www.lexsynergy.com/tld/co.ss
- https://www.juhub.ss/domain/

National Communication Authority (NCA) source: 
- https://x.com/NCA_SSD/status/1811778704059547783

![image](https://github.com/user-attachments/assets/7f00fbe1-3140-4e25-845b-f6301a7493cb)

![image](https://github.com/user-attachments/assets/049c99ee-552f-43bc-a9f4-a865251d4d6a)

I sent an email to the ssNIC contacts (https://www.iana.org/domains/root/db/ss.html) but have not received any response.