### PR TITLE
Add DevZero domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12607,6 +12607,10 @@ dedyn.io
 deta.app
 deta.dev
 
+// DevZero: https://devzero.io
+// Submitted by Ellie Ford <ellie@devzero.io>
+dv0.io
+
 // dhosting.pl Sp. z o.o.: https://dhosting.pl/
 // Submitted by Michal Kokoszkiewicz <bok@dhosting.pl>
 dfirma.pl


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Run Syntax Checker (`make test`)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

**Abuse Contact: DevZero Support (support@devzero.io)**

* [x] Abuse contact information (email or web form) is available and easily accessible.

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---


<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Hi! I'm Ellie from DevZero - I'm a staff software engineer here, working primarily on our networking & compute infrastructure. At DevZero, we're looking to provide cloud development environments, in the form of a Linux-based workspace and a virtual ephemeral Kubernetes cluster. This (unfortunately) makes us a hosting provider, and as part of that, we also are in the business of maintaining a globally distributed fleet of reverse proxies to expose our customer's services to the public internet. With that, we also aim to keep everything secure & encrypted, by means of automagically conjuring HTTPS certificates out of thin air, so that our customers don't need to think about all of that nonsense.

**Organization Website: https://devzero.io**

## Reason for PSL Inclusion
As part of conjuring HTTPS certificates out of thin air, we've come to realize that providers like Let's Encrypt & Cloudflare impose limitations on what you're able to do - namely, how many certificates you're able to provision for a single domain within a certain span of time (typically a week). We haven't run into those limitations yet, and as such, we haven't started conversations with Let's Encrypt / Cloudflare yet. 

It's important to note that we're not only interested in *just* the SSL certificates. We will start those conversations with those providers directly when we've started hitting those rate-limits, and we're not looking to be listed for the sole purpose of circumventing third-party limits. We're also interested in keeping each subdomain isolated from each other (i.e. we don't want cookies from *.team-foo.dv0.io to be present on *.team-bar.dv0.io), as we expect that users will be hosting their own web applications through our networking services.

**Number of users this request is being made to serve: According to our product analytics, approximately ~1600 users.**

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
```
; dig +short @1.1.1.1 TXT _psl.dv0.io
"https://github.com/publicsuffix/list/pull/2229"
;
```

## Results of Syntax Checker (`make test`)
```
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```
