### PR TITLE
Remove `certmgr.org` to rollback #225

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12346,10 +12346,6 @@ uk.net
 ae.org
 com.se
 
-// certmgr.org : https://certmgr.org
-// Submitted by B. Blechschmidt <hostmaster@certmgr.org>
-certmgr.org
-
 // Cityhost LLC  : https://cityhost.ua
 // Submitted by Maksym Rivtin <support@cityhost.net.ua>
 cx.ua


### PR DESCRIPTION
This PR is to remove `certmgr.org` to rollback #225

Evidence:

- The WHOIS creation date 2020-11-06 is later than the PSL inclusion date of #225, suggesting the domain was likely allowed to expire.
- Attempts to contact via email (admin@certmgr.org) were unsuccessful - no MX record at `certmgr.org`
- Attempted to contact the original requester through a GitHub mention in #225, but there has been no response for over 2 weeks.
- The organization website (https://certmgr.org) is not functioning.
- The [Google search](https://www.google.com/search?q=site%3Acertmgr.org) and [Bing search](https://www.bing.com/search?&q=site%3Acertmgr.org) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=certmgr.org) reveals no active SSL certificates in use. None active after 2024-06-24.
- Running `dig +short TXT _psl.certmgr.org` no longer returns the required record value.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/certmgr.org/relations)] (no resolvable subdomains).