### PR TITLE
Update `.PL` comments and fix alphabetical sorting

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5109,12 +5109,12 @@ org.pk
 web.pk
 
 // pl http://www.dns.pl/english/index.html
-// Submitted by registry
+// Confirmed by registry <info@dns.pl> 2024-11-18
 pl
 com.pl
 net.pl
 org.pl
-// pl functional domains (http://www.dns.pl/english/index.html)
+// pl functional domains : https://www.dns.pl/en/list_of_functional_domain_names
 agro.pl
 aid.pl
 atm.pl
@@ -5145,7 +5145,7 @@ tm.pl
 tourism.pl
 travel.pl
 turystyka.pl
-// Government domains
+// Government domains : https://www.dns.pl/informacje_o_rejestracji_domen_gov_pl
 gov.pl
 ap.gov.pl
 griw.gov.pl
@@ -5202,7 +5202,7 @@ wuoz.gov.pl
 wzmiuw.gov.pl
 zp.gov.pl
 zpisdn.gov.pl
-// pl regional domains (http://www.dns.pl/english/index.html)
+// pl regional domains : https://www.dns.pl/en/list_of_regional_domain_names
 augustow.pl
 babia-gora.pl
 bedzin.pl
@@ -5229,11 +5229,11 @@ jaworzno.pl
 jelenia-gora.pl
 jgora.pl
 kalisz.pl
-kazimierz-dolny.pl
 karpacz.pl
 kartuzy.pl
 kaszuby.pl
 katowice.pl
+kazimierz-dolny.pl
 kepno.pl
 ketrzyn.pl
 klodzko.pl
@@ -5276,8 +5276,8 @@ pisz.pl
 podhale.pl
 podlasie.pl
 polkowice.pl
-pomorze.pl
 pomorskie.pl
+pomorze.pl
 prochowice.pl
 pruszkow.pl
 przeworsk.pl
@@ -5288,11 +5288,11 @@ rybnik.pl
 rzeszow.pl
 sanok.pl
 sejny.pl
+skoczow.pl
 slask.pl
 slupsk.pl
 sosnowiec.pl
 stalowa-wola.pl
-skoczow.pl
 starachowice.pl
 stargard.pl
 suwalki.pl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5146,6 +5146,7 @@ tourism.pl
 travel.pl
 turystyka.pl
 // Government domains : https://www.dns.pl/informacje_o_rejestracji_domen_gov_pl
+// In accordance with the .gov.pl Domain Name Regulations : https://www.dns.pl/regulamin_gov_pl
 gov.pl
 ap.gov.pl
 griw.gov.pl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5115,8 +5115,8 @@ com.pl
 net.pl
 org.pl
 // pl functional domains (http://www.dns.pl/english/index.html)
-aid.pl
 agro.pl
+aid.pl
 atm.pl
 auto.pl
 biz.pl
@@ -5125,8 +5125,8 @@ gmina.pl
 gsm.pl
 info.pl
 mail.pl
-miasta.pl
 media.pl
+miasta.pl
 mil.pl
 nieruchomosci.pl
 nom.pl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5108,7 +5108,7 @@ net.pk
 org.pk
 web.pk
 
-// pl https://www.dns.pl/en/
+// pl : https://www.dns.pl/en/
 // Confirmed by registry <info@dns.pl> 2024-11-18
 pl
 com.pl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5108,7 +5108,7 @@ net.pk
 org.pk
 web.pk
 
-// pl http://www.dns.pl/english/index.html
+// pl https://www.dns.pl/en/
 // Confirmed by registry <info@dns.pl> 2024-11-18
 pl
 com.pl


### PR DESCRIPTION
This PR did not add or remove any entries in the `.PL` block; it simply added comments to assist with future reference and corrected the alphabetical ordering.  

Confirmed by `<info@dns.pl>`:

> 1. Current Status: Are the above-listed NXDOMAIN domains (ic.gov.pl, is.gov.pl, kwp.gov.pl, oirm.gov.pl, oum.gov.pl, us.gov.pl, wskr.gov.pl, wzmiuw.gov.pl) still active and registrable?
> The above-mentioned names are zones in the .gov.pl domain, in which we enable domain registration for authorized entities, in accordance with the .gov.pl Domain Name Regulations https://www.dns.pl/regulamin_gov_pl (available only in Polish language version). The status of each zone may be verified in the WHOIS database.
> 
> 2. Available Suffixes: Could you provide an updated list of all second-level domains currently operated by the .PL registry?
> The lists of available suffixes are published at www.dns.pl:
> 
> - functional domain names: https://www.dns.pl/en/list_of_functional_domain_names
> 
> - regional domain names: https://www.dns.pl/en/list_of_regional_domain_names
> 
> - gov.pl domain names: https://www.dns.pl/informacje_o_rejestracji_domen_gov_pl
