### PR TITLE
Update `.MG` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3979,17 +3979,14 @@ gov.me
 its.me
 priv.me
 
-// mg : http://nic.mg/nicmg/?page_id=39
+// mg : https://nic.mg
 mg
-org.mg
-nom.mg
-gov.mg
-prd.mg
-tm.mg
-edu.mg
-mil.mg
-com.mg
 co.mg
+com.mg
+gov.mg
+nom.mg
+org.mg
+prd.mg
 
 // mh : https://www.iana.org/domains/root/db/mh.html
 mh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3983,7 +3983,9 @@ priv.me
 mg
 co.mg
 com.mg
+edu.mg
 gov.mg
+mil.mg
 nom.mg
 org.mg
 prd.mg


### PR DESCRIPTION
I am creating this pull request to update the .MG block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/mg.html and identified the email address as well as the registry website for registration services https://www.nic.mg/
2. Located the email address provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry `Dany RANDRIARINIVO <dany@nic.mg>`, confirming the requested information.

Fully reply to the email confirmation:

> On Tue, Nov 19, 2024 at 3:27 AM Dany RANDRIARINIVO <dany@nic.mg> wrote:
> Greetings,
> 
> The active and registrable second-level domains for the .MG are :
> org.mg
> nom.mg
> gov.mg
> prd.mg
> com.mg
> co.mg
> 
> edu.mg and mil.mg are reserved.
> 
> tm.mg is not active.
> Sincerely,

- SPF:	PASS with IP 46.105.41.16
- No DKIM

The email has been forwarded to @simon-friedberger 
