### PR TITLE
remove `shiftedit.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15144,10 +15144,6 @@ as.sh.cn
 // Submitted by Nyoom <admin@sheezy.art>
 sheezy.games
 
-// ShiftEdit : https://shiftedit.net/
-// Submitted by Adam Jimenez <adam@shiftcreate.com>
-shiftedit.io
-
 // Shopblocks : http://www.shopblocks.com/
 // Submitted by Alex Bowers <alex@shopblocks.com>
 myshopblocks.com


### PR DESCRIPTION
Reasons for removal:
- Domain expired 2024-10-27
- No results on Google
- No results on https://subdomainfinder.c99.nl/

Note: The domain is in a redemption period, according to a WHOIS lookup, however it seems they will not be renewing it as it expired over a month ago and still hasn't been renewed.

Pretty basic removal, domain is expired, should be safe to remove.