### PR TITLE
remove `mcpe.me`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14223,10 +14223,6 @@ mcdir.ru
 vps.mcdir.ru
 mcpre.ru
 
-// mcpe.me : https://mcpe.me
-// Submitted by Noa Heyl <hi@noa.dev>
-mcpe.me
-
 // Mediatech : https://mediatech.by
 // Submitted by Evgeniy Kozhuhovskiy <ugenk@mediatech.by>
 mediatech.by


### PR DESCRIPTION
See https://github.com/publicsuffix/list/pull/1080#issuecomment-2357881134 for evidence of removal. No response from author in over 2 months.

Should be safe to remove as the same issues are still occuring (e.g. website has been down for months, there is not enough sufficient evidence to keep PSL status, etc.)