### PR TITLE
Remove *.sensiosite.cloud and *.s5y.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15341,11 +15341,6 @@ supabase.co
 supabase.in
 supabase.net
 
-// Symfony, SAS : https://symfony.com/
-// Submitted by Fabien Potencier <fabien@symfony.com>
-*.sensiosite.cloud
-*.s5y.io
-
 // Syncloud : https://syncloud.org
 // Submitted by Boris Rybalkin <syncloud@syncloud.it>
 syncloud.it


### PR DESCRIPTION
These domains are not active anymore.

Related to https://github.com/publicsuffix/list/pull/572#issuecomment-2357609725
