### PR TITLE
update `.tt` section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5784,23 +5784,17 @@ gov.nc.tr
 
 // tt : http://www.nic.tt/
 tt
+biz.tt
 co.tt
 com.tt
-org.tt
-net.tt
-biz.tt
-info.tt
-pro.tt
-int.tt
-coop.tt
-jobs.tt
-mobi.tt
-travel.tt
-museum.tt
-aero.tt
-name.tt
-gov.tt
 edu.tt
+gov.tt
+info.tt
+mil.tt
+name.tt
+net.tt
+org.tt
+pro.tt
 
 // tv : https://www.iana.org/domains/root/db/tv.html
 // Not listing any 2LDs as reserved since none seem to exist in practice,

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5782,7 +5782,8 @@ nc.tr
 // Used by government agencies of Northern Cyprus
 gov.nc.tr
 
-// tt : http://www.nic.tt/
+// tt : https://www.nic.tt/
+// Confirmed by registry <admin@nic.tt> - 2024-11-19
 tt
 biz.tt
 co.tt


### PR DESCRIPTION
Confirmed by TTNIC <admin@nic.tt>:
```
Hi,

The list should be as follows:

•	co.tt
•	com.tt
•	org.tt
•	net.tt
•	biz.tt
•	info.tt
•	pro.tt
•	name.tt
•	mil.tt
•	gov.tt
•	edu.tt
 

So add mil.tt and remove int.tt, coop.tt, jobs.tt, mobi.tt, travel.tt, museum.tt, and aero.tt

Thanks.

-Patrick
```

- Email was sent to admin@nic.tt; tech@nic.tt; got a response from admin@nic.tt.

Email thread is available to maintainers at request.