### PR TITLE
Update `.TW` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5818,7 +5818,7 @@ pro.tt
 tv
 
 // tw : https://www.iana.org/domains/root/db/tw.html
-// https://www.twnic.tw/
+// https://twnic.tw/dnservice_catag.php
 // Confirmed by registry <dns@twnic.tw> 2024-11-26
 tw
 club.tw
@@ -6650,7 +6650,7 @@ yt
 تونس
 
 // xn--kpry57d ("Taiwan", Chinese, Traditional) : TW
-// https://twnic.tw
+// https://twnic.tw/dnservice_catag.php
 台灣
 
 // xn--kprw13d ("Taiwan", Chinese, Simplified) : TW

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6650,7 +6650,7 @@ yt
 تونس
 
 // xn--kpry57d ("Taiwan", Chinese, Traditional) : TW
-// http://www.twnic.net/english/dn/dn_07a.htm
+// https://twnic.tw
 台灣
 
 // xn--kprw13d ("Taiwan", Chinese, Simplified) : TW

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5818,20 +5818,19 @@ pro.tt
 tv
 
 // tw : https://www.iana.org/domains/root/db/tw.html
+// https://www.twnic.tw/
+// Confirmed by registry <dns@twnic.tw> 2024-11-26
 tw
-edu.tw
-gov.tw
-mil.tw
+club.tw
 com.tw
+ebiz.tw
+edu.tw
+game.tw
+gov.tw
+idv.tw
+mil.tw
 net.tw
 org.tw
-idv.tw
-game.tw
-ebiz.tw
-club.tw
-網路.tw
-組織.tw
-商業.tw
 
 // tz : http://www.tznic.or.tz/index.php/domains
 // Submitted by registry <manager@tznic.or.tz>


### PR DESCRIPTION
I am creating this pull request to update the .TW block in the ICANN section.

Steps taken to verify information from the authoritative source:

1. Started at the IANA page: https://www.iana.org/domains/root/db/tw.html and identified the email address as well as the registry website for registration services http://rs.twnic.net.tw/
4. Located the email address provided on the registry website and sent an inquiry.
5. Received a direct reply from the domain registry `<dns@twnic.tw>`, confirming the requested information.

---

## 1. Email confirmation

Ticket # 20650

From `no_reply@twnic.net.tw`

> 感謝來信，關於詢問有關.tw的後綴問題，補充說明如下:
> 1. 運營狀態：網路.tw、組織.tw 和 商業.tw 是否仍然活躍並可供註冊？
> --> 目前這三類的域名已不再提供新註冊及續用，現存的域名也不提供異動設定，也無法解析。
> 網路.tw、組織.tw 和 商業.tw   這些後綴是否應該繼續包括在公共後綴列表中？是否需要移除？
> --> 是否從公共後綴列表中移除，您可自行評估。
> 當前後綴列表：能否提供 .TW 註冊機構目前運營的所有二級域名的最新列表？
> --> 如下:
> tw
> 台灣 (xn--kpry57d)
> edu.tw
> gov.tw
> mil.tw
> com.tw
> net.tw
> org.tw
> idv.tw
> game.tw
> ebiz.tw
> club.tw
> 
> TWNIC

## 2. Registry website

The list of active suffixes is available at https://twnic.tw/dnservice_catag.php

## Removed suffixes

```
網路.tw
組織.tw
商業.tw
```

Confirmed by registry: 

> 目前這三類的域名已不再提供新註冊及續用，現存的域名也不提供異動設定，也無法解析。

These three are no longer available for new registrations and renewals, and existing domain names are not available for change settings and cannot be resolved.
