### PR TITLE
Update `.NA` entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4140,24 +4140,12 @@ net.mz
 org.mz
 
 // na : http://www.na-nic.com.na/
-// http://www.info.na/domain/
 na
-info.na
-pro.na
-name.na
-school.na
-or.na
-dr.na
-us.na
-mx.na
-ca.na
-in.na
-cc.na
-tv.na
-ws.na
-mobi.na
+alt.na
 co.na
 com.na
+gov.na
+net.na
 org.na
 
 // name : has 2nd-level tlds, but there's no list of them


### PR DESCRIPTION
This PR is created to update the `.NA` entries.

@dnsguru has obtained confirmation directly from the .NA registry, as documented in https://github.com/publicsuffix/list/issues/2199#issuecomment-2396379694 and https://github.com/publicsuffix/list/pull/2198#discussion_r1789874645 :

> I am friends with .NA and reached out by private email (sorry, won't share) but got the following response from them about the structure of "official" subdomains underneath .NA
> 
> Here is the list he provided me:
> 
> na
> alt.na
> co.na
> com.na
> gov.na
> net.na
> org.na
> 
> They actually asked if we would purge the balance of them - I will note this in https://github.com/publicsuffix/list/pull/2198
