### PR TITLE
Update .AU Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -244,7 +244,6 @@ gov.au
 asn.au
 id.au
 // Historic 2LDs (closed to new registration, but sites still exist)
-info.au
 conf.au
 oz.au
 // CGDNs - http://www.cgdn.org.au/


### PR DESCRIPTION
I am creating this pull request to update the .AU block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/au.html and identified the registry website for registration services: https://www.auda.org.au
2. Located the email address `lkeys@ddns.com.au` provided on the registry website and sent an inquiry.
3. Adviced by `lkeys@ddns.com.au` that I need to contact `general <general@auda.org.au>`
4. Received a direct reply from `general <general@auda.org.au>`, confirming the requested information.

Excerpt from the email confirmation:

> You can register names at the third level for domains like: com.au, net.au, org.au, asn.au, id.au, gov.au and edu.au.
> 
> Since 2022 we also allowed registration directly at the second level of .au.   We call that .au direct.    There are now more than 700,000 domains at the second level - e.g. bruce.au
> 
> See: https://www.auda.org.au/au-domain-names/domain-name-help/au-domain-names-fact-sheet
> 
> You can look up the registrant of a name at:  https://whois.auda.org.au/
> 
> info.au is held by the Government in the state of Tasmania.    Their main page is here:   https://www.tas.gov.au/   
> 
> They don't seem to have delegated any DNS nameservers for info.au.
> 
> I had a look at the public suffix list at https://publicsuffix.org/list/public_suffix_list.dat
> 
> info.au should be removed from that list.   The rest of the entries are still valid.
> 
> Regards,
> 
> Bruce Tonkin
> 
> .au Domain Administration Limited (auDA)

A copy of the email confirmation along with the email headers is available to be forwarded to a maintainer for review upon request.