### PR TITLE
chore: Update `.BO` comments and fix alphabetical sorting

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -436,15 +436,16 @@ gov.bn
 net.bn
 org.bn
 
-// bo : https://nic.bo/delegacion2015.php#h-1.10
+// bo : https://nic.bo
+// Confirmed by registry <soporte@nic.bo> 2024-11-19
 bo
 com.bo
 edu.bo
 gob.bo
 int.bo
-org.bo
-net.bo
 mil.bo
+net.bo
+org.bo
 tv.bo
 web.bo
 // Social Domains
@@ -470,9 +471,9 @@ natural.bo
 nombre.bo
 noticias.bo
 patria.bo
+plurinacional.bo
 politica.bo
 profesional.bo
-plurinacional.bo
 pueblo.bo
 revista.bo
 salud.bo


### PR DESCRIPTION
This PR did not add or remove any entries in the .BO block.

Added comments and fixed the broken link to assist with future reference and corrected the alphabetical ordering.

List of suffixes can be found at https://nic.bo traced from IANA database page.

Confirmed by registry <soporte@nic.bo> 2024-11-19 

> I send the correct suffixes:
> - Second Level Domain
> .bo
> 
>  -Third Level Domain
> .com.bo
> .edu.bo
> .gob.bo
> .int.bo
> .org.bo
> .net.bo
> .mil.bo
> .tv.bo
> .web.bo
> 
>  -Third Level Domains Social
> 
> .academia.bo    
> .agro.bo    
> .arte.bo    
> .blog.bo    
> .bolivia.bo    
> .ciencia.bo    
> .cooperativa.bo    
> .democracia.bo    
> .deporte.bo    
> .ecologia.bo    
> .economia.bo    
> .empresa.bo    
> .indigena.bo    
> .industria.bo    
> .info.bo    
> .medicina.bo    
> .movimiento.bo    
> .musica.bo    
> .natural.bo    
> .nombre.bo    
> .noticias.bo    
> .patria.bo    
> .politica.bo    
> .profesional.bo    
> .plurinacional.bo    
> .pueblo.bo    
> .revista.bo    
> .salud.bo    
> .tecnologia.bo    
> .tksat.bo    
> .transporte.bo    
> .wiki.bo
> 
> Regards
> Rene Cayo
> ADMINISTRACION DE NOMBRES DE DOMINIO .BO
> AGENCIA PARA EL DESARROLLO DE LA SOCIEDAD DE LA INFORMACIÓN EN BOLIVIA - ADSIB
> Email: soporte@nic.bo
> Telf. (591-2) 2200720 - 2200730 - 2200740 Interno 2301 - 2302 - 2303
> LA PAZ - BOLIVIA
