### PR TITLE
Remove `forte.id` to rollback #1081

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14301,10 +14301,6 @@ routingthecloud.org
 // Submitted by Robert Böttinger <r@minion.systems>
 csx.cc
 
-// MobileEducation, LLC : https://joinforte.com
-// Submitted by Grayson Martin <grayson.martin@mobileeducation.us>
-forte.id
-
 // MODX Systems LLC : https://modx.com
 // Submitted by Elizabeth Southwell <elizabeth@modx.com>
 modx.dev


### PR DESCRIPTION
This PR is to remove `forte.id` to rollback PR #1081

Evidence:

- The domain has been SERVFAIL for a long time. Also noted in #2160. None of the authoritative DNS servers are available. 
- ⚠️ Attempted to contact the original requestor through a GitHub mention in #1081, but the requestor has been no longer associated with the organization.
- ⚠️ ~~Email confirmation yet to be sent.~~ Sent on 09/18/2024 to both the email listed in PSL and `contact@mobileeducation.us` which is found on the company website.
- The organization website (https://joinforte.com) is now a music service. No longer matching the described purpose in #1081 : `MobileEducation, LLC provides online education services, primarily Forte. We allow schools and teachers to register vanity urls as subdomains of forte.id to make it easy for their students to join with a short link.`
- The [Google search](https://www.google.com/search?q=site%3Aforte.id) and [Bing search](https://www.bing.com/search?&q=site%3Aforte.id) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=forte.id) reveals no active SSL certificates in use. None after 2023-04-15.
- Running `dig +short TXT _psl.forte.id` no longer returns the required record value. 
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/forte.id/relations)] (no resolvable subdomains).