### PR TITLE
Remove Banzai Cloud

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12206,12 +12206,6 @@ b-data.io
 // Submitted by Petros Angelatos <petrosagg@balena.io>
 balena-devices.com
 
-// Banzai Cloud
-// Submitted by Janos Matyas <info@banzaicloud.com>
-*.banzai.cloud
-app.banzaicloud.io
-*.backyards.banzaicloud.io
-
 // BASE, Inc. : https://binc.jp
 // Submitted by Yuya NAGASAWA <public-suffix-list@binc.jp>
 base.ec


### PR DESCRIPTION
Related issue: #2172 

- Company was [acquired by Cisco in 2020](https://www.cisco.com/c/en/us/about/corporate-strategy-office/acquisitions/banzaicloud.html)
- All activity on github and related CNCF spaces stopped >1 year ago, aside from automated depaware updates.
- All three domains (`banzai.cloud`, `app.banzaicloud.io`, `backyards.banzaicloud.io`) are hard down at the DNS level. All domains are delegated to AWS Route53, which is responding REFUSED - indicating Route53 is no longer configured to serve those domains. My guess is the AWS account was shut down.
- Another open source project [removed references to banzai cloud](https://github.com/thanos-io/thanos/pull/6901) around a year ago, due to the link becoming dead at that time.
- A final piece of hosting for Banzai's products went down 2 weeks ago, [there has been no response at all to repeated requests for help from its users](https://github.com/banzaicloud/banzai-charts/issues/1350).
- I failed to find any way to contact banzai that doesn't go through one of the dead DNS zones.

This all paints a picture of Cisco winding up the infrastructure of one of their acquisitions, and the former employees of banzai now working on something else.