### PR TITLE
Enable DNS validation in psltool

### DIFF
--- a/tools/internal/parser/errors.go
+++ b/tools/internal/parser/errors.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"fmt"
+
+	"github.com/publicsuffix/list/tools/internal/domain"
 )
 
 // ErrInvalidEncoding reports that the input is encoded with
@@ -180,4 +182,15 @@ type ErrConflictingSuffixAndException struct {
 
 func (e ErrConflictingSuffixAndException) Error() string {
 	return fmt.Sprintf("%s: suffix %s conflicts with exception in wildcard at %s", e.LocationString(), e.Domain, e.Wildcard.LocationString())
+}
+
+type ErrIncorrectDNSRecord struct {
+	SourceRange
+	Domain domain.Name
+	gh_pr_id int
+	dns_pr_id int
+}
+
+func (e ErrIncorrectDNSRecord) Error() string {
+	return fmt.Sprintf("%s: domain %s does not have the right PR ID in _psl DNS record: DNS: %d (should be %d like on Github)", e.LocationString(), e.Domain)
 }

--- a/tools/psltool/psltool.go
+++ b/tools/psltool/psltool.go
@@ -143,6 +143,7 @@ func runValidate(env *command.Env, path string) error {
 	errs = append(errs, parser.ValidateOffline(psl)...)
 	if validateArgs.Online {
 		// TODO: no online validations implemented yet.
+		parser.ValidateOnline(psl, nil)
 	}
 
 	clean := psl.MarshalPSL()
@@ -187,11 +188,12 @@ func runCheckPR(env *command.Env, prStr string) error {
 
 	before, _ := parser.Parse(withoutPR)
 	after, errs := parser.Parse(withPR)
-	after.SetBaseVersion(before, true)
+	after.SetBaseVersion(before, false)
 	errs = append(errs, after.Clean()...)
 	errs = append(errs, parser.ValidateOffline(after)...)
-	if validateArgs.Online {
-		// TODO: no online validations implemented yet.
+	if checkPRArgs.Online {
+		parser.ValidateOnline(after, &pr)
+
 	}
 
 	clean := after.MarshalPSL()


### PR DESCRIPTION
@danderson If you have a few minutes maybe you can answer some questions for me. :)
1. I disabled `wholeSuffixBlocks bool` because I need to distinguish between suffixes which have changed in this PR, so I can compare the PR ID and suffixes which belong to the same entity so I can check if the old _psl DNS record is still present.
2. I am now nesting a loop for the private section, with a loop for the entity, with a loop for the suffixes. That seems a bit weird since there is an interface `for _, suffix := range BlocksOfType[*Suffix](suffixes) {` which seems like I should be able to just iterate all the suffixes, but there doesn't seem to be any filtering. Could you clarify what the intent was here?