### PR TITLE
Added frii.site domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15755,4 +15755,8 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// frii.site : https://www.frii.site
+// Submitted by Onni Nevala <nevalaonni@frii.site>
+*.frii.site
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15756,7 +15756,7 @@ virtualserver.io
 enterprisecloud.nu
 
 // frii.site : https://www.frii.site
-// Submitted by Onni Nevala <nevalaonni@frii.site>
+// Submitted by Onni Nevala <support@frii.site>
 frii.site
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15757,6 +15757,6 @@ enterprisecloud.nu
 
 // frii.site : https://www.frii.site
 // Submitted by Onni Nevala <nevalaonni@frii.site>
-*.frii.site
+frii.site
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (`make test`)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__frii.site affirms the following:__ 
 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [X] This request was _not_ submitted with the objective of working around other third-party limits.

 * [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.


**Abuse Contact:**

* [X] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.frii.site/report/

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

For example:
* [X] Description of Organization

## Description of Organization
A free subdomain service that has a dashboard to make it accessible for everyone.

I (the submitter) lead the project's development, design, and work as the community manager.


**Organization Website:** https://www.frii.site/

## Reason for PSL Inclusion
Security for our users (cookies)

**Number of users this request is being made to serve:** 600

## DNS Verification
```
dig +short TXT _psl.frii.site
"https://github.com/publicsuffix/list/pull/XXXX"
```


Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->

## Results of Syntax Checker (`make test`)

```
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_NFKC: 
OK
-n test_allowedchars: 
OK
-n test_dots: 
OK
-n test_duplicate: 
OK
-n test_exception: 
OK
-n test_punycode: 
OK
-n test_section1: 
OK
-n test_section2: 
OK
-n test_section3: 
OK
-n test_section4: 
OK
-n test_spaces: 
OK
-n test_wildcard: 
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
	  cd libpsl;                                                                    \
	  git pull;                                                                     \
	  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
	  echo "CLEANFILES =" >> gtk-doc.make;                                          \
	  autoreconf --install --force --symlink;
Already up to date.
Can't exec "autopoint": No such file or directory at /usr/local/Cellar/autoconf/2.72/share/autoconf/Autom4te/FileUtils.pm line 318.
autoreconf: error: autopoint failed with exit status: 2
make: *** [libpsl-config] Error 2
```
