### PR TITLE
remove `paris.eu.org`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13097,7 +13097,6 @@ ng.eu.org
 nl.eu.org
 no.eu.org
 nz.eu.org
-paris.eu.org
 pl.eu.org
 pt.eu.org
 q-a.eu.org


### PR DESCRIPTION
Reasons for removal:
- Not listed on nic.eu.org's open domains page: https://nic.eu.org/opendomains.html
- No sites found when searching `site:paris.eu.org`
- No subdomains were found when searching on https://subdomainfinder.c99.nl/

There was one subdomain found with active SSL certificates (https://crt.sh/?q=paris.eu.org), `cdn.paris.eu.org`, it does have active NS records pointing to Cloudflare, however I cannot find any live sites or any records on that zone when using [NSLookup.io](https://www.nslookup.io/domains/cdn.paris.eu.org/dns-records). The SSL certificates are likely auto generated by Cloudflare, as there are no active sites that can be found on that subdomain.

It should be safe to remove this domain as there does not seem to be evidence of usage. Even if `cdn.paris.eu.org` counts as usage it is not enough to keep this subdomain on the PSL anyway.