### PR TITLE
Update .JO section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1896,7 +1896,8 @@ org.je
 // jm : http://www.com.jm/register.html
 *.jm
 
-// jo : http://www.dns.jo/Registration_policy.aspx
+// jo : https://www.dns.jo/JoFamily.aspx
+// Confirmed by registry <DNS@modee.gov.jo> 2024-11-17
 jo
 agri.jo
 ai.jo

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1901,16 +1901,16 @@ jo
 agri.jo
 ai.jo
 com.jo
+edu.jo
 eng.jo
 fm.jo
-org.jo
-net.jo
-edu.jo
-sch.jo
 gov.jo
 mil.jo
+net.jo
+org.jo
 per.jo
 phd.jo
+sch.jo
 tv.jo
 
 // jobs : https://www.iana.org/domains/root/db/jobs.html

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1898,14 +1898,20 @@ org.je
 
 // jo : http://www.dns.jo/Registration_policy.aspx
 jo
+agri.jo
+ai.jo
 com.jo
+eng.jo
+fm.jo
 org.jo
 net.jo
 edu.jo
 sch.jo
 gov.jo
 mil.jo
-name.jo
+per.jo
+phd.jo
+tv.jo
 
 // jobs : https://www.iana.org/domains/root/db/jobs.html
 jobs


### PR DESCRIPTION
I am creating this pull request to update the .JO block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/jo.html and identified the registry website for registration services: https://www.dns.jo/
2. Located the email address provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry (`Domain .jo/الاردن. <DNS@modee.gov.jo>`), confirming the requested information.

Excerpt from the email confirmation:

> 1. Operational Status: Is [name.jo](http://name.jo/) still active and registrable?
> ‘.[name.jo](http://name.jo/)’ was stopped since many years and not available for registration, it replaced with ‘.[per.jo](http://per.jo/)’.
> 2. Available Suffixes: Could you provide an updated list of all second-level domains currently operated by the .JO registry?
> see our website:  https://www.dns.jo/JoFamily.aspx

A copy of the email confirmation along with the email headers is available to be forwarded to a maintainer for review upon request.
