### PR TITLE
Add `netlib.re`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14357,6 +14357,10 @@ o365.cloud.nospamproxy.com
 // Submitted by Suranga Ranasinghe <security@mavicsoft.com>
 netfy.app
 
+// Net libre : https://www.netlib.re
+// Submitted by Philippe PITTOLI <security@netlib.re>
+netlib.re
+
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
 netlify.app

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14353,13 +14353,13 @@ ui.nabu.casa
 cloud.nospamproxy.com
 o365.cloud.nospamproxy.com
 
-// Netfy Domains : https://netfy.domains
-// Submitted by Suranga Ranasinghe <security@mavicsoft.com>
-netfy.app
-
 // Net libre : https://www.netlib.re
 // Submitted by Philippe PITTOLI <security@netlib.re>
 netlib.re
+
+// Netfy Domains : https://netfy.domains
+// Submitted by Suranga Ranasinghe <security@mavicsoft.com>
+netfy.app
 
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
- None. The rate limit of Let's Encrypt seems to be fine for now as I didn't experience any problem for the websites I manage and nobody contacted me to tell me otherwise.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:** abuse@netlib.re

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://netlib.re (section "Contact")

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

My website "www.netlib.re" provides subdomains such as "SOMETHING.netlib.re" for free. The users are guided through the configuration of their DNS zone. They simply fill in a form with what they want, and the corresponding zone file is automatically generated. The goal is to provide a user-friendly interface and to generate an error-free zone file. Also, `netlibre` provides a token-based `DynDNS-like` service, enabling a simple visit to https://www.netlib.re/token-update/TOKEN to update the IP address of a resource record.

My name is Philippe PITTOLI. I have developed the website and manage it as a private individual. It is not affiliated with any organization.

The service has been online for a decade and has recently been updated to a new version with a cleaner code (the source code is free). 

**Organization Website:** https://www.netlib.re

## Reason for PSL Inclusion

I provide "netlib.re" subdomains but don't host anything, apart from my own website "www.netlib.re". I am not responsible for the other "netlib.re" subdomains. Each one of them is distinct and belongs to a different owner. Browsers should therefore handle their cookies separately, which is why I request the related PSL inclusion.

**Number of users this request is being made to serve:** the service **currently** has 7000+ users.

I made a previous PR years ago https://github.com/publicsuffix/list/pull/500 but I did several mistakes and failed to respond in time.

## DNS Verification

```
dig +short TXT _psl.netlib.re
"https://github.com/publicsuffix/list/pull/2308"
```

## Syntax checking

`make test` result: https://pastebin.com/p0HujJeH