### PR TITLE
Remove `mycd.eu` to rollback #233

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12290,10 +12290,6 @@ vm.bytemark.co.uk
 // Submitted by Antonio Lain <antlai@cafjs.com>
 cafjs.com
 
-// callidomus : https://www.callidomus.com/
-// Submitted by Marcus Popp <admin@callidomus.com>
-mycd.eu
-
 // Canva Pty Ltd : https://canva.com/
 // Submitted by Joel Aquilina <publicsuffixlist@canva.com>
 canva-apps.cn


### PR DESCRIPTION
This PR is to remove `mycd.eu` to rollback #233

Evidence:

- Attempts to contact via email (Marcus Popp at admin@callidomus.com) were unsuccessful - no MX record at `callidomus.com`.
- Attempted to contact the original requester through a GitHub mention in #233, but there has been no response for over 2 weeks.
- The organization website (https://www.callidomus.com/) is not functioning.
- The [Google search](https://www.google.com/search?q=site%3Amycd.eu) and [Bing search](https://www.bing.com/search?&q=site%3Amycd.eu) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=mycd.eu) reveals no active SSL certificates in use. None alive after 2021-04-22.
- Running `dig +short TXT _psl.mycd.eu` no longer returns the required record value.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/mycd.eu/relations)] (the second discovered some but none of them are resolvable subdomains).