### PR TITLE
chore: update `.io` section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1428,9 +1428,9 @@ int
 eu.int
 
 // io : http://www.nic.io/rules.htm
-// list of other 2nd level tlds ?
 io
 com.io
+net.io
 
 // iq : http://www.cmc.iq/english/iq/iqregister1.htm
 iq

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1429,6 +1429,7 @@ eu.int
 
 // io : http://www.nic.io/rules.htm
 io
+co.io
 com.io
 net.io
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1431,7 +1431,12 @@ eu.int
 io
 co.io
 com.io
+edu.io
+gov.io
+mil.io
 net.io
+nom.io
+org.io
 
 // iq : http://www.cmc.iq/english/iq/iqregister1.htm
 iq


### PR DESCRIPTION
Updating the list of SLDs under the `.io` TLD.

I'm adding `co.io` and `net.io` as they do seem to be a domain offered by the registry, as it is not reserved, and is registered to the registry operator themselves (`Registry Operator acts as Registrar (9998)`), along with having the same nameservers of `com.io`, which we know is a SLD already. However I will confirm this with the registry, to make sure.

Note: You can technically register domains at the 3rd level, however they are restricted to residents in the British Indian Ocean Territory, however I don't believe there are any inhabitants living there. However, they are still TLDs technically offered by the registry.

This PR will remain in a draft state until I receive a response from the .io registry.