### PR TITLE
Remove ddns5.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12568,10 +12568,6 @@ mydatto.com
 dattolocal.net
 mydatto.net
 
-// DDNS5 : https://ddns5.com
-// Submitted by Cameron Elliott <cameron@cameronelliott.com>
-ddns5.com
-
 // ddnss.de : https://www.ddnss.de/
 // Submitted by Robert Niedziela <webmaster@ddnss.de>
 ddnss.de


### PR DESCRIPTION
Related issue: #1353 

- Entry added in 2021, with submitter acknowledging requirements of availability, responsiveness and maintaining ownership via a TXT record.
- Domain is hard down at the DNS layer. Glue records delegate to Cloudflare nameservers, which respond REFUSED - presumably account has been shut down.
- Domain has been down since at least 2024-09-05, when @groundcat found its organization URL didn't load in #2135. While hacking on TXT record checking I've probed it multiple times since then, and it's been consistently down.
- All web activity google can find for ddns5.com ended in 2021, a few months after the PSL entry was merged. I couldn't find evidence of any users of the service. The only hits on Google are copies of the PSL, malware reports that reference the domain (in the context of tracking dynamic DNS services in general), and a few github notes from the domain's owner, dating back to 2021.
- Suffix owner was [pinged a month ago](https://github.com/publicsuffix/list/pull/1353#issuecomment-2357593935) about the status of the domain. No response and the domain remains hard down as before.

All of the above paints the picture of a defunct project.