### PR TITLE
remove `q-a.eu.org`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13100,7 +13100,6 @@ nz.eu.org
 paris.eu.org
 pl.eu.org
 pt.eu.org
-q-a.eu.org
 ro.eu.org
 ru.eu.org
 se.eu.org


### PR DESCRIPTION
Similar PR to #2099.

Reasons for removal:
- Not listed on nic.eu.org's open domains page: https://nic.eu.org/opendomains.html
- No sites found when searching `site:q-a.eu.org`
- No SSL certificates have been issued for this subdomain: https://crt.sh/?q=q-a.eu.org
- No subdomains were found when searching on https://subdomainfinder.c99.nl/

It should be safe to remove this domain as there does not seem to be evidence of usage.