### PR TITLE
Remove `gov.cu`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -866,7 +866,6 @@ cu
 com.cu
 edu.cu
 gob.cu
-gov.cu
 inf.cu
 nat.cu
 net.cu


### PR DESCRIPTION
This PR is to remove `gov.cu`, as it is not a public suffix, which has been confirmed by the .CU operator with assistance from the IANA contact in this comment: https://github.com/publicsuffix/list/issues/1695#issuecomment-2429339242.

> We (IANA) spoke with the .CU manager and they confirmed `gob.cu` is in use as a public suffix, and `gov.cu` is not.

 `gob.cu` has been added by #2143.