### PR TITLE
Update `kh` ccTLD (ICANN section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3721,8 +3721,15 @@ edu.kg
 gov.kg
 mil.kg
 
-// kh : http://www.mptc.gov.kh/dns_registration.htm
-*.kh
+// kh : https://www.domain.gov.kh/help/general-info
+// https://www.domain.gov.kh/static/media/Guideline-DNS.8f09c480e5a6fe54936b.pdf
+kh
+com.kh
+edu.kh
+mil.kh
+net.kh
+org.kh
+per.kh
 
 // ki : http://www.ki/dns/index.html
 ki

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3726,6 +3726,7 @@ mil.kg
 kh
 com.kh
 edu.kh
+gov.kh
 mil.kh
 net.kh
 org.kh


### PR DESCRIPTION
This entry is outdated compared to the official registry source.

https://github.com/publicsuffix/list/blob/769cda5b33403e39a470f69f38f0af6b132d6ddf/public_suffix_list.dat#L3724-L3725

Historically, `kh` initially allowed registrations only at the second level under specific categories (such as .com.kh, .org.kh, etc.), before eventually permitting direct registrations at the top level.

## `.kh`-level domains

Since mid-2022, Cambodian companies are required to use the .kh domain name for their websites and email addresses, with a stated deadline of January 2023. However, this deadline does not seem to have been strictly enforced.

Registry sources: 
https://domain.gov.kh/help/how-to-register
https://trc.gov.kh/en/dns-registration-kh/

By [searching](https://www.google.com/search?q=site%3Akh+-com.kh+-edu.kh+-gov.kh+-org.kh+-net.kh+-mil.kh&uact=5) `site:kh -com.kh -edu.kh -gov.kh -org.kh -net.kh -mil.kh` on Google, **new registrants** of the `.kh`-level domains can be observed, and including the `*.kh` entry in the PSL may cause issues for some of these websites in certain cases.

![image](https://github.com/user-attachments/assets/abdd27ea-08ec-4fc0-8d22-f2af3fe43ee0)

The Telecommunication Regulator of Cambodia (TRC) is currently responsible for managing .kh domain registrations.

## Second level `kh` domains

Registry source: https://www.domain.gov.kh/help/general-info

1. **.com.kh**: For commercial or public enterprises.  
2. **.org.kh**: For organizations, associations, or unions.  
3. **.edu.kh**: For public and private educational institutions.  
4. **.net.kh**: For companies or institutions providing computer network services.

Registry source: https://www.domain.gov.kh/static/media/Guideline-DNS.8f09c480e5a6fe54936b.pdf

- **.gov.kh**: For government institutions or organizations.
- **.mil.kh**: For military institutions or entities under the Ministry of Defense.
- **.com.kh**: For commercial or public enterprises.
- **.net.kh**: For companies or institutions providing internet network services.
- **.org.kh**: For organizations, associations, or unions.
- **.edu.kh**: For public and private educational institutions and universities.
- **.per.kh**: For personal use by Cambodian citizens.

## Registry Response (**Pending**)

I have attempted to contact the registry via email but have not yet received a response as of this PR submission.

https://www.icann.org/en/system/files/files/octo-011-18may20-en.pdf