### PR TITLE
tools/internal/parser: remove exception for duplicate sections

### DIFF
--- a/tools/internal/parser/diff.go
+++ b/tools/internal/parser/diff.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"strings"
 )
 
 // SetBaseVersion sets the list's base of comparison to old, and
@@ -304,15 +303,7 @@ func (d *differ) makeKey(b Block, parentKey string) string {
 		// indirectly dirty the block, because the metadata comment
 		// includes the entire comment text in its identity, and will
 		// dirty the parent Suffixes.
-		//
-		// Two temporary exceptions: TransIP and MetaCentrum both have
-		// two blocks each, with different contact emails. Until those
-		// are fixed, also include the maintainer email in the
-		// identity to avoid constant false positives.
 		ret := fmt.Sprintf("%s;Suffixes,%q", parentKey, v.Info.Name)
-		if strings.Contains(v.Info.Name, "MetaCentrum") || strings.Contains(v.Info.Name, "TransIP") {
-			ret += fmt.Sprintf(",%v", v.Info.Maintainers)
-		}
 		return ret
 	case *Suffix:
 		return fmt.Sprintf("%s;Suffix,%q", parentKey, v.Domain)


### PR DESCRIPTION
Opened in relation to #2168 as it seems we are meant to keep CI changes separate, which was mentioned by @danderson in https://github.com/publicsuffix/list/pull/2168#issuecomment-2359018880.

*Only merge this PR once #2168 is merged, otherwise checks will likely fail.*