### PR TITLE
chore: add `.bw` 2LDs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -676,11 +676,16 @@ org.bt
 bv
 
 // bw : https://www.iana.org/domains/root/db/bw.html
-// http://www.gobin.info/domainname/bw.doc
-// list of other 2nd level tlds ?
+// https://en.wikipedia.org/wiki/.bw#Structure
 bw
+ac.bw
+agric.bw
 co.bw
+gov.bw
+me.bw
+net.bw
 org.bw
+shop.bw
 
 // by : https://www.iana.org/domains/root/db/by.html
 // http://tld.by/rules_2006_en.html


### PR DESCRIPTION
2LDs for `.bw` were found on Wikipedia: https://en.wikipedia.org/wiki/.bw#Structure

These 2LDs do seem to be in use when searching `site:{ac,agric,gov,me,net,shop}.bw` on Google.

These should be added ASAP as people are currently able to set cookies on the TLDs themselves, which would affect potentially thousands of other domains on these TLDs.