### PR TITLE
Remove inactive or expired yombo domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15725,6 +15725,10 @@ official.academy
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com
 
+// Yombo : https://yombo.net
+// Submitted by Mitch Schwenk <mitch@yombo.net>
+yombo.me
+
 // Yunohost : https://yunohost.org
 // Submitted by Valentin Grimaud <security@yunohost.org>
 ynh.fr

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15725,16 +15725,6 @@ official.academy
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com
 
-// Yombo : https://yombo.net
-// Submitted by Mitch Schwenk <mitch@yombo.net>
-ybo.faith
-yombo.me
-homelink.one
-ybo.party
-ybo.review
-ybo.science
-ybo.trade
-
 // Yunohost : https://yunohost.org
 // Submitted by Valentin Grimaud <security@yunohost.org>
 ynh.fr


### PR DESCRIPTION
This PR is to remove `ybo.faith`, `homelink.one`, `ybo.party`, `ybo.review`, `ybo.science`, and `ybo.trade` due to evidence suggesting domain inactivity.

### General Evidence (applies to all domains):

- Attempts to contact via email (mitch@yombo.net) were unsuccessful – no MX record at `yombo.net`. No mail servers found.
- The organization website (https://yombo.net) is no longer functioning and now points to a stationary print business.
- Unable to identify any email address. `@yombo.net` has no MX.

As identified in #2172:

```
ybo.faith TIMEOUT
ybo.party TIMEOUT
ybo.review SERVFAIL
ybo.science TIMEOUT
ybo.trade TIMEOUT
```

### Domain-Specific Checks:

---

**1. `ybo.faith`**
- The [Google search](https://www.google.com/search?q=site%3Aybo.faith) and [Bing search](https://www.bing.com/search?q=site%3Aybo.faith) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=ybo.faith) reveals no active SSL certificates in use.
- ~~Running `dig +short TXT _psl.ybo.faith` no longer returns the required record value.~~ Not required at the time.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/ybo.faith/relations)].

---

**2. `homelink.one`**
- WHOIS `Creation Date: 2021-12-10T19:56:27Z` > PSL inclusion (pre-GitHub). The WHOIS creation dates for the domains are later than the PSL inclusion dates, suggesting the domains were likely allowed to expire.
- The [Google search](https://www.google.com/search?q=site%3Ahomelink.one) and [Bing search](https://www.bing.com/search?q=site%3Ahomelink.one) show 1 results for the domain.
  - Led to `This domain is available for sale!` page.
- [Certificate Transparency](https://crt.sh/?q=homelink.one) reveals no active SSL certificates in use.
- ~~Running `dig +short TXT _psl.homelink.one` no longer returns the required record value.~~  Not required at the time.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/homelink.one/relations)].

---

**3. `ybo.party`**
- The [Google search](https://www.google.com/search?q=site%3Aybo.party) and [Bing search](https://www.bing.com/search?q=site%3Aybo.party) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=ybo.party) reveals no active SSL certificates in use.
- ~~Running `dig +short TXT _psl.ybo.party` no longer returns the required record value.~~ Not required at the time.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/ybo.party/relations)].

---

**4. `ybo.review`**
- The [Google search](https://www.google.com/search?q=site%3Aybo.review) and [Bing search](https://www.bing.com/search?q=site%3Aybo.review) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=ybo.review) reveals no active SSL certificates in use.
- ~~Running `dig +short TXT _psl.ybo.review` no longer returns the required record value.~~ Not required at the time.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/ybo.review/relations)].

---

**5. `ybo.science`**
- The [Google search](https://www.google.com/search?q=site%3Aybo.science) and [Bing search](https://www.bing.com/search?q=site%3Aybo.science) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=ybo.science) reveals no active SSL certificates in use.
- ~~Running `dig +short TXT _psl.ybo.science` no longer returns the required record value.~~ Not required at the time.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/ybo.science/relations)].

---

**6. `ybo.trade`**
- The [Google search](https://www.google.com/search?q=site%3Aybo.trade) and [Bing search](https://www.bing.com/search?q=site%3Aybo.trade) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=ybo.trade) reveals no active SSL certificates in use.
- ~~Running `dig +short TXT _psl.ybo.trade` no longer returns the required record value.~~ Not required at the time.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/ybo.trade/relations)].

---

**7. `yombo.me`** to be revisited
- The [Google search](https://www.google.com/search?q=site%3Ayombo.me) and [Bing search](https://www.bing.com/search?q=site%3Ayombo.me) show 1 result (a DDNS homepage) for the domain but no subdomain.
- [Certificate Transparency](https://crt.sh/?q=yombo.me) reveals few active SSL certificates in use.
- Running `dig +short TXT _psl.yombo.me` still returns the required record value along with a note "reserved for upcoming projects"
- For this PR, keeping this entry just in case, but I will revisit after November to check for CT again. Likely this should be removed too by that time.