### PR TITLE
chore: remove 2nd level comment for `.sk`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5569,7 +5569,6 @@ si
 sj
 
 // sk : https://www.iana.org/domains/root/db/sk.html
-// list of 2nd level domains ?
 sk
 
 // sl : http://www.nic.sl


### PR DESCRIPTION
.sk does not offer TLDs at the 2nd level, they only allow direct .sk registration.

This was confirmed by the registry.