### PR TITLE
Add home.arpa

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -206,6 +206,7 @@ tur.ar
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 arpa
 e164.arpa
+home.arpa
 in-addr.arpa
 ip6.arpa
 iris.arpa


### PR DESCRIPTION
This is not actually a *public* suffix but it is a domain suffix.

This closes #1205.