### PR TITLE
move `wdh.app` to new section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13676,7 +13676,6 @@ häkkinen.fi
 
 // Harrison Network : https://hrsn.net
 // Submitted by William Harrison <psl@hrsn.net>
-wdh.app
 hrsn.dev
 
 // Hashbang : https://hashbang.sh
@@ -15627,6 +15626,10 @@ pages.wiardweb.com
 toolforge.org
 wmcloud.org
 wmflabs.org
+
+// William Harrison : https://wdh.gg
+// Submitted by William Harrison <william@harrison.id.au>
+wdh.app
 
 // WISP : https://wisp.gg
 // Submitted by Stepan Fedotov <stepan@wisp.gg>


### PR DESCRIPTION
Simply moving the domain `wdh.app` to a new section.

Reason for move is the domain is not really associated with Harrison Network.

The email address is a personal one, as the section is a personal section. 

Updated `_psl` TXT record:
```
$ dig +short TXT _psl.wdh.app
"https://github.com/publicsuffix/list/pull/2246"
```

All tests passed.