### PR TITLE
Remove discontinued Jelastic domains (from #1095)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13914,7 +13914,6 @@ iserv.dev
 // Submitted by Ihor Kolodyuk <ik@jelastic.com>
 mel.cloudlets.com.au
 cloud.interhostsolutions.be
-mycloud.by
 alp1.ae.flow.ch
 appengine.flow.ch
 es-1.axarnet.cloud
@@ -13936,7 +13935,6 @@ us.reclaim.cloud
 ch.trendhosting.cloud
 de.trendhosting.cloud
 jele.club
-amscompute.com
 dopaas.com
 paas.hosted-by-previder.com
 rag-cloud.hosteur.com
@@ -13944,10 +13942,8 @@ rag-cloud-ch.hosteur.com
 jcloud.ik-server.com
 jcloud-ver-jpc.ik-server.com
 demo.jelastic.com
-kilatiron.com
 paas.massivegrid.com
 jed.wafaicloud.com
-lon.wafaicloud.com
 ryd.wafaicloud.com
 j.scaleforce.com.cy
 jelastic.dogado.eu
@@ -13959,18 +13955,14 @@ mircloud.host
 paas.beebyte.io
 sekd1.beebyteapp.io
 jele.io
-cloud-fr1.unispace.io
 jc.neen.it
-cloud.jelastic.open.tim.it
 jcloud.kz
-upaas.kazteleport.kz
 cloudjiffy.net
 fra1-de.cloudjiffy.net
 west1-us.cloudjiffy.net
 jls-sto1.elastx.net
 jls-sto2.elastx.net
 jls-sto3.elastx.net
-faststacks.net
 fr-1.paas.massivegrid.net
 lon-1.paas.massivegrid.net
 lon-2.paas.massivegrid.net
@@ -13980,11 +13972,9 @@ sg-1.paas.massivegrid.net
 jelastic.saveincloud.net
 nordeste-idc.saveincloud.net
 j.scaleforce.net
-jelastic.tsukaeru.net
 sdscloud.pl
 unicloud.pl
 mircloud.ru
-jelastic.regruhosting.ru
 enscaled.sg
 jele.site
 jelastic.team


### PR DESCRIPTION
https://github.com/publicsuffix/list/pull/1095#issuecomment-2334331448  by @tuchinsun :

> Hi, Thank you for the notification. I've reviewed our existing list, and the following domains(subdomains) can be deleted from the PSL list
> 
> ```
> mycloud.by
> amscompute.com
> kilatiron.com
> lon.wafaicloud.com
> cloud-fr1.unispace.io
> cloud.jelastic.open.tim.it
> faststacks.net
> jelastic.tsukaeru.net
> jelastic.regruhosting.ru
> upaas.kazteleport.kz
> ```

The connection between Jelastic and the user who provided this confirmation can be identified through #1151.