### PR TITLE
remove `betainabox.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12225,10 +12225,6 @@ beagleboard.io
 // Submitted by Hazel Cora <hazy@besties.house>
 pages.gay
 
-// BetaInABox
-// Submitted by Adrian <adrian@betainabox.com>
-betainabox.com
-
 // BinaryLane : http://www.binarylane.com
 // Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
 bnr.la


### PR DESCRIPTION
Reasons for removal:
- No subdomains found (only 2 showed up in a scan, however they did not resolve): https://subdomainfinder.c99.nl/scans/2024-11-15/betainabox.com
- No active sites found when searching `site:betainabox.com` on Google
  - One unresolvable site showed up, which had the description of `No Sponsors. help.betainabox.com currently does not have any sponsors for you.`, which could mean the domain name was sold.
- No TXT record at `_psl.betainabox.com`
- Only a default Apache web server page is shown at http://betainabox.com
- Not technically a factor for removal, but worth noting: The registrant appears to be an individual named `Robert Gregson`, so I believe the domain has changed hands at some point.

This domain does not meet the standards for PSL inclusion, nor does it seem to be active. From what I've seen, it might be possible that the domain name has changed hands. It should be safe to remove.