### PR TITLE
Add ne.pw

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5408,6 +5408,7 @@ publ.pt
 pw
 belau.pw
 co.pw
+ne.pw
 ed.pw
 go.pw
 or.pw


### PR DESCRIPTION
Due to [#2200](https://github.com/publicsuffix/list/pull/2200)
We found the official website of the registry of the .pw top-level domain, which shows that ne.pw is still a valid second-level domain suffix. It would be hasty to remove ne.pw under the current circumstances. Please reconsider.
.pw registry website: https://pwregistry.pw/