### PR TITLE
Update .IS section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1464,14 +1464,8 @@ sch.ir
 ايران.ir
 
 // is : http://www.isnic.is/domain/rules.php
-// Confirmed by registry <marius@isgate.is> 2008-12-06
+// Confirmed by registry <marius@isgate.is> 2024-11-17
 is
-net.is
-com.is
-edu.is
-gov.is
-org.is
-int.is
 
 // it : https://www.iana.org/domains/root/db/it.html
 it


### PR DESCRIPTION
I am creating this pull request to update the .IS block in the ICANN section.

**Steps taken to verify information from the authoritative source:**

1. Started at the IANA page: https://www.iana.org/domains/root/db/is.html and identified the registry website for registration services: https://www.isnic.is/
2. Located the email address provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry (`Marius Olafsson <marius@isgate.is>`), confirming the requested information.

Excerpt from the email confirmation:

```
> I?ve noticed that the .IS registry operates several second-level domains,
> including:
>
>   * is
>   * net.is
>   * com.is
>   * edu.is
>   * gov.is
>   * org.is
>   * int.is

ISNIC (the .IS registry) only operates .is -- the others above are
simply reserved to avoid confusion.

> For example, users can register domains like example.net.is and educational
> organizations can register example.edu.is.

No, they can not. These are reserved and not available for registation and thus
can not be operated as SLDs. Just type in e.g. 'x.edu.is' on https://www.isnic.is/en

> However, when querying some domains directly, I encountered NXDOMAIN errors
> for:
>
>   * net.is
>   * com.is
>   * edu.is
>   * gov.is
>   * org.is
>   * int.is

Yes -- they are reserved and thus not registered in DNS.

> Could you please clarify the following:
>
>  1. Operational Status: Are these second-level domains (net.is, com.is, edu.is,
>     gov.is, org.is, int.is) still actively operated and available for
>     registration?

They have never been available for registration. Have been reserved from the
establishment of the .IS domain in 1986.

>  2. Available Suffixes: Can you provide an updated list of all second-level
>     domains currently managed by the .IS registry?

Only .IS is currently managed by the .IS registry.


>  3. Decommissioning: If any of these SLDs have been retired or deprecated,
>     could you share the reasons and the timeline for these changes?

These SLD have never been available for registration.
```

A complete copy of the email confirmation along with the email headers is available to be forwarded to a maintainer for review upon request.
