### PR TITLE
remove `browsersafetymark.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12279,10 +12279,6 @@ square7.net
 shop.brendly.hr
 shop.brendly.rs
 
-// BrowserSafetyMark
-// Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
-browsersafetymark.io
-
 // BRS Media : https://brsmedia.com/
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 radio.am


### PR DESCRIPTION
Reasons for removal:
- Website does not resolve: http://browsersafetymark.io
- A record `35.161.17.166` does not respond to pings
- No subdomains found when searching using https://subdomainfinder.c99.nl
- No results when searching `site:browsersafetymark.io` on Google.
- No results on archive.org (not a factor for removal, but worth noting): https://web.archive.org/web/*/https://browsersafetymark.io/*

Reasons against removal:
- The TXT record at `_psl.browsersafetymark.io` still exists

I think this domain is safe to remove as it does not seem to be used. It is likely they have pretty much abandoned this domain.