### PR TITLE
remove `herokussl.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13718,7 +13718,7 @@ heliohost.us
 hepforge.org
 
 // Heroku : https://www.heroku.com/
-// Submitted by Tom Maher <tmaher@heroku.com>
+// Submitted by Shumon Huque <public-dns@salesforce.com>
 herokuapp.com
 
 // Heyflow : https://www.heyflow.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13720,7 +13720,6 @@ hepforge.org
 // Heroku : https://www.heroku.com/
 // Submitted by Tom Maher <tmaher@heroku.com>
 herokuapp.com
-herokussl.com
 
 // Heyflow : https://www.heyflow.com
 // Submitted by Mirko Nitschke <tech@heyflow.com>


### PR DESCRIPTION
Reasons for removal:
- Heroku no longer uses `herokussl.com` for SSL certificates, it now uses `herokudns.com` - you see no mention of the domain in their support article (last updated 2nd February, 2024) on SSL certificates: https://devcenter.heroku.com/articles/ssl
- Another article, on TLS, shows `herokudns.com` being used instead of `herokussl.com`: https://devcenter.heroku.com/articles/understanding-tls-on-heroku
- There have been no SSL certificates issued on the domain itself either since 2019: https://crt.sh/?q=herokussl.com (note: no SSLs have been issued on `herokudns.com` since 2020 either, however it is actively shown and used in documentation regarding SSL)

There does not seem to be any evidence of usage of this domain and it should be safe to say it is no longer in use and can be removed.