### PR TITLE
Adding Ruhr University Bochum domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14934,6 +14934,12 @@ git-pages.rit.edu
 // Submitted by Neil Hanlon <neil@resf.org>
 rocky.page
 
+// Ruhr University Bochum http://ruhr-uni-bochum.de
+// Submitted by Andreas Jobs <noc@ruhr-uni-bochum.de>
+rub.de
+ruhr-uni-bochum.de
+io.noc.ruhr-uni-bochum.de
+
 // Rusnames Limited: http://rusnames.ru/
 // Submitted by Sergey Zotov <admin@rusnames.ru>
 биз.рус


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig
* [X] Run Syntax Checker (`make test`)

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [X] This request was _not_ submitted with the objective of working around other third-party limits.

 * [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

**Abuse Contact: RUB abuse team <abuse@ruhr-uni-bochum.de>**

* [X] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  https://www.ruhr-uni-bochum.de/de/impressum or https://www.ruhr-uni-bochum.de/en/legal-notice
  found via imprint on (almost) every web page

  A more detailed (german only) contact page can be found via "Meldewege" at our IT-Security pages:
  https://www.itsb.ruhr-uni-bochum.de/themen/meldewege.html

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Ruhr University Bochum (RUB), established in 1962, is among Germany's largest
universities and the first new post-war public university in West Germany.
Located in Bochum's Querenburg district, the campus supports approximately
43,000 students and is known for its diverse academic offerings across 20
faculties. The university emphasizes interdisciplinary research, excelling in
fields like materials science, neuroscience, and engineering.

I myself work at the RUB Network Operation Center and support the abuse /
information security team in matters of practical IT security.

**Organization Website:**

https://www.rub.de   (main site)
https://www.itsb.rub.de (security stuff, german only)

## Reason for PSL Inclusion

The subdomains of the two main domains (rub.de and ruhr-uni-bochum.de) are
delegated to faculties, chairs and other institutions. The main reason for
including the PSL is to increase the level of security (cookie security), in
particular because there have already been incidents here and we were
recommended to have the domain entered in the PSL.

The third one is exclusively used to host websites via Gitlab Pages. They
recommend adding the Gitlab Pages domain to the PSL.

As the RUB is a federal institution, the related domains have a long history
and will not be removed in the next three years.


**Number of users this request is being made to serve:**

We currently have ~6300 employees, ~43000 students and ~4000 gitlab users.


## DNS Verification


```
dig +short TXT _psl.rub.de
"https://github.com/publicsuffix/list/pull/2292"
```

```
dig +short TXT _psl.ruhr-uni-bochum.de
"https://github.com/publicsuffix/list/pull/2292"
```

```
dig +short TXT _psl.io.noc.ruhr-uni-bochum.de
"https://github.com/publicsuffix/list/pull/2292"
```

## Results of Syntax Checker (`make test`)

```
cd linter; ./pslint_selftest.sh; ./pslint.py ../public_suffix_list.dat;
test_NFKC: OK
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;    cd libpsl;                                          ;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: linking file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file 'version.txt' included several times
configure.ac:4: warning: file 'version.txt' included several times
aclocal.m4:835: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:369: warning: file 'version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/home/jobsanzl/sandbox/publicsuffixl4
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/POTFILES
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
Making clean in fuzz
Making clean in tests
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CC       libpsl_la-psl.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       common.o
  CC       test-is-public.o
  CC       test-is-public-all.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-cookie-domain-acceptable
  CCLD     test-is-public
  CCLD     test-is-public-builtin
  CCLD     test-is-public-all
  CCLD     test-registrable-domain
PASS: test-is-public-builtin
PASS: test-is-public
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
PASS: test-is-public-all
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```