### PR TITLE
Remove `dyn53.io` to rollback #820

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14727,10 +14727,6 @@ platterp.us
 // Submitted by Henning Pohl <infra@pley.com>
 pley.games
 
-// Port53 : https://port53.io/
-// Submitted by Maximilian Schieder <maxi@zeug.co>
-dyn53.io
-
 // Porter : https://porter.run/
 // Submitted by Rudraksh MK <rudi@porter.run>
 onporter.run


### PR DESCRIPTION
This PR is to remove dyn53.io as a rollback for #820

- I [attempted](https://github.com/publicsuffix/list/pull/820#issuecomment-2330553290) to contact the original requester through a GitHub mention, but received no response for over 2 weeks.
- ⚠️ ~~Email confirmation yet to be sent.~~ Pending reply. Sent on 09/18/2024 to both the email listed in PSL and the requestor's GitHub profile email.
- The organization's website (https://port53.io) is not functioning and is using domain parking nameservers.
- The [Google search](https://www.google.com/search?q=site%3Adyn53.io) and [Bing search](https://www.bing.com/search?&q=site%3Adyn53.io) shows no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=dyn53.io) reveals no active SSL certificates in use.
- Running `dig +short TXT _psl.dyn53.io` no longer returns the required record value.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/dyn53.io/relations)].