### PR TITLE
add projects.staging.oryapis.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14631,6 +14631,10 @@ operaunite.com
 // Submitted by Alexandre Linte <alexandre.linte@orange.com>
 tech.orange
 
+// Ory Corp : https://www.ory.sh 
+// Submitted by Ory Corp - Andreas Bucksteeg <security@ory.sh>
+projects.staging.oryapis.dev
+
 // OsSav Technology Ltd. : https://ossav.com/
 // TLD Nic: http://nic.can.re - TLD Whois Server: whois.can.re
 // Submitted by OsSav Technology Ltd. <support@ossav.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)
 - MAKE SURE UPDATE THE FOLLOWING LIST WITH YOUR LIMITATIONS! REMOVE ENTRIES WHICH DO NOT APPLY AS WELL AS REMOVING THIS LINE!

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

**Abuse Contact:**
**eMail:** security@ory.sh

* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: 
  **eMail:** security@ory.sh

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization
Ory is a modern Identity and Access Management (IAM) platform providing Identity & Login Management, OAuth2/OIDC, and Permission Management through Ory Network, our cloud service. We serve hundreds of customers globally, managing over 100 million identities. While Ory offers various deployment options including open-source and enterprise licenses, this PSL request concerns Ory Network, our instant-on global identity system where each customer project receives its own subdomain for accessing identity services.
Our platform combines enterprise-grade security with developer-friendly implementations, making it a trusted choice for organizations requiring solutions that balance user experience, privacy, and security. A key component of our security architecture is our cookie-based security model for browser applications. Instead of using token storage in localStorage or document.cookies, we implement HTTP cookies with strict security flags (secure, httpOnly, sameSite=Strict), providing best-in-class protection against common browser attack vectors such as XSS and CSRF.

**Organization Website:**
https://www.ory.sh

## Reason for PSL Inclusion
Before adding our production domain (projects.oryapis.com) to the PSL, we need to validate in our staging environment that this change does not negatively impact our customers' authentication systems. Therefore, we first require PSL inclusion for our staging domain projects.staging.oryapis.dev.
Our cookie-based security model (detailed at https://www.ory.sh/docs/security-model) is core to our browser security architecture. Instead of using traditional token-based methods, we implement HTTP cookies with strict security flags (secure, httpOnly, sameSite=Strict) to store session states and protect against common attack vectors like XSS and CSRF. This approach requires strict cookie isolation between different project subdomains.
The staging environment mirrors our production setup, allowing us to thoroughly test the PSL integration and validate these critical security boundaries before affecting hundreds of customers' authentication systems. Each subdomain serves a different customer's authentication and identity management APIs, making proper domain isolation essential for our security architecture.

**Number of users this request is being made to serve:**
Hundreds of customers use our services to manage over 100 million identities.

## DNS Verification
```
❯ dig +short TXT _psl.projects.staging.oryapis.dev
"https://github.com/publicsuffix/list/pull/2288"
```
