### PR TITLE
Update `.CO` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -832,21 +832,17 @@ mo.cn
 tw.cn
 
 // co : https://www.iana.org/domains/root/db/co.html
-// Submitted by registry <tecnico@uniandes.edu.co>
+// https://www.cointernet.com.co/registra
+// https://www.cointernet.com.co/como-funciona-un-dominio-restringido
+// Confirmed by registry <gonzalo@cointernet.com.co> 2024-11-18
 co
-arts.co
 com.co
 edu.co
-firm.co
 gov.co
-info.co
-int.co
 mil.co
 net.co
 nom.co
 org.co
-rec.co
-web.co
 
 // com : https://www.iana.org/domains/root/db/com.html
 com


### PR DESCRIPTION
I am creating this pull request to update the .co block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/co.html and identified the email address as well as the registry website for registration services https://www.cointernet.com.co/
2. Located the email address provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry `<Gonzalo@cointernet.com.co>`, confirming the requested information.

Fully reply to the email confirmation:

<!--EndFragment-->
</body>
</html>

> Greetings from “.CO Internet”, the “.CO” ccTLD’s Registry Operator.
> 
> Based on the current “.CO “ policies, we operate the following for third level registration:
> 
> “.com.co”, “.net.co”, “.nom.co” for open registration.
> .edu.co, gov.co, org.co and .mil.co for restricted applicants.
>  
> As shown in https://www.cointernet.com.co/registra and https://www.cointernet.com.co/como-funciona-un-dominio-restringido.
> 
> The other are restricted second-level domains following the guide in https://www.cointernet.com.co/politicas.
> 
> Regards,
> 
> ///Gonzalo
> 
> +++
> 
> Gonzalo Romero | Principal Security Manager | .CO INTERNET – The “.CO” ccTLD’s Registry Operator | Gonzalo@COInternet.com.CO

4. So, based on their reply, it appears that

The registry operates only these domains **for third level registration**:

```
co
com.co
edu.co
gov.co
mil.co
net.co
nom.co
org.co
```

These second-level domains are reserved (also returning NXDOMAIN errors)

```
arts.co
firm.co
info.co
int.co
rec.co
web.co
```

The referenced document, https://www.cointernet.com.co/docs/politicas/Lista-de-Dominios-Restringidos-030810.pdf, contains a long list of reserved domains in a similar situation. I believe these should not be included in the PSL, based on the confirmation from the registry and the observation that these domains are reserved and not resolvable.

A copy of the email confirmation along with the email headers is available to be forwarded to a maintainer for review upon request.
-  DKIM:	'PASS' with domain cointernet.com.co