### PR TITLE
Update PR Template Requiring Abuse Contact for Subdomain Registry Requestors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -138,6 +138,7 @@ stay that way for an indefinite period of time (typically long).
  * [ ] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
 ---
 
+
 <!--
 As you complete each item in the checklist please mark it with an X.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -97,6 +97,19 @@ so getting this right initially will aid successfully having it
 proceed. Mislocated entries and trailing spaces should be avoided.
 -->
 
+**Abuse Contact:**
+
+<!--
+Please confirm that you have an accessible abuse contact information on your website. 
+
+At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
+-->
+
+* [ ] Abuse contact information (email or web form) is available and easily accessible.
+
+  URL where abuse contact or abuse reporting form can be found: 
+  <!-- Provide the URL where an Internet user can access the abuse contact information -->
+
 ---
 
 For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.
@@ -123,29 +136,6 @@ stay that way for an indefinite period of time (typically long).
 (Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))
 
  * [ ] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
-
-<!--
-For Subdomain Registries: Abuse Contact Confirmation
-
-If your project operates as a subdomain registry, please confirm that you have an accessible abuse contact information on your website. 
-
-This requirement applies to entities including but not limited to:
-- Registries of gTLDs/ccTLDs operating on third-level domains: For example, registries managing domains like .eu.org that offer third-level domain registrations.
-- Registries that resell subdomains to registrars: These are entities that manage domains and sell subdomains of those domains to other registrars, who then distribute them to end users.
-- Registries that directly resell subdomains to end customers: These operators provide subdomains directly to individuals or businesses, acting as an intermediary for domain usage.
-- Hosting providers offering subdomains: Hosting services that offer free/paid subdomains (such as clientname.example.com) as part of their hosting package, making them de facto registries for their hosted clients.
-- Dynamic DNS providers: These are services like Synology's *.quickconnect.to, which provide subdomains for users to dynamically map IP addresses, functioning similarly to subdomain registries.
-- URL shortening services using subdomains: Services that provide shortened URLs utilizing subdomains also fall under this broad definition.
-
-At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-
-Uncomment the following checkbox if applicable:
-
-* [ ] This request is made for a subdomain registry service. Abuse contact information (email or web form) is available and easily accessible.
-
-**URL where abuse contact or abuse reporting form can be found**: 
-
--->
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,6 +71,29 @@ the PR.
  * [ ] This request was _not_ submitted with the objective of working around other third-party limits.
 
 <!--
+For Subdomain Registries: Abuse Contact Confirmation
+
+If your project operates as a subdomain registry, please confirm that you have an accessible abuse contact information on your website. 
+
+This requirement applies to entities including but not limited to:
+- Registries of gTLDs/ccTLDs operating on third-level domains: For example, registries managing domains like .eu.org that offer third-level domain registrations.
+- Registries that resell subdomains to registrars: These are entities that manage domains and sell subdomains of those domains to other registrars, who then distribute them to end users.
+- Registries that directly resell subdomains to end customers: These operators provide subdomains directly to individuals or businesses, acting as an intermediary for domain usage.
+- Hosting providers offering subdomains: Hosting services that offer free/paid subdomains (such as clientname.example.com) as part of their hosting package, making them de facto registries for their hosted clients.
+- Dynamic DNS providers: These are services like Synology's *.quickconnect.to, which provide subdomains for users to dynamically map IP addresses, functioning similarly to subdomain registries.
+- URL shortening services using subdomains: Services that provide shortened URLs utilizing subdomains also fall under this broad definition.
+
+At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
+
+Uncomment the following checkbox if applicable:
+
+* [ ] This request is made for a subdomain registry service. Abuse contact information (email or web form) is available and easily accessible.
+
+**URL where abuse contact or abuse reporting form can be found**: 
+
+-->
+
+<!--
 Submitter will maintain domains in good standing or may lose section.
 
 The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -136,7 +136,6 @@ stay that way for an indefinite period of time (typically long).
 (Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))
 
  * [ ] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
