### PR TITLE
Update `.DM` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -926,12 +926,15 @@ dj
 dk
 
 // dm : https://www.iana.org/domains/root/db/dm.html
+// https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf
+// Confirmed by registry <admin@dotdm.dm> 2024-11-19
 dm
+co.dm
 com.dm
-net.dm
-org.dm
 edu.dm
 gov.dm
+net.dm
+org.dm
 
 // do : https://www.iana.org/domains/root/db/do.html
 do


### PR DESCRIPTION
I am creating this pull request to update the .DM block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/dm.html and identified the email address as well as the registry website for registration services http://www.nic.dm
2. Located the email address provided on the registry website and sent an inquiry.
3. Received a direct reply from the domain registry <admin@dotdm.dm>, confirming the requested information.

- DKIM:	'PASS' with domain dotdm.dm

> Thank you for your email and inquiry about .dm domains.
> 
> We invite you to visit our Network Information Center, Rules and Guidelines Policy where all your questions can be answered:
> 
> https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf
> 
> best regards,
> 
> Ms. Kerri Christopher
> DotDM Registry/Registrar Services

From https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf :

![image](https://github.com/user-attachments/assets/08db90c7-ad03-4b1e-830c-4884060fe4a0)

> Requests for registration of .dm and .co.dm Domain Names are open to all entities and
> individuals within or outside of the Commonwealth of Dominica with no domicile requirements.
> Registrations may be accepted for Second Level .dm Domain Names. The corresponding
> Third Level extensions:.com.dm/.net.dm/.org.dm will be Brand-Protected to the Registrant.
> However, these Third Level extensions:.com.dm/.net.dm/.org.dm cannot be configured in
> the DM zone.
> .edu.dm - suffix is restricted to Educational Institutions registered and accredited for operating
> in the Commonwealth of Dominica.
> .gov.dm - suffix is restricted for use by the Government of the Commonwealth of Dominica.

Therefore, updating the `.DM` block:

```
dm
co.dm
com.dm
edu.dm
gov.dm
net.dm
org.dm
```

`co.dm` has been added.



