### PR TITLE
Remove `presse.ci` and `md.ci`, other ccTLD stubs not associated w respective registry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4100,6 +4100,7 @@ coop.mw
 edu.mw
 gov.mw
 int.mw
+museum.mw
 net.mw
 org.mw
 
@@ -4140,6 +4141,8 @@ org.mz
 // http://www.info.na/domain/
 na
 info.na
+pro.na
+name.na
 school.na
 or.na
 dr.na
@@ -4150,6 +4153,7 @@ in.na
 cc.na
 tv.na
 ws.na
+mobi.na
 co.na
 com.na
 org.na
@@ -5392,6 +5396,7 @@ nome.pt
 // pw : https://www.iana.org/domains/root/db/pw.html
 pw
 co.pw
+ne.pw
 or.pw
 ed.pw
 go.pw

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -756,8 +756,6 @@ go.ci
 asso.ci
 aéroport.ci
 int.ci
-presse.ci
-md.ci
 gouv.ci
 
 // ck : https://www.iana.org/domains/root/db/ck.html
@@ -4102,7 +4100,6 @@ coop.mw
 edu.mw
 gov.mw
 int.mw
-museum.mw
 net.mw
 org.mw
 
@@ -4143,8 +4140,6 @@ org.mz
 // http://www.info.na/domain/
 na
 info.na
-pro.na
-name.na
 school.na
 or.na
 dr.na
@@ -4155,7 +4150,6 @@ in.na
 cc.na
 tv.na
 ws.na
-mobi.na
 co.na
 com.na
 org.na
@@ -5398,7 +5392,6 @@ nome.pt
 // pw : https://www.iana.org/domains/root/db/pw.html
 pw
 co.pw
-ne.pw
 or.pw
 ed.pw
 go.pw


### PR DESCRIPTION
## Unusual Registrations of Outdated ICANN Section Domains by China-Based Entity on the PSL

# **Main discussion has been moved to #2199** 

This PR focuses on the `.ci` TLD.

