### PR TITLE
chore: update is-a.dev contact info

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13897,8 +13897,8 @@ ir.md
 // Submitted by William Harrison <webmaster@is-a-good.dev>
 is-a-good.dev
 
-// is-a.dev : https://www.is-a.dev
-// Submitted by William Harrison <admin@m.is-a.dev>
+// is-a.dev : https://is-a.dev
+// Submitted by William Harrison <psl@is-a.dev>
 is-a.dev
 
 // IServ GmbH : https://iserv.de


### PR DESCRIPTION
Just updating contact information for is-a.dev.

Last PR updating this section #2074 was created by me.

I've updated the `_psl` TXT record as well:
```
$ dig +short TXT _psl.is-a.dev
"https://github.com/publicsuffix/list/pull/2225"
```