### PR TITLE
Add United Tech domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15504,6 +15504,11 @@ unison-services.cloud
 virtual-user.de
 virtualuser.de
 
+// United Tech : https://unitedtech.ai/
+// Submitted by Illia Korzh <illia.k@unitedtech.ai>
+*.pages-unitedtech.link
+*.dev-pages-unitedtech.link
+
 // UNIVERSAL DOMAIN REGISTRY : https://www.udr.org.yt/
 // see also: whois -h whois.udr.org.yt help
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@udr.org.yt>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15506,8 +15506,8 @@ virtualuser.de
 
 // United Tech : https://unitedtech.ai/
 // Submitted by DevOps Service team <devops@unitedtech.ai>
-*.dev-pages-unitedtech.link
-*.pages-unitedtech.link
+dev-pages-unitedtech.link
+pages-unitedtech.link
 
 // UNIVERSAL DOMAIN REGISTRY : https://www.udr.org.yt/
 // see also: whois -h whois.udr.org.yt help

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15505,7 +15505,7 @@ virtual-user.de
 virtualuser.de
 
 // United Tech : https://unitedtech.ai/
-// Submitted by Illia Korzh <illia.k@unitedtech.ai>
+// Submitted by DevOps Service team <devops@unitedtech.ai>
 *.dev-pages-unitedtech.link
 *.pages-unitedtech.link
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15506,8 +15506,8 @@ virtualuser.de
 
 // United Tech : https://unitedtech.ai/
 // Submitted by Illia Korzh <illia.k@unitedtech.ai>
-*.pages-unitedtech.link
 *.dev-pages-unitedtech.link
+*.pages-unitedtech.link
 
 // UNIVERSAL DOMAIN REGISTRY : https://www.udr.org.yt/
 // see also: whois -h whois.udr.org.yt help


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (`make test`)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 United Tech is not using this to work around rate-limits of third party services.

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.


 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

**Abuse Contact:**
info@unitedtech.ai
abuse@unitedtech.ai

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  By abuse-email message.

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---


<!--
As you complete each item in the checklist please mark it with an X.


* [x] Description of Organization
-->

## Description of Organization
Our company is engaged in the development of advanced social networks according to the requirements of our clients.


**Organization Website:**
 [https://unitedtech.ai](https://unitedtech.ai) 

## Reason for PSL Inclusion
- Our employees must deploy to Gitlab Pages with a unique subdomain (for our customers and feature-branch environments). 
- We want our tenant customers' apps to be isolated from each other (cookies, etc.)


**Number of users this request is being made to serve:**
3000-5000

## DNS Verification by dig
```
dig +short TXT _psl.pages-unitedtech.link
"https://github.com/publicsuffix/list/pull/2227"
```

```
dig +short TXT _psl.dev-pages-unitedtech.link
"https://github.com/publicsuffix/list/pull/2227"
```

## Results of Syntax Checker (`make test`)
TOTAL: 5
PASS: 5
