### PR TITLE
Update `.POST` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5334,7 +5334,11 @@ edu.pn
 net.pn
 
 // post : https://www.iana.org/domains/root/db/post.html
+// https://trust.post/legal/
 post
+com.post
+edu.post
+org.post
 
 // pr : http://www.nic.pr/index.asp?f=1
 pr


### PR DESCRIPTION
I am creating this pull request to update the .POST block in the ICANN section.

Starting today, any legal entity engaged in the postal, logistics, or supply chain sectors can register its name in .post, .com.post, .org.post and .edu.post.

**Steps taken to verify information from the authoritative source:**

1. Started at the IANA page: https://www.iana.org/domains/root/db/post.html and identified the registry website for registration services http://www.upu.int
2. From https://www.upu.int, located registry website https://trust.post
3. From https://trust.post located the policy page https://trust.post/legal/
4. Located "[Table 2 – Domain naming conventions and restrictions](https://cdn.sanity.io/files/ppne44jb/production/fd7947f2077c82acee13ed60d407360c8ee3dcd8.pdf)":

![image](https://github.com/user-attachments/assets/3d9f531d-57cf-4c92-b5eb-73e85bc742ec)

Therefore, adding:

```
com.post
edu.post
org.post
```

**Other supplemental information from the registrar:**

https://www.101domain.com/post.htm