This PR addresses concerns around the `presse.ci` and `md.ci` domain, part of a broader issue (https://github.com/publicsuffix/list/issues/2199), where a China-based entity appears to be exploiting outdated ICANN section domains. The suspicious activity includes possible SEO manipulation and potential spamming through randomized subdomains. Given `presse.ci` and `md.ci`'s treatment by PSL users as a ccTLD, this raises concerns about its legitimate use and potential abuse.

## presse.ci

- `Creation Date: 2020-04-15` is later than the PSL inclusion date.
- The [Google search](https://www.google.com/search?q=site%3Apresse.ci) and [Bing search](https://www.bing.com/search?&q=site%3Apresse.ci) show no results for the **presse.ci** domain.
- [Certificate Transparency](https://crt.sh/?q=presse.ci) reveals no active SSL certificates in use for `presse.ci`.
  - All issued SSL certificates for `presse[.]ci` have expired. However, upon reviewing the certificate history, it appears that the subdomains previously issued were randomized strings, such as `qtadnma.presse[.]ci`, `vurbpzz.presse[.]ci`, `ntmwtfw.presse[.]ci`, and `ujtcswn.presse[.]ci`. This pattern suggests potential past activity related to spamming, likely as an attempt to circumvent spam filters, given that `presse[.]ci` is treated as a ccTLD.

![image](https://github.com/user-attachments/assets/fc5b1fd6-fab2-43a0-b2be-9162d15a8dbd)

- Due to the specialty of this domain (as a PSL ICANN section domain), both VirusTotal and Subdomain Finder are **unable to scan it** because VirusTotal treats it as a ccTLD. Consequently, no subdomains were found for presse.ci by these tools.


<details>
  <summary>presse.ci WHOIS Data</summary>

```plaintext
Domain Name: presse.ci
Registry Domain ID: 114934-CoCCA
Registry WHOIS Server: whois.nic.ci
Updated Date: 2024-03-07T10:16:11.642Z
Creation Date: 2020-04-15T22:32:58.96Z
Registry Expiry Date: 2025-04-15T22:32:58.180Z
Registrar Registration Expiration Date: 2025-04-15T22:32:58.180Z
Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Registry Registrant ID: q1UJH-L7oJh
Registrant Name: Redacted | Registry Policy
Registrant Organization: Asia Domain Name Registration Company Limited
Registrant Street: Edif. Industrial Man Kei
Registrant City: Macau
Registrant Postal Code: 999078
Registrant Country: MO
Registrant Phone: Redacted | Registry Policy
Registrant Email: Redacted | Registry Policy
Registry Admin ID: WGpMZ-SlfKI
Admin Name: Redacted | Registry Policy
Admin Organization: Asia Domain Name Registration Company Limited
Admin Street: Redacted | Registry Policy
Admin City: Redacted | Registry Policy
Admin Postal Code: Redacted | Registry Policy
Admin Country: MO
Admin Phone: Redacted | Registry Policy
Admin Email: abuse@macau.net
Registry Tech ID: XcXUa-G3o7X
Tech Name: Redacted | Registry Policy
Tech Organization: Asia Domain Name Registration Company Limited
Tech Street: Redacted | Registry Policy
Tech City: Redacted | Registry Policy
Tech Postal Code: Redacted | Registry Policy
Tech Country: MO
Tech Phone: Redacted | Registry Policy
Tech Email: abuse@macau.net
Registry Billing ID: hvF9m-ydwnt
Billing Name: Redacted | Registry Policy
Billing Organization: Asia Domain Name Registration Company Limited
Billing Street: Redacted | Registry Policy
Billing City: Redacted | Registry Policy
Billing Postal Code: Redacted | Registry Policy
Billing Country: MO
Billing Phone: Redacted | Registry Policy
Billing Email: Redacted | Registry Policy
Registrar: AFRIREGISTER
Name Server: a.dnspod.com
Name Server: b.dnspod.com
Name Server: c.dnspod.com
DNSSEC: unsigned
>>> Last update of WHOIS database: 2024-10-05T08:00:08.64Z <<<

For more information on EPP status codes, please visit https://icann.org/epp
```

</details>

## md.ci

- `Creation Date: 2023-06-26T10:02:14.447Z` is later than the PSL inclusion date.
- The [Google search](https://www.google.com/search?q=site%3Amd.ci) and [Bing search](https://www.bing.com/search?&q=site%3Amd.ci) show no results for the **md.ci** domain.
- [Certificate Transparency](https://crt.sh/?q=md.ci) reveals numerous subdomains with randomized characters. Possible spamming or SEO manipulation.
- Due to the specialty of this domain (as a PSL ICANN section domain), both VirusTotal and Subdomain Finder are **unable to scan it** because VirusTotal treats it as a ccTLD. Consequently, no subdomains were found for md.ci by these tools.

![image](https://github.com/user-attachments/assets/0a0e7c70-89d4-4b40-830b-37021a999982)

<details>
  <summary>md.ci WHOIS Data</summary>

```plaintext
Domain Name: md.ci
Registry Domain ID: 153326-cinic
Registry WHOIS Server: whois.nic.ci
Updated Date: 2024-05-26T02:01:30.221Z
Creation Date: 2023-06-26T10:02:14.447Z
Registry Expiry Date: 2025-06-26T10:02:14.457Z
Registrar Registration Expiration Date: 2025-06-26T10:02:14.457Z
Domain Status: ok https://icann.org/epp#ok
Registry Registrant ID: DUGjh-P0daG
Registrant Name: Redacted | Registry Policy
Registrant Street: Redacted | Registry Policy
Registrant Street: Redacted | Registry Policy
Registrant City: Redacted | Registry Policy
Registrant Postal Code: Redacted | Registry Policy
Registrant Country: MO
Registrant Phone: Redacted | Registry Policy
Registrant Email: Redacted | Registry Policy
Registry Admin ID: ICblx-ZtAsy
Admin Name: Redacted | Registry Policy
Admin Street: Redacted | Registry Policy
Admin Street: Redacted | Registry Policy
Admin City: Redacted | Registry Policy
Admin Postal Code: Redacted | Registry Policy
Admin Country: MO
Admin Phone: Redacted | Registry Policy
Admin Email: abuse@macau.net
Registry Tech ID: l9nQE-wiyhz
Tech Name: Redacted | Registry Policy
Tech Street: Redacted | Registry Policy
Tech Street: Redacted | Registry Policy
Tech City: Redacted | Registry Policy
Tech Postal Code: Redacted | Registry Policy
Tech Country: MO
Tech Phone: Redacted | Registry Policy
Tech Email: abuse@macau.net
Registry Billing ID: wZykB-UJFoY
Billing Name: Redacted | Registry Policy
Billing Street: Redacted | Registry Policy
Billing Street: Redacted | Registry Policy
Billing City: Redacted | Registry Policy
Billing Postal Code: Redacted | Registry Policy
Billing Country: MO
Billing Phone: Redacted | Registry Policy
Billing Email: Redacted | Registry Policy
Registrar: AFRIREGISTER
Name Server: a.dnspod.com
Name Server: b.dnspod.com
Name Server: c.dnspod.com
DNSSEC: unsigned
>>> Last update of WHOIS database: 2024-10-05T08:00:08.64Z <<<
```

</details>

## Absence from Officially Promoted .ci Domains on NIC.CI

The official website for .ci domains ([www.nic.ci](http://www.nic.ci/)) promotes specific second-level domains, such as .go.ci, .com.ci, .net.ci, .org.ci, etc.. However, there is no mention of `presse.ci` or `md.ci` in this list of promoted second-level domains.

![image](https://github.com/user-attachments/assets/f498e944-82c1-4344-8c5b-a4e3d60ed2b5)
