### PR TITLE
Add `org.ao`, `edu.ao`, `gov.ao` ccTLD (ICANN section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -180,7 +180,7 @@ edu.ao
 gov.ao
 gv.ao
 og.ao
-org.co
+org.ao
 co.ao
 pb.ao
 it.ao

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -176,8 +176,11 @@ org.am
 // http://www.dns.ao/REGISTR.DOC
 ao
 ed.ao
+edu.ao
+gov.ao
 gv.ao
 og.ao
+org.co
 co.ao
 pb.ao
 it.ao


### PR DESCRIPTION
Based on information from the IANA page for .AO domains (https://www.iana.org/domains/root/db/ao.html), the registration services are available at http://www.dns.ao/.

According to the official registry site (http://www.dns.ao/), the suffixes currently available for registration under the .AO domain are:

- .ao
- .it.ao
- .co.ao
- .org.ao
- .edu.ao
- .gov.ao

![image](https://github.com/user-attachments/assets/c9b9624a-b9d3-4214-8a19-e439a0aee56d)

However, the current PSL shows the following suffixes:

- .ao
- .ed.ao
- .gv.ao
- .og.ao
- .co.ao
- .pb.ao
- .it.ao

Notably, the registry has announced on 2024-07-11 that the domains “.ed.ao” and “.og.ao” will be phased out. This announcement can be found here: https://www.dns.ao/ao/noticias/titulares-de-dominios-ed-ao-e-og-ao-tem-30-dias-para-conversao/

Recently, the registry accredited an official registrar, as announced here: https://www.dns.ao/ao/noticias/novo-revendedor-oficial-autorizado/. The list of newly available domain suffixes and pricing on the registrar's website (https://www.cloudspace.ao/domain) also aligns with the information found on the registry's website.

For now, this PR remains cautious and does not remove any domains, only adding .org.ao, .edu.ao, and .gov.ao.

Attempts to contact ao@dns.ao have received no response as of the date of this PR submission.