### PR TITLE
internal/parser: add PublicSuffix and RegisteredDomain methods to List

### DIFF
--- a/tools/internal/parser/file_test.go
+++ b/tools/internal/parser/file_test.go
@@ -1,0 +1,95 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/publicsuffix/list/tools/internal/domain"
+)
+
+func TestPublicSuffix(t *testing.T) {
+	lst := list(
+		section(1, 1, "PRIVATE DOMAINS",
+			suffixes(1, 1, noInfo,
+				suffix(1, "example.com"),
+				wildcard(2, 3, "baz.net", "except", "other"),
+				suffix(4, "com"),
+
+				// Wildcards and exceptions nested inside each
+				// other. This doesn't appear in the PSL in practice,
+				// and is implicitly forbidden by the format spec, but
+				// the parser/validator does not currently reject such
+				// files, so we want PublicSuffix/RegisteredDomain to
+				// be well-defined for such inputs.
+				wildcard(5, 6, "nested.org", "except"),
+				wildcard(7, 8, "in.except.nested.org", "other-except"),
+			),
+		),
+	)
+
+	tests := []struct {
+		in        string
+		pubSuffix string
+		regDomain string
+	}{
+		{"www.example.com", "example.com", "www.example.com"},
+		{"www.public.example.com", "example.com", "public.example.com"},
+		{"example.com", "example.com", ""},
+
+		{"www.other.com", "com", "other.com"},
+		{"other.com", "com", "other.com"},
+		{"com", "com", ""},
+
+		{"qux.bar.baz.net", "bar.baz.net", "qux.bar.baz.net"},
+		{"bar.baz.net", "bar.baz.net", ""},
+		{"baz.net", "net", "baz.net"}, // Implicit * rule
+		{"qux.except.baz.net", "baz.net", "except.baz.net"},
+		{"except.baz.net", "baz.net", "except.baz.net"},
+		{"other.other.baz.net", "baz.net", "other.baz.net"},
+
+		// Tests for nested wildcards+exceptions. Does not appear in
+		// the real PSL, and implicitly disallowed by the format spec,
+		// but necessary to make PublicSuffix and RegisteredDomain's
+		// outputs well defined for all inputs.
+		{"qux.bar.foo.nested.org", "foo.nested.org", "bar.foo.nested.org"},
+		{"bar.foo.nested.org", "foo.nested.org", "bar.foo.nested.org"},
+		{"foo.nested.org", "foo.nested.org", ""},
+		{"nested.org", "org", "nested.org"},
+		{"bar.except.nested.org", "nested.org", "except.nested.org"},
+		{"except.nested.org", "nested.org", "except.nested.org"},
+		{"in.except.nested.org", "nested.org", "except.nested.org"},
+		// Matches both nested wildcard and also outer exception,
+		// outer exception wins.
+		{"other.in.except.nested.org", "nested.org", "except.nested.org"},
+		// Matches both outer and inner exceptions, inner exception
+		// wins.
+		{"qux.other-except.in.except.nested.org", "in.except.nested.org", "other-except.in.except.nested.org"},
+	}
+
+	for _, tc := range tests {
+		in := mustParseDomain(tc.in)
+		wantSuffix := mustParseDomain(tc.pubSuffix)
+
+		gotSuffix := lst.PublicSuffix(in)
+		if !gotSuffix.Equal(wantSuffix) {
+			t.Errorf("PublicSuffix(%q) = %q, want %q", in, gotSuffix, wantSuffix)
+		}
+
+		gotReg, ok := lst.RegisteredDomain(in)
+		if ok && tc.regDomain == "" {
+			t.Errorf("RegisteredDomain(%q) = %q, want none", in, gotReg)
+		} else if ok {
+			wantReg := mustParseDomain(tc.regDomain)
+			if !gotReg.Equal(wantReg) {
+				t.Errorf("RegisteredDomain(%q) = %q, want %q", in, gotReg, wantReg)
+			}
+		}
+	}
+}
+
+func mustParseDomain(s string) domain.Name {
+	d, err := domain.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}


### PR DESCRIPTION
These calculate the public suffix or registered/registerable domain of some input domain, according to the strict PSL algorithm. Aside from being useful as a reference implementation of the algorithm, it comes in handy in validations that need to do stuff like figure out what registry to query for domain info.

---

Please check my work carefully on the PSL algorithm, in particular the handling of wildcard domains. I read [the spec](https://github.com/publicsuffix/list/wiki/Format#formal-algorithm) very carefully and also the [platform.sh wiki page](https://wiki.mozilla.org/Public_Suffix_List/platform.sh_Problem), and I _think_ I've correctly implemented the strict PSL algorithm with no deviation (a public suffix `*.foo.com` does not imply a public suffix `foo.com`, and there is an implicit hardcoded `*` public suffix so that all unknown TLDs are automatically public suffixes).

Later on I could add modifiers to these methods to implement the variants as well, but for now I stuck to the reference algorithm. I ended up needing this logic to implement RDAP support for checking domain expiry, since I have to map a random PSL entry to "which registry RDAP service should I query", and for some suffixes that requires computing the "next" public suffix of the PSL entry :)