### PR TITLE
remove `test.ru`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12501,7 +12501,6 @@ edu.ru
 gov.ru
 int.ru
 mil.ru
-test.ru
 
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>


### PR DESCRIPTION
Originally moved from the ICANN section to the PRIVATE section in #815.

Reasons for removal:
- We do not allow testing domains as per the guidelines:
> Projects that are smaller in scale or are temporary or seasonal in nature will likely be declined. Examples of this might be private-use, sandbox, test, lab, beta, or other exploratory nature changes or requests. It should be expected that despite whatever site or service referred a requestor to seek addition of their domain(s) to the list, projects not serving more then thousands of users are quite likely to be declined.

- No SSL certificates found: https://crt.sh/?q=.test.ru (the first `.` is required, otherwise it returns results from unrelated domains for some reason, you can verify this yourself here: https://crt.sh/?q=test.ru)
- Domain is not delegated as per a WHOIS lookup: `status: REGISTERED, NOT DELEGATED, VERIFIED`
- No sites found when searching `site:test.ru` on Google (not a valid reason for removal, but worth noting)
- No subdomains found when using https://subdomainfinder.c99.nl/

It should be safe to remove it as it does not seem to have any usage, especially as the domain is not even delegated according to WHOIS.