### PR TITLE
Add `hf.space` and `static.hf.space` to `public_suffix_list.dat`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15763,4 +15763,9 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// Hugging Face: https://huggingface.co
+// Submitted by Eliott Coyac <website@huggingace.co>
+hf.space
+static.hf.space
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13781,6 +13781,11 @@ ie.ua
 // HostyHosting : https://hostyhosting.com
 hostyhosting.io
 
+// Hugging Face: https://huggingface.co
+// Submitted by Eliott Coyac <website@huggingace.co>
+hf.space
+static.hf.space
+
 // Hypernode B.V. : https://www.hypernode.com/
 // Submitted by Cipriano Groenendal <security@nl.team.blue>
 hypernode.io
@@ -15762,10 +15767,5 @@ bss.design
 basicserver.io
 virtualserver.io
 enterprisecloud.nu
-
-// Hugging Face: https://huggingface.co
-// Submitted by Eliott Coyac <website@huggingace.co>
-hf.space
-static.hf.space
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13782,7 +13782,7 @@ ie.ua
 hostyhosting.io
 
 // Hugging Face: https://huggingface.co
-// Submitted by Eliott Coyac <website@huggingace.co>
+// Submitted by Eliott Coyac <website@huggingface.co>
 hf.space
 static.hf.space
 


### PR DESCRIPTION
To isolate user-created spaces between each other.

Spaces have `*.static.hf.space` domains for space composed of static files only, and `*.hf.space` domains when they run a backend.

# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (`make test`)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s). **=> extending the domain is done, waiting for info to propagate to the registrar**

__Submitter affirms the following:__ 

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Hugging Face is a repository host for ML models, datasets, and ML demos - "Spaces". Similar to Github, but specialized towards Machine Learing Models/Data/Code.

The request is for the purpose of Spaces - of which a list of popular ones is available at https://huggingface.co/spaces. They are user-created or org-created demos, that can run on our infra or be comprised of static files.

My role in the organization is as a software engineer in charge of maintaining the "Hub"- the site served at https://huggingface.co. 

**Organization Website:**

https://huggingface.co

## Reason for PSL Inclusion

To prevent users from setting cookies on the `hf.space` and `static.hf.space` domains. We control a proxy so we can filter out all `Set-Cookie` responses by the backends, unfortunately we have no way of blocking client-side `document.cookie=...` javascript from executing with domain `.hf.space`.

This allows attackers from "cookie-bombing" the domain, causing the browser of the victim to send massive cookie headers and interfere with AWS Cloudfront, ... making spaces unusable for the victim until they clear their cookies.

### Example of Spaces URLs::

- For the `hf.space` rule, https://fffiloni-rb-modulation.hf.space (Spaces with an actual backend)
- For the `static.hf.space` rule, https://coyotte508-client-side-oauth.static.hf.space (static files)

Anyone can create a Space at https://huggingface.co/new-space, provided an email-verified account (no payment required for basic hardware or static spaces)

**Number of users this request is being made to serve:**

https://huggingface.co has over 5 million users registered. The spaces serve 100ks of users monthly, trending spaces have thousands of likes.

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->

```
dig +short TXT _psl.hf.space
"https://github.com/publicsuffix/list/pull/2157"

dig +short TXT _psl.static.hf.space
"https://github.com/publicsuffix/list/pull/2157"
```

## Results of Syntax Checker (`make test`)

<details>
<summary>Results</summary>

```console
make test                                                                                                      
cd linter;                                \
  ./pslint_selftest.sh;                     \
  ./pslint.py ../public_suffix_list.dat;
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
  cd libpsl;                                                                    \
  git pull;                                                                     \
  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
  echo "CLEANFILES =" >> gtk-doc.make;                                          \
  autoreconf --install --force --symlink;
Déjà à jour.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file `version.txt' included several times
configure.ac:4: warning: file `version.txt' included several times
aclocal.m4:765: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:369: warning: file `version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/home/coyotte508/code/list/public_suffix_list.dat --with-psl-testfile=/home/coyotte508/code/list/tests/tests.txt && make -s clean && make -s check -j4
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
 rm -f psl
Making clean in fuzz
 rm -f libpsl_icu_fuzzer libpsl_icu_load_fuzzer libpsl_icu_load_dafsa_fuzzer
Making clean in tests
 rm -f test-is-public test-is-public-all test-is-cookie-domain-acceptable test-is-public-builtin test-registrable-domain
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       common.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```

</details>