### PR TITLE
Sync changes to query.publicsuffix.zone

### DIFF
--- a/.github/workflows/sync-query-zone.yml
+++ b/.github/workflows/sync-query-zone.yml
@@ -1,0 +1,45 @@
+name: sync query zone
+
+on:
+  push:
+    branches:
+    - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install psl-dns
+    - name: Check out sync tools
+      uses: actions/checkout@v4
+      with:
+        repository: desec-io/desec-tools
+        path: desec-tools
+    - name: Check out PSL
+      uses: actions/checkout@v4
+      with:
+        repository: publicsuffix/list
+        path: list
+        sparse-checkout: 'public_suffix_list.dat'
+        sparse-checkout-cone-mode: false
+    - name: Run sync
+      env:
+        TOKEN: ${{ secrets.DESEC_TOKEN }}
+      working-directory: ./desec-tools
+      run: psl-dns_parse ../list/public_suffix_list.dat | ./patch_zone.sh query.publicsuffix.zone -
+    - name: Print PATCH request data
+      working-directory: ./desec-tools
+      run: cat *.json
+    - name: Print log
+      working-directory: ./desec-tools
+      run: cat *.log


### PR DESCRIPTION
A domain's public suffix can be looked up via DNS by appending `query.publicsuffix.zone` and querying resulting name for type PTR. For details, see https://publicsuffix.zone/.

People [have been complaining](https://github.com/sse-secure-systems/psl-dns/issues/6) that [this zone is not always up to date](https://github.com/sse-secure-systems/psl-dns/issues/7).

This commit adds a GitHub action that syncs new/removed entries whenever a change is made to the list on the master branch.

It has been running as a daily job for a few months in a separate repo, and has been working fine / no maintenance needed. However, it can't run there indefinitely, because [GitHub will disable scheduled actions on repos that have no commits for 60 days](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows).

To patch the query zone, an API token is required. The workflow expects it to be configured as a repo secret named `DESEC_TOKEN`.

@dnsguru As discussed. I'll send the token to you privately.