### PR TITLE
remove `upli.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15548,10 +15548,6 @@ rs.ba
 // Submitted by Marcin <dns@ath.bielsko.pl>
 bielsko.pl
 
-// Upli : https://upli.io
-// Submitted by Lenny Bakkalian <lenny.bakkalian@gmail.com>
-upli.io
-
 // urown.net : https://urown.net
 // Submitted by Hostmaster <hostmaster@urown.net>
 urown.cloud


### PR DESCRIPTION
Reasons for removal:
- No public website at https://upli.io (which is listed as the org website)
- No subdomains can be found either by searching `site:upli.io` on Google or using a subdomain finder like https://subdomainfinder.c99.nl
- No SSL certificates have been issued for subdomains since 2021-10-22, which was a wildcard SSL certificate, which expired 2022-01-20. The only SSLs issued since then seem to be auto-renewed for the root domain: https://crt.sh/?q=upli.io

I think it is safe to remove this domain as it does not seem to be used, nor have any SSLs been issued for subdomains in over 3 years. The purpose of the original inclusion in #1446 was for customer subdomains, however none were found.