### PR TITLE
Remove `bounty-full.com` to rollback commit e54599a

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15161,12 +15161,6 @@ vipsinaapp.com
 // Submitted by Skylar Challand <support@siteleaf.com>
 siteleaf.net
 
-// Skyhat : http://www.skyhat.io
-// Submitted by Shante Adam <shante@skyhat.io>
-bounty-full.com
-alpha.bounty-full.com
-beta.bounty-full.com
-
 // Small Technology Foundation : https://small-tech.org
 // Submitted by Aral Balkan <aral@small-tech.org>
 small-web.org


### PR DESCRIPTION
This PR is to remove bounty-full.com, alpha.bounty-full.com, and beta.bounty-full.com as a rollback for commit e54599a

Evidence:

- Attempted to contact the original requester through a GitHub mention in #104, but received no response for over 2 weeks.
- The organization's website (http://www.skyhat.io) is not functioning.
- The [Google search](https://www.google.com/search?q=site%3Abounty-full.com) and [Bing search](https://www.bing.com/search?&q=site%3Abounty-full.com) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=bounty-full.com) reveals no active SSL certificates in use.
- ⚠️ Running `dig +short TXT _psl.bounty-full.com` still returns the required record value.
- No resolvable subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/bounty-full.com/relations)].
- ⚠️ Pending reply: Email confirmation sent on 09/18/2024 to the email listed in PSL. Unable to locate the GitHub profile because this was submitted 8 years ago.