### PR TITLE
alphabetise `.tm` section + add confirmation comment

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5716,14 +5716,14 @@ gov.tl
 
 // tm : http://www.nic.tm/local.html
 tm
-com.tm
 co.tm
-org.tm
-net.tm
-nom.tm
+com.tm
+edu.tm
 gov.tm
 mil.tm
-edu.tm
+net.tm
+nom.tm
+org.tm
 
 // tn : http://www.registre.tn/fr/
 // https://whois.ati.tn/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5714,7 +5714,8 @@ tk
 tl
 gov.tl
 
-// tm : http://www.nic.tm/local.html
+// tm : https://www.nic.tm/local.html
+// Confirmed by registry <admin@nic.TM> - 2024-11-19
 tm
 co.tm
 com.tm


### PR DESCRIPTION
Confirmed by the registry (admin@nic.TM):

Here is an excerpt of the email thread:
```
It IS possible to register directly under the TOP level .TM .... AND also

com.tm
co.tm
org.tm
net.tm
nom.tm
gov.tm
mil.tm
edu.tm
```

The full email chain can be provided to a maintainer at request.

- I emailed batyr@nic.tm; hostmaster@nic.tm; which are both listed on the IANA root database and received a response from admin@nic.TM.