### PR TITLE
Remove `museum.mw`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4102,7 +4102,6 @@ coop.mw
 edu.mw
 gov.mw
 int.mw
-museum.mw
 net.mw
 org.mw
 


### PR DESCRIPTION
## Unusual Registrations of Outdated PSL ICANN Section Domains by China-Based Entity

This PR addresses concerns around the `museum.mw` domain, part of a broader issue (#2199), where a China-based entity appears to be exploiting outdated ICANN section domains. The suspicious activity includes possible SEO manipulation and potential spamming through randomized subdomains. Given `museum.mw`'s treatment by PSL users as a ccTLD, this raises concerns about its legitimate use and potential abuse.

## museum.mw

- The [Google search](https://www.google.com/search?q=site%3Amuseum.mw) found 1 dysfunctional site for the **museum.mw** domain, while [Bing search](https://www.bing.com/search?&q=site%3Amuseum.mw) returned several sites under **museum.mw**. However, nearly all the results have the same site name and title and randomized subdomains, suggesting possible SEO manipulation, likely taking advantage of the fact that **museum.mw** is treated as a ccTLD (similar to **.co.uk**, **.com.au**, etc.) by search engines due to its inclusion in the ICANN section of the PSL.

![image](https://github.com/user-attachments/assets/6bf7d161-27e7-43af-9264-5adedfe68921)


- Additionally, [Certificate Transparency](https://crt.sh/?q=museum.mw) reveals numerous SSL certificates issued to subdomains with randomized characters, which looks suspicious at best. This likely indicates manipulation for either SEO or spamming activities.

![image](https://github.com/user-attachments/assets/aeb688d5-28bd-4edc-bfe5-396ce62f43a2)

This looks very similar to #2200 

- Due to the specialty of this domain (as a PSL ICANN section domain), both VirusTotal and Subdomain Finder are **unable to scan it**, as VirusTotal treats it as a ccTLD. Consequently, no subdomains were found for **museum.mw** by these tools.

## Domain Creation and Expiry History

The `museum.mw` domain has a creation date of **2024-03-19**, as per the WHOIS data. It is later than the original inclusion date in the PSL, meaning that it was previously allowed to expire by the original registry. It was then re-registered in 2024.

```
% Domain Information over Whois protocol
%
% Whoisd Server Version: 3.9.0
% Timestamp: Mon Oct 07 10:40:37 2024

domain: museum.mw
registrant: CMW-RM5068
admin-c: CMW-RM5069
nsset: NETIM-MW-119
registrar: NETIM-REG
registered: 19.03.2024 18:00:55
changed: 19.03.2024 18:10:54
expire: 19.03.2026

contact: CMW-RM5068
org: asia domain name registration company limited
name: Macaunet REGISTRY
address: edif. industrial man kei
address: MACAU
address: 999078
address: MO
phone: +853.8612368
e-mail: [abuse@macau.net](mailto:abuse@macau.net)
registrar: NETIM-REG
created: 16.03.2024 18:13:46

contact: CMW-RM5069
org: asia domain name registration company limited
name: Macaunet REGISTRY
address: edif. industrial man kei
address: MACAU
address: 999078
address: MO
phone: +853.8612368
e-mail: [abuse@macau.net](mailto:abuse@macau.net)
registrar: NETIM-REG
created: 16.03.2024 18:13:47

nsset: NETIM-MW-119
nserver: a.dnspod.com
nserver: b.dnspod.com
nserver: c.dnspod.com
tech-c: CMW-NETIM
registrar: NETIM-REG
created: 19.03.2024 18:10:51
```

## Registrar information

The 101domain [page](https://www.101domain.com/museum_mw.htm) shows "The registry has suspended .museum.mw domain registrations at this time."

![image](https://github.com/user-attachments/assets/3ea490fa-56d5-4931-a2f6-5f512a89ea18)

## Registry information

https://www.nic.mw/advert.php did not indicate any information about third-level domain registrations.