### PR TITLE
Add checkbox for contact method to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -97,7 +97,7 @@ proceed. Mislocated entries and trailing spaces should be avoided.
 -->
 
 <!--
-In your domain block submission, please include a role-based email address (e.g., hostmaster@example.com, noc@example.com) rather than a personal email address (e.g., jane.doe@example.com) under your organization name, so that the PSL project can maintain contact with your organization, independent of personnel changes.
+In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
 This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 14 days, as maintaining timely communication is required for continued inclusion in the PSL. If you receive any suspicious emails related to the PSL that deviate from PSL guidelines, please notify the PSL maintainers immediately.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -96,6 +96,13 @@ so getting this right initially will aid successfully having it
 proceed. Mislocated entries and trailing spaces should be avoided.
 -->
 
+<!--
+In your domain block submission, please include a role-based email address (e.g., hostmaster@example.com, noc@example.com) rather than a personal email address (e.g., jane.doe@example.com) under your organization name, so that the PSL project can maintain contact with your organization, independent of personnel changes.
+This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 14 days, as maintaining timely communication is required for continued inclusion in the PSL. If you receive any suspicious emails related to the PSL that deviate from PSL guidelines, please notify the PSL maintainers immediately.
+-->
+
+ * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 14 days.
+
 **Abuse Contact:**
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -98,7 +98,7 @@ proceed. Mislocated entries and trailing spaces should be avoided.
 
 <!--
 In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
-This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL. If you receive requests related to the PSL that seem unusual, please refer to our PSL guidelines to verify if the request is reasonable and compliant with our standards.
+This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
 -->
 
  * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -98,10 +98,10 @@ proceed. Mislocated entries and trailing spaces should be avoided.
 
 <!--
 In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
-This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 14 days, as maintaining timely communication is required for continued inclusion in the PSL. If you receive any suspicious emails related to the PSL that deviate from PSL guidelines, please notify the PSL maintainers immediately.
+This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL. If you receive requests related to the PSL that seem unusual, please refer to our PSL guidelines to verify if the request is reasonable and compliant with our standards.
 -->
 
- * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 14 days.
+ * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
 
 **Abuse Contact:**
 


### PR DESCRIPTION
Currently, domain submissions often use personal email addresses despite our preference for role-based addresses. However, this requirement isn't explicitly stated in our guidelines.

This PR attempts to add a new checkbox to the PR template to ensure submitters are using appropriate contact methods and understand the communication requirements for PSL inclusion. Also we've observed a "set and forget" pattern not only with the domains but also with the contact emails too, where submitters either use personal emails (which become invalid when they leave the organization) or set up role-based emails like `psl@example.org` that aren't actively monitored after submission.

The changes include:

1. Requirements for a role-based email addresses
2. Specified 14-day maximum response time for PSL inquiries
3. Added guidance for reporting suspicious communications - _attempts to partially address #2184 and then possibly close #2296 as the solutions proposed there seem impracticable/challenging to implement..._

**Note**: The guidelines should also be updated to include this requirement by someone with write access. (This would be easier if we migrate the guideline to a new website powered by GitHub Pages as previously discussed, allowing for better collaboration on such documentation.)

---

Preview:

In your domain block submission, please include a role-based email address (e.g., hostmaster@example.com, noc@example.com) rather than a personal email address (e.g., jane.doe@example.com) under your organization name, so that the PSL project can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 14 days, as maintaining timely communication is required for continued inclusion in the PSL. If you receive any suspicious emails related to the PSL that deviate from PSL guidelines, please notify the PSL maintainers immediately.

 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 14 days.