### PR TITLE
add `co.bz`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -698,6 +698,7 @@ of.by
 // bz : https://www.iana.org/domains/root/db/bz.html
 // http://www.belizenic.bz/
 bz
+co.bz
 com.bz
 net.bz
 org.bz


### PR DESCRIPTION
Taken from https://belizenic.bz, the URL linked in the section.

There does seem to be usage of the 2LD `.co.bz`, when searching `site:co.bz` on Google.

These should be added ASAP as people are currently able to set cookies on the 2LD itself, which would affect potentially hundreds of other domains on this 2LD.