### PR TITLE
Remove domain:ktistory.com from PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14020,10 +14020,6 @@ js.org
 kaas.gg
 khplay.nl
 
-// Kakao : https://www.kakaocorp.com/
-// Submitted by JaeYoong Lee <cec@kakaocorp.com>
-ktistory.com
-
 // Kapsi : https://kapsi.fi
 // Submitted by Tomi Juntunen <erani@kapsi.fi>
 kapsi.fi


### PR DESCRIPTION
https://github.com/publicsuffix/list/pull/1493

Request to remove ktistory.com from the PSL
