### PR TITLE
Update `.CV` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -872,13 +872,13 @@ net.cu
 org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
-// cv : http://www.dns.cv/tldcv_portal/do?com=DS;5446457100;111;+PAGE(4000018)+K-CAT-CODIGO(RDOM)+RCNT(100); <- registration rules
+// cv : https://comprar.cv/cart.php?a=add&domain=register
 cv
 com.cv
 edu.cv
 int.cv
-nome.cv
 org.cv
+publ.cv
 
 // cw : http://www.una.cw/cw_registry/
 // Confirmed by registry <registry@una.net> 2013-03-26

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -876,7 +876,6 @@ org.cu
 cv
 com.cv
 edu.cv
-int.cv
 org.cv
 publ.cv
 


### PR DESCRIPTION
I am creating this pull request to update the .CV block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/cv.html and identified the registry website for registration services http://www.dns.cv/
2. http://www.dns.cv/ is redirected to https://comprar.cv/
3. From https://comprar.cv/ located https://comprar.cv/cart.php?a=add&domain=register

List of suffixes listed on the registry website:

> cv
> com.cv
> edu.cv
> org.cv
> publ.cv

`publ.cv` should be added due to living examples of sites https://www.google.com/search?q=site%3Apubl.cv
