### PR TITLE
add lgbt.sh

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14072,6 +14072,10 @@ leadpages.co
 lpages.co
 lpusercontent.com
 
+// LGBT.sh : https://lgbt.sh
+// Submitted by LGBT.sh Team <psl@lgbt.sh>
+lgbt.sh
+
 // Lelux.fi : https://lelux.fi/
 // Submitted by Lelux Admin <publisuffix@lelux.site>
 lelux.site

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14072,13 +14072,13 @@ leadpages.co
 lpages.co
 lpusercontent.com
 
-// LGBT.sh : https://lgbt.sh
-// Submitted by LGBT.sh Team <psl@lgbt.sh>
-lgbt.sh
-
 // Lelux.fi : https://lelux.fi/
 // Submitted by Lelux Admin <publisuffix@lelux.site>
 lelux.site
+
+// LGBT.sh : https://lgbt.sh
+// Submitted by LGBT.sh Team <psl@lgbt.sh>
+lgbt.sh
 
 // libp2p project : https://libp2p.io
 // Submitted by Interplanetary Shipyard <domains@ipshipyard.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Test results included

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale, such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example).

We are **not** submitting this request to bypass any third-party limitations. Specifically:
 - Cloudflare: No issues or rate limits are being addressed through this request. `lgbt.sh` operates independently of Cloudflare's systems.
 - Let's Encrypt: We are not seeking to circumvent Let's Encrypt rate limits. Certificates for `lgbt.sh` and its subdomains are issued within standard limits and policies.
 - Other third parties: This request is not intended to address issues related to iOS, Facebook, or any other third-party systems.

This submission is being made solely to ensure that `lgbt.sh` is recognized as a public suffix for proper handling of cookies, cross-origin policies, and security isolation.


 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  [abuse email](mailto:abuse@lgbt.sh) / [Abuse Page https://lgbt.sh/abuse.html](https://lgbt.sh/abuse)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

**Organization Name:** LGBT.SH  
**Organization Website:** [https://lgbt.sh](https://lgbt.sh)  
**Description:** LGBT.SH is a public subdomain registry that provides domain name services specifically tailored to the global LGBTQ+ community. The platform allows users to register subdomains under `lgbt.sh` for personal, organizational, or advocacy purposes. 

Subdomain registrations are available through two methods: email requests or by opening a GitHub issue. This ensures transparency and ease of access for a wide range of users. Abuse reporting mechanisms are in place to address any misuse.

---

## Reason for PSL Inclusion

The inclusion of `lgbt.sh` in the Public Suffix List is requested to ensure proper handling of cookies, security, and cross-origin policies. Being a public subdomain registry, `lgbt.sh` allows independent registration of subdomains by users, which makes its behavior closer to a TLD than a typical domain.

This inclusion will enhance compatibility with browsers and applications, enabling subdomain users to implement independent security policies without cross-origin interference from other subdomains.

**Number of users this request is being made to serve:**  
Approximately **180 active subdomains**, with potential for continued growth as registrations increase.

---

## DNS Verification

The following DNS verification records have been added:

```
dig +short TXT _psl.lgbt.sh
"https://github.com/publicsuffix/list/pull/2304"
```

---

## Test Results

The `make test` command was run as part of the submission process, and all tests passed successfully:

https://pastebin.com/raw/CLJnfQ5s

---

Thank you for considering this submission. I am happy to provide additional information or address any concerns the reviewers might have.