### PR TITLE
Add back `cnpy.gdn` to restore #633

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12434,6 +12434,10 @@ objects.rma.cloudscale.ch
 // Submitted by Patrick Nielsen <patrick@clovyr.io>
 wnext.app
 
+// CNPY : https://cnpy.gdn
+// Submitted by Angelo Gladding <angelo@lahacker.net>
+cnpy.gdn
+
 // Co & Co : https://co-co.nl/
 // Submitted by Govert Versluis <govert@co-co.nl>
 *.otap.co


### PR DESCRIPTION
This PR has been created to re-add `cnpy.gdn` to the PSL, restoring #633 by reverting the removal PR #2174, as requested by @angelogladding, who is the original requestor of #633:

https://github.com/publicsuffix/list/pull/2174#issuecomment-2387255985

The DNS failure mentioned in the related issue https://github.com/publicsuffix/list/issues/2172 may be due to a temporary misconfiguration error, as indicated by the requestor.