### PR TITLE
Update `.CV` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -873,8 +873,8 @@ net.cu
 org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
-// cv : https://ola.cv/
-// Confirmed by registry <support@ola.cv> 2024-11-22
+// https://ola.cv/domain-extensions-under-cv/
+// Confirmed by registry <support@ola.cv> 2024-11-26
 cv
 com.cv
 edu.cv
@@ -883,7 +883,7 @@ int.cv
 net.cv
 nome.cv
 org.cv
-pub.cv
+publ.cv
 
 // cw : https://www.uoc.cw/cw-registry
 // Confirmed by registry <registry@uoc.cw> 2024-11-19

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -873,13 +873,17 @@ net.cu
 org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
-// cv : http://www.dns.cv/tldcv_portal/do?com=DS;5446457100;111;+PAGE(4000018)+K-CAT-CODIGO(RDOM)+RCNT(100); <- registration rules
+// cv : https://ola.cv/
+// Confirmed by registry <support@ola.cv> 2024-11-22
 cv
 com.cv
 edu.cv
+id.cv
 int.cv
+net.cv
 nome.cv
 org.cv
+pub.cv
 
 // cw : https://www.uoc.cw/cw-registry
 // Confirmed by registry <registry@uoc.cw> 2024-11-19


### PR DESCRIPTION
I am creating this pull request to update the `.CV` block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/cv.html and identified the email address as well as the registry website for registration services http://www.dns.cv/
2. http://www.dns.cv/ is redirected to https://comprar.cv/
3. Located the email address provided on the registry website and sent an inquiry.
4. Received a direct reply from the domain registry `	OlaCV Support <support@ola.cv>`, confirming the requested information.

Email confirmation:

> Thank you for reaching out.
> Registry link: ola.cv
> .cv
> com.cv
> int.cv
> nome.cv
> net.cv
> org.cv
> pub.cv
> id.cv - not open for purchase
> edu.cv -  open to educational institutions only

Therefore, updating the section to the following:

```
cv
com.cv
edu.cv
id.cv
int.cv
net.cv
nome.cv
org.cv
publ.cv -> typo, not pub.cv, confirmed on 2024-11-26
```
