### PR TITLE
rename `William Harrison` to `Harrison Network`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13689,6 +13689,14 @@ häkkinen.fi
 hs.run
 hs.zone
 
+// Harrison Network : https://hrsn.net
+// Submitted by William Harrison <psl@hrsn.net>
+wdh.app
+preview.wdh.app
+hrsn.dev
+t.hrsn.dev
+t.hrsn.net
+
 // Hashbang : https://hashbang.sh
 hashbang.sh
 
@@ -15640,14 +15648,6 @@ pages.wiardweb.com
 toolforge.org
 wmcloud.org
 wmflabs.org
-
-// William Harrison : https://wdharrison.com
-// Submitted by William Harrison <publicsuffix@wdharrison.com>
-wdh.app
-preview.wdh.app
-hrsn.dev
-t.hrsn.dev
-t.hrsn.net
 
 // WISP : https://wisp.gg
 // Submitted by Stepan Fedotov <stepan@wisp.gg>


### PR DESCRIPTION
Renaming my section as `Harrison Network` is more fitting considering it is not for personal use per se.