### PR TITLE
Remove `n4t.co`, `now-dns.top`, `001www.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14505,7 +14505,6 @@ notion.site
 // Submitted by Steve Russell <steve@now-dns.com>
 dnsking.ch
 mypi.co
-001www.com
 myiphost.com
 forumz.info
 soundcast.me

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14505,7 +14505,6 @@ notion.site
 // Submitted by Steve Russell <steve@now-dns.com>
 dnsking.ch
 mypi.co
-n4t.co
 001www.com
 myiphost.com
 forumz.info
@@ -14519,7 +14518,6 @@ vpndns.net
 dynserv.org
 now-dns.org
 x443.pw
-now-dns.top
 ntdll.top
 freeddns.us
 


### PR DESCRIPTION
This PR is to remove `n4t.co` and `now-dns.top` to rollback commit #257

- Related issue: #2172

**n4t.co Evidence:**

- Attempts to contact the admin via email (listed at https://now-dns.com > Contact) have been unsuccessful for over 3 months.
- The [Google search](https://www.google.com/search?q=site%3An4t.co) and [Bing search](https://www.bing.com/search?&q=site%3An4t.co) show 1 results for the domain `n4t.co` but the subdomain is dead.
- [Certificate Transparency](https://crt.sh/?q=n4t.co) reveals no active SSL certificates in use.
- Running `dig +short TXT _psl.n4t.co` no longer returns the required record value. (EDIT: TXT record preservation was not required at the time.)
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/n4t.co/relations)] (no resolvable subdomains).

**now-dns.top Evidence:**

- Attempts to contact the admin via email (listed at https://now-dns.com > Contact) have been unsuccessful for over 3 months.
- It has been in `serverHold` status for a long time. `Domain Status: serverHold https://icann.org/epp#serverHold`
- The [Google search](https://www.google.com/search?q=site%3Anow-dns.top) and [Bing search](https://www.bing.com/search?&q=site%3Anow-dns.top) show no results for the domain `now-dns.top`.
- [Certificate Transparency](https://crt.sh/?q=now-dns.top) reveals no active SSL certificates in use.
- Running `dig +short TXT _psl.now-dns.top` no longer returns the required record value. (EDIT: TXT record preservation was not required at the time.)
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/now-dns.top/relations)] (no resolvable subdomains).

**001www.com Evidence:**

- Attempts to contact the admin via email (listed at https://now-dns.com > Contact) have been unsuccessful for over 3 months.
- It has been in `clientHold` status for a long time. `Domain Status: clientHold https://icann.org/epp#clientHold`
- The [Google search](https://www.google.com/search?q=site%3A001www.com) and [Bing search](https://www.bing.com/search?&q=site%3A001www.com) show some results for the domain `001www.com` but none of them are accessible websites.
- [Certificate Transparency](https://crt.sh/?q=001www.com) reveals no active SSL certificates in use.
- Running `dig +short TXT _psl.001www.com` no longer returns the required record value. (EDIT: TXT record preservation was not required at the time.)
- No subdomains were found by third-party tools [[1](https://subdomainfinder.c99.nl)] [[2](https://www.virustotal.com/gui/domain/001www.com/relations)] (no resolvable subdomains).

**Additional Information:**

- The service at https://now-dns.com is still running, but the status of their operation is uncertain. It is likely a dead/zombie project and there has been a lack of moderation, leading to abuse of existing domains that are alive. 
- Multiple domains were in clienthold or serverhold status set by the registrar or TLD registry.
- The admin has been unresponsive for several months despite multiple attempts to reach them via email. An example is #2113.