### PR TITLE
remove `nom.ad`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -19,6 +19,7 @@ mil.ac
 org.ac
 
 // ad : https://www.iana.org/domains/root/db/ad.html
+// Confirmed by Amadeu Abril i Abril (CORE) <amadeu.abril@corenic.org> 2024-11-17
 ad
 
 // ae : https://tdra.gov.ae/en/aeda/ae-policies

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -20,7 +20,6 @@ org.ac
 
 // ad : https://www.iana.org/domains/root/db/ad.html
 ad
-nom.ad
 
 // ae : https://tdra.gov.ae/en/aeda/ae-policies
 ae


### PR DESCRIPTION
Confirmed by the .ad registry:
```
Hi William.

We can confirm that the .ad TLD does no currently operate any functional public SLD. .nom.ad existed, in theory, some time ago, but is no longer offered and there is no currently existing domain under tht SLD nor any other. Only domains under the TLD .ad do exist and are available for registration.

Thanks for checking and for the good work tith PSL.

Equip de suport domini .ad
```

- Email was originally sent to info@domini.ad which is listed on the registry's site in the footer: https://www.domini.ad/contacte/ (Page URL can be verified through IANA's website: https://www.iana.org/domains/root/db/ad.html)
- I received a response from `Amadeu Abril i Abril (CORE) <amadeu.abril@corenic.org>`.
- You can also confirm yourself that the `nom.ad` TLD no longer is in use as you cannot find any active sites under a Google search or a subdomain scanner like https://subdomainfinder.c99.nl/ (I know, we cannot rely on these, however it is a good indication of usage)