### PR TITLE
Update `.SG` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5540,14 +5540,14 @@ x.se
 y.se
 z.se
 
-// sg : http://www.nic.net.sg/page/registration-policies-procedures-and-guidelines
+// sg : https://www.sgnic.sg/domain-registration/sg-categories-rules
+// Confirmed by registry <dnq@sgnic.sg> 2024-11-19
 sg
 com.sg
 net.sg
 org.sg
 gov.sg
 edu.sg
-per.sg
 
 // sh : http://nic.sh/rules.htm
 sh


### PR DESCRIPTION
I am creating this pull request to update the .sg block in the ICANN section.

1. Removed `per.sg`
2. Fixed broken link in the comment
3. Added registry contact and date to the comment

**Steps taken to verify information from the authoritative source:**

1. Started at the IANA page: https://www.iana.org/domains/root/db/sg.html and identified the email address as well as the registry website for registration services http://www.sgnic.sg
2. Located the online web-based contact form provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry `<dnq@sgnic.sg>`, confirming the requested information.

> Please be informed that ".per.sg" is no longer in operation but the others are still in the operation.
> 
> Thank you.
> 
> 
> Best regards
> Elysa Cheng
> Asst. Executive| T: (65) 6659 2534 |  W: www.sgnic.sg
> ·      SINGAPORE NETWORK INFORMATION CENTRE (SGNIC) PTE LTD
> ·      10 Pasir Panjang Road, #03-01 Mapletree Business City, Singapore 117438

A copy of the email confirmation along with the email headers is available to be forwarded to a maintainer for review upon request.

However,

- DKIM:	'FAIL' with domain sgnic.sg
- DMARC:	'FAIL' 

**Additional steps:**

- Examined the ".SG Categories & Rules" page at https://www.sgnic.sg/domain-registration/sg-categories-rules and made sure the list of domains is consistent.

|  sg       | This category is available to all persons. A foreign applicant must appoint and duly authorise a local agent as its administrative contact. The administrative contact must furnish a valid Singapore postal address for SGNIC's records.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|  com.sg   | Commercial entities may wish to register in this extension. Applicants registering for a .com.sg will need to be either registered, or in the midst of registering, with the Accounting & Corporate Regulatory Authority (ACRA), Enterprise Singapore or any professional body in Singapore. A foreign company may apply for a .com.sg domain name if it appoints a local agent as the administrative contact. The administrative contact must furnish a valid Singapore postal address for SGNIC's records.                                                                                                                                                                                                                                                                                 |
|  org.sg   | Names under .org.sg are only available to organisations which are either registered, or in the midst of registering, with the Registry of Societies (ROS). Also eligible are town councils, community centres, places of worship or embassies. Other organisations not registrable under the Societies Act, Companies Act or with professional bodies could also apply under this extension.                                                                                                                                                                                                                                                                                                                                                                                                 |
|  edu.sg   | Only educational institutions may apply under this category. Applicants must be registered with (i) the Ministry of Education (MOE) in Singapore, (ii) the Ministry of Social and Family Development, (iii) under the Private Education Act, or (iv) is otherwise authorised by law or the Government to provide educational services in Singapore. Applicants not so registered will need to be entities that (a) provide courses or training that either lead to certifications or qualifications (which are issued by such entities or in partnership with educational institution(s)) that are recognised by a government authority or institution in Singapore, or (b) receive support in the form of funding, endorsement and so on from a relevant government authority in Singapore. |
|  gov.sg   | Only government organisations are eligible to apply under this category. Applicants for domain names under this category must be members of the Singapore Government. Government bodies which register in this category may also wish to register domain names that reflect their identities, or the services and schemes they provide, in the other domain name categories.                                                                                                                                                                                                                                                                                                                                                                                                                 |
|  net.sg   | Applicants for names under this category must be (i) Infocomm Media Development Authority licensees (SBO individual licensees, FBO licence or other licenses providing connectivity or value-added network services), or (ii) providers offering network-based data hosting services such as email hosting. DNS hosting, web hosting and data centres may also apply in this category. Any applied name in this category must be reflective of and substantially linked to the Applicant's principle business and/or company name. Any use of the applied name must be for the main purpose of conducting the Applicant's said business.                                                                                                                                                     |
|  新加坡   | This category is the Chinese language equivalent of the .sg category. The same eligibility criteria applies.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
|  சிங்கப்பூர் | This category is the Tamil language equivalent of the .sg category. The same eligibility criteria applies.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |