### PR TITLE
Remove `ne.pw`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5398,7 +5398,6 @@ nome.pt
 // pw : https://www.iana.org/domains/root/db/pw.html
 pw
 co.pw
-ne.pw
 or.pw
 ed.pw
 go.pw


### PR DESCRIPTION
## Unusual Registrations of Outdated PSL ICANN Section Domains by China-Based Entity

This PR addresses concerns around the `ne.pw` domain, part of a broader issue (#2199), where a China-based entity appears to be exploiting outdated ICANN section domains. The suspicious activity includes possible SEO manipulation and potential spamming through randomized subdomains. Given `ne.pw`'s treatment by PSL users as a ccTLD, this raises concerns about its legitimate use and potential abuse.

## ne.pw

- The [Google search](https://www.google.com/search?q=site%3Ane.pw) found nothing for the **ne.pw** domain, while [Bing search](https://www.bing.com/search?&q=site%3Ane.pw) returned several sites under **ne.pw**. However, nearly all the results have the same site name and title, suggesting possible SEO manipulation, likely taking advantage of the fact that **ne.pw** is treated as a ccTLD (similar to **.co.uk**, **.com.au**, etc.) by search engines due to its inclusion in the ICANN section of the PSL.

![image](https://github.com/user-attachments/assets/d3580011-e3c0-490d-9ba6-92ae3014e750)

- Additionally, [Certificate Transparency](https://crt.sh/?q=ne.pw) reveals numerous SSL certificates issued to subdomains with randomized characters, which looks suspicious at best. This likely indicates manipulation for either SEO or spamming activities.

![image](https://github.com/user-attachments/assets/9505cf26-a674-4761-90b5-7e20a5c73aae)

- Due to the specialty of this domain (as a PSL ICANN section domain), both VirusTotal and Subdomain Finder are **unable to scan it**, as VirusTotal treats it as a ccTLD. Consequently, no subdomains were found for **ne.pw** by these tools.

## Tracing to macau dot net

The domain `ne.pw` is being advertised and possibly sold on the website https://www.macau.net by "Asia Domain Name Registration Company Limited." 

However, they do not appear to be an authorized registrar for `.pw` domains (List of registars: https://registry.pw/list-of-registrars/), and the advertising on their website is somewhat misleading.

![image](https://github.com/user-attachments/assets/e43149e1-f063-49af-bbf5-a9cc5aaafa21)

"國際認可 無處不在的 .NE.PW 域名全球流通"
This claim translates to "International Recognition: The ubiquitous .NE.PW domain is globally circulated." This is misleading because `ne.pw` is not widely recognized or globally established as a legitimate TLD. It suggests an attempt to legitimize the domain's visibility, possibly as a cover for back-end activities that may include SEO manipulation or spamming, taking advantage of its ccTLD status in search engines.

## Domain Creation and Expiry History

The `ne.pw` domain has a creation date of **December 8, 2014**, as per the WHOIS data. It is later than the original inclusion date in the PSL, meaning that it was previously allowed to expire by the original registry. It was then re-registered in 2014.

```
Domain Name: NE.PW
Registry Domain ID: D6614709-CNIC
Registrar WHOIS Server: whois.dynadot.com
Registrar URL: http://www.dynadot.com/
Updated Date: 2024-06-27T16:00:33.0Z
Creation Date: 2014-12-08T00:42:20.0Z
Registry Expiry Date: 2032-12-08T23:59:59.0Z
Registrar: Dynadot LLC
Registrar IANA ID: 472
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Registrant Email: https://whois.nic.pw/contact/ne.pw/registrant
Admin Email: https://whois.nic.pw/contact/ne.pw/admin
Tech Email: https://whois.nic.pw/contact/ne.pw/tech
Name Server: A.DNSPOD.COM
Name Server: B.DNSPOD.COM
Name Server: C.DNSPOD.COM
DNSSEC: unsigned
Billing Email: https://whois.nic.pw/contact/ne.pw/billing
Registrar Abuse Contact Email: [abuse@1dynadot.com](mailto:abuse@1dynadot.com)
Registrar Abuse Contact Phone: +1.6502620100
URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of WHOIS database: 2024-10-05T23:44:57.0Z <<<
```