### PR TITLE
Remove `daplie.me` to rollback commit a4d8335

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12549,11 +12549,6 @@ firm.dk
 reg.dk
 store.dk
 
-// Daplie, Inc : https://daplie.com
-// Submitted by AJ ONeal <aj@daplie.com>
-daplie.me
-localhost.daplie.me
-
 // dappnode.io : https://dappnode.io/
 // Submitted by Abel Boldu / DAppNode Team <community@dappnode.io>
 dyndns.dappnode.io


### PR DESCRIPTION
This PR is to remove `daplie.me` to rollback commit a4d8335

Evidence:

- The WHOIS creation date 2022-05-14 is later than the PSL inclusion date, suggesting the domain was likely allowed to expire.
- Attempts to contact via email (aj@daplie.com) were unsuccessful - no MX record at `daplie.com`
- Attempted to contact the original requester through a GitHub mention in #74, but there has been no response for over 2 weeks.
- The organization website (https://daplie.com) is not functioning.
- The [Google search](https://www.google.com/search?q=site%3Adaplie.me) and [Bing search](https://www.bing.com/search?&q=site%3Adaplie.me) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=daplie.me) reveals no active SSL certificates in use.
- Running `dig +short TXT _psl.daplie.me` no longer returns the required record value.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/daplie.me/relations)] (no resolvable subdomains)