### PR TITLE
Remove Handshake suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13672,11 +13672,6 @@ conf.se
 // Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
 häkkinen.fi
 
-// Handshake : https://handshake.org
-// Submitted by Mike Damm <md@md.vc>
-hs.run
-hs.zone
-
 // Harrison Network : https://hrsn.net
 // Submitted by William Harrison <psl@hrsn.net>
 wdh.app


### PR DESCRIPTION
Related: #796 

 - Suffixes added in 2019, with a requirement to maintain TXT records.
 - Domains have been hard down since at least 2023-05, when #1753 found the domains were returning SERVFAIL.
 - Domains are currently hard down. Glue records delegate to 2 IPs that are not running any DNS server.
 - No evidence of use. Web search finds one passing mention of reliability issues in a related github project back in 2019. All other mentions are copies of the PSL scattered around the web.
 - Suffix owner was pinged about the status of these domains over a month ago in #796. No response.

This seems to be a long dead service, if it was ever active at all.