### PR TITLE
Update `.RE` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5415,10 +5415,11 @@ org.qa
 sch.qa
 
 // re : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf
+// Confirmed by registry <support@afnic.fr> 2024-11-18
 re
+// Closed for registration on 2013-03-15 but domains are still maintained
 asso.re
 com.re
-nom.re
 
 // ro : http://www.rotld.ro/
 ro


### PR DESCRIPTION
I am creating this pull request to update the .re block in the ICANN section.

Steps taken to verify information from the authoritative source:

## 1. Email verification

1. Started at the IANA page: https://www.iana.org/domains/root/db/re.html and identified the email address as well as the registry website for registration services http://www.nic.re (Association Française pour le Nommage Internet en Coopération (A.F.N.I.C.))
2. Located the email address provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry `<support@afnic.fr>`, confirming the requested information.

Email confirmation:

> From memory, .nom.re was created in 2001 but was not used. What is absolutely certain is that it is not possible to create domain names under .nom.re.

So, `nom.re` should be removed.

A copy of the email confirmation along with the email headers is available to be forwarded to a maintainer for review upon request.
- DKIM:	'PASS' with domain afnic.fr

## 2. AFNIC Documentation

https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf

> 43. Closed for registration on 15 March 2013, the domain names under the naming zones
> .tm.fr, .asso.fr, .asso.re, .com.fr and .com.re are maintained
