### PR TITLE
remove `bci.dnstrace.pro`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12650,10 +12650,6 @@ jozi.biz
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de
 
-// dnstrace.pro : https://dnstrace.pro/
-// Submitted by Chris Partridge <chris@partridge.tech>
-bci.dnstrace.pro
-
 // DotArai : https://www.dotarai.com/
 // Submitted by Atsadawat Netcharadsang <atsadawat@dotarai.co.th>
 online.th


### PR DESCRIPTION
Reasons for removal:
- The PR (#630) the domain was added in, predates the WHOIS registration date of `2024-02-05`. The previous owner likely let the domain lapse and a new registrant registered it.
- The `_psl.bci.dnstrace.pro` TXT record is no longer in place.
- No results on Google for either `site:bci.dnstrace.pro` or `site:dnstrace.pro`.
- The homepage at http://dnstrace.pro is just a blank page.
- There are no active SSL certificates under the domain: https://crt.sh/?q=dnstrace.pro
- No subdomains found when searching under https://subdomainfinder.c99.nl/

This domain should be safe to remove as there is no evidence of usage.