### PR TITLE
remove wildcard for `.ck`, replace with list of 2LDs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -763,8 +763,15 @@ int.ci
 gouv.ci
 
 // ck : https://www.iana.org/domains/root/db/ck.html
-*.ck
-!www.ck
+// https://en.wikipedia.org/wiki/.ck#Requirements_of_.ck_registration
+ck
+biz.ck
+co.ck
+edu.ck
+gen.ck
+gov.ck
+net.ck
+org.ck
 
 // cl : https://www.nic.cl
 // Confirmed by .CL registry <hsalgado@nic.cl>


### PR DESCRIPTION
List of 2LDs taken from https://en.wikipedia.org/wiki/.ck#Requirements_of_.ck_registration.

I would recommend removing the wildcard and specifying the 2LDs specifically, just in the event they allow 2nd level registrations, it won't affect anyone attempting to set cookies at the second level.

This PR isn't super urgent, and won't affect any active domains once deployed.

The `!www.ck` entry has been removed in favour of specifying the TLD itself.