### PR TITLE
Remove `cnpy.gdn` to rollback #633

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12444,10 +12444,6 @@ objects.rma.cloudscale.ch
 // Submitted by Patrick Nielsen <patrick@clovyr.io>
 wnext.app
 
-// CNPY : https://cnpy.gdn
-// Submitted by Angelo Gladding <angelo@lahacker.net>
-cnpy.gdn
-
 // Co & Co : https://co-co.nl/
 // Submitted by Govert Versluis <govert@co-co.nl>
 *.otap.co


### PR DESCRIPTION
This PR is to remove `cnpy.gdn` to rollback #633

Related issue #2172 

Evidence:

- The WHOIS creation date `Creation Date: 2017-08-25T00:11:00Z` is later than the PSL inclusion date, suggesting the domain was likely allowed to expire.
- The organization website (https://cnpy.gdn) is not functioning.
- The [Google search](https://www.google.com/search?q=site%3Acnpy.gdn) and [Bing search](https://www.bing.com/search?&q=site%3Acnpy.gdn) show no results for the domain.
- [Certificate Transparency](https://crt.sh/?q=cnpy.gdn) reveals no active SSL certificates in use. Nothing after `2020-10-27`.
- From #2172: The domain `cnpy.gdn` is expired according to WHOIS. However, it still has NS records, and `_psl.cnpy.gdn` incorrectly points to #100, which is unrelated to `cnpy.gdn`. The correct PR reference should have been #633.
- From #2172: In PR #633, the owner of `cnpy.gdn` referred to `understory.live` as the user-facing website for the entity, but this domain is also expired and currently unregistered, as confirmed by WHOIS.
- From #2172: With an invalid `_psl` record and a lapsed registration, this seems like an obvious case for removal.
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/cnpy.gdn/relations)] (no resolvable subdomains). Some from VT but none of them are resolvable.
  

