### PR TITLE
rename `GetLocalCert` to `LocalCert`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13390,11 +13390,6 @@ gentlentapis.com
 lab.ms
 cdn-edges.net
 
-// GetLocalCert : https://getlocalcert.net
-// Submitted by William Harrison <psl@getlocalcert.net>
-localcert.net
-localhostcert.net
-
 // GignoSystemJapan: http://gsj.bz
 // Submitted by GignoSystemJapan <kakutou-ec@gsj.bz>
 gsj.bz
@@ -14115,6 +14110,11 @@ we.bs
 // Submitted by Gerry Keh <biz@l53.net>
 filegear-sg.me
 ggff.net
+
+// LocalCert : https://localcert.net
+// Submitted by William Harrison <psl@localcert.net>
+localcert.net
+localhostcert.net
 
 // Localcert : https://localcert.dev
 // Submitted by Lann Martin <security@localcert.dev>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14111,14 +14111,14 @@ we.bs
 filegear-sg.me
 ggff.net
 
+// Localcert : https://localcert.dev
+// Submitted by Lann Martin <security@localcert.dev>
+*.user.localcert.dev
+
 // LocalCert : https://localcert.net
 // Submitted by William Harrison <psl@localcert.net>
 localcert.net
 localhostcert.net
-
-// Localcert : https://localcert.dev
-// Submitted by Lann Martin <security@localcert.dev>
-*.user.localcert.dev
 
 // Lodz University of Technology LODMAN regional domains https://www.man.lodz.pl/dns
 // Submitted by Piotr Wilk <dns@man.lodz.pl>


### PR DESCRIPTION
Last update was #2247, authored by me.

We are renaming it as there is no real reason for us to keep using `getlocalcert.net` when we already have `localcert.net`.

Note: User subdomains will still be hosted on both `localcert.net` and `localhostcert.net`, hence why they are still being included in the PSL. I understand the risks of continuing to have `localcert.net` listed.