-
 ---
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -100,7 +100,7 @@ proceed. Mislocated entries and trailing spaces should be avoided.
 **Abuse Contact:**
 
 <!--
-Please confirm that you have an accessible abuse contact information on your website. 
+Please confirm that you have accessible abuse contact information on your website. 
 
 At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,29 +71,6 @@ the PR.
  * [ ] This request was _not_ submitted with the objective of working around other third-party limits.
 
 <!--
-For Subdomain Registries: Abuse Contact Confirmation
-
-If your project operates as a subdomain registry, please confirm that you have an accessible abuse contact information on your website. 
-
-This requirement applies to entities including but not limited to:
-- Registries of gTLDs/ccTLDs operating on third-level domains: For example, registries managing domains like .eu.org that offer third-level domain registrations.
-- Registries that resell subdomains to registrars: These are entities that manage domains and sell subdomains of those domains to other registrars, who then distribute them to end users.
-- Registries that directly resell subdomains to end customers: These operators provide subdomains directly to individuals or businesses, acting as an intermediary for domain usage.
-- Hosting providers offering subdomains: Hosting services that offer free/paid subdomains (such as clientname.example.com) as part of their hosting package, making them de facto registries for their hosted clients.
-- Dynamic DNS providers: These are services like Synology's *.quickconnect.to, which provide subdomains for users to dynamically map IP addresses, functioning similarly to subdomain registries.
-- URL shortening services using subdomains: Services that provide shortened URLs utilizing subdomains also fall under this broad definition.
-
-At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-
-Uncomment the following checkbox if applicable:
-
-* [ ] This request is made for a subdomain registry service. Abuse contact information (email or web form) is available and easily accessible.
-
-**URL where abuse contact or abuse reporting form can be found**: 
-
--->
-
-<!--
 Submitter will maintain domains in good standing or may lose section.
 
 The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
@@ -146,8 +123,31 @@ stay that way for an indefinite period of time (typically long).
 (Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))
 
  * [ ] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
----
 
+<!--
+For Subdomain Registries: Abuse Contact Confirmation
+
+If your project operates as a subdomain registry, please confirm that you have an accessible abuse contact information on your website. 
+
+This requirement applies to entities including but not limited to:
+- Registries of gTLDs/ccTLDs operating on third-level domains: For example, registries managing domains like .eu.org that offer third-level domain registrations.
+- Registries that resell subdomains to registrars: These are entities that manage domains and sell subdomains of those domains to other registrars, who then distribute them to end users.
+- Registries that directly resell subdomains to end customers: These operators provide subdomains directly to individuals or businesses, acting as an intermediary for domain usage.
+- Hosting providers offering subdomains: Hosting services that offer free/paid subdomains (such as clientname.example.com) as part of their hosting package, making them de facto registries for their hosted clients.
+- Dynamic DNS providers: These are services like Synology's *.quickconnect.to, which provide subdomains for users to dynamically map IP addresses, functioning similarly to subdomain registries.
+- URL shortening services using subdomains: Services that provide shortened URLs utilizing subdomains also fall under this broad definition.
+
+At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
+
+Uncomment the following checkbox if applicable:
+
+* [ ] This request is made for a subdomain registry service. Abuse contact information (email or web form) is available and easily accessible.
+
+**URL where abuse contact or abuse reporting form can be found**: 
+
+-->
+
+---
 
 <!--
 As you complete each item in the checklist please mark it with an X.


### PR DESCRIPTION
To address the issue:

- #1813

This PR introduces updates to the PR submission template to address the issue raised in #1813 concerning the accountability of subdomain registries and the need for abuse contact information.

The new requirements aims to require that requestors who operate subdomain registries provide easily accessible abuse contact information, such as an email address or a web form, which allows responsible parties to be contacted in the event of abuse or malicious activities.

---

cc @dnsguru @simon-friedberger 