### PR TITLE
Update `.EG` Section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1000,16 +1000,24 @@ org.ee
 fie.ee
 
 // eg : https://www.iana.org/domains/root/db/eg.html
+// https://domain.eg/en/domain-rules/subdomain-names-types/
 eg
+ac.eg
+adn.eg
 com.eg
 edu.eg
+egregistry.eg
 eun.eg
 gov.eg
+info.eg
+me.eg
 mil.eg
 name.eg
 net.eg
 org.eg
 sci.eg
+sport.eg
+tv.eg
 
 // er : https://www.iana.org/domains/root/db/er.html
 *.er

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1003,10 +1003,8 @@ fie.ee
 // https://domain.eg/en/domain-rules/subdomain-names-types/
 eg
 ac.eg
-adn.eg
 com.eg
 edu.eg
-egregistry.eg
 eun.eg
 gov.eg
 info.eg


### PR DESCRIPTION
I am creating this pull request to update the .EG block in the ICANN section.

## Steps taken to verify information from the authoritative source

1. Started at the IANA page: https://www.iana.org/domains/root/db/eg.html and identified the email address as well as the registry website for registration services http://www.egregistry.eg/
2. `http://www.egregistry.eg/` is redirected to `https://domain.eg/`
3. It appears that the website is only accessible with an Egypt IP address. Otherwise geo-blocked.
4. At `https://domain.eg/`, located the list of suffixes at https://domain.eg/en/domain-rules/subdomain-names-types/

|                                                    | Suffix                             |
|----------------------------------------------------|------------------------------------|
|         The educational   Sector                   |            .edu.eg                 |
|         Research and   Scientific Sector           |            .sci.eg                 |
|         Government Sector                          |            .gov.eg                 |
|         Military Sector                            |            .mil.eg                 |
|         Non-governmental   Organizations           |            .org.eg                 |
|         Commercial Sector                          |            .com.eg                 |
|         IT services                                |            .net.eg                 |
|         Information Sector                         |            .info.eg                |
|         Media Sector                               |            .tv.eg                  |
|         Personal Domains                           |            .name.eg - .me.eg       |
|         Sports Sector                              |            .Sport.eg               |
|         Egyptian   Universities Network            |            .eun.eg                 |
|         Top Domain Services                        |            .egregistry.eg          |
|         Experimental   purposes for Arabic domains |            .adn.eg                 |
|         Academic sector                            |            .ac.eg                  |

Therefore, updating the PSL to the following:

```
ac.eg
com.eg
edu.eg
eun.eg
gov.eg
info.eg
me.eg
mil.eg
name.eg
net.eg
org.eg
sci.eg
sport.eg
tv.eg
```

These two are not included because they are experimental or their usage is not found on the Internet.

```
adn.eg
egregistry.eg
```

Registry not responsive to emails 2024-11-17

## Registry Website (Screenshot)

https://domain.eg/en/domain-rules/subdomain-names-types/

![image](https://github.com/user-attachments/assets/a89e9487-0933-4739-83ec-e86c47567550)

## Registrar Website

https://portal.domgate.com/knowledgebase/36/eg-rules

> Sub-domains:	.gov.eg, .sci.eg, mil.eg, .com.eg, .net.eg, .info.eg, .org.eg, .tv.eg, .sport.eg, .ac.eg, .name.eg, .edu.eg, .sports.eg