### PR TITLE
update `.us`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5968,13 +5968,11 @@ police.uk
 *.sch.uk
 
 // us : https://www.iana.org/domains/root/db/us.html
+// Confirmed via the .us zone file by William Harrison - 2024-12-10
 us
 dni.us
-fed.us
 isa.us
-kids.us
-nsn.us
-// us geographic names
+// Geographic Names
 ak.us
 al.us
 ar.us
@@ -6201,15 +6199,15 @@ lib.wi.us
 // lib.wv.us  Bug 941670 - Removed at request of Larry W Arnold <arnold@wvlc.lib.wv.us>
 lib.wy.us
 // k12.ma.us contains school districts in Massachusetts. The 4LDs are
-//  managed independently except for private (PVT), charter (CHTR) and
-//  parochial (PAROCH) schools.  Those are delegated directly to the
-//  5LD operators.   <k12-ma-hostmaster _ at _ rsuc.gweep.net>
+// managed independently except for private (PVT), charter (CHTR) and
+// parochial (PAROCH) schools. Those are delegated directly to the
+// 5LD operators. <k12-ma-hostmaster@rsuc.gweep.net>
 chtr.k12.ma.us
 paroch.k12.ma.us
 pvt.k12.ma.us
 // Merit Network, Inc. maintains the registry for =~ /(k12|cc|lib).mi.us/ and the following
-//    see also: http://domreg.merit.edu
-//    see also: whois -h whois.domreg.merit.edu help
+// see also: https://domreg.merit.edu : domreg@merit.edu
+// see also: whois -h whois.domreg.merit.edu help
 ann-arbor.mi.us
 cog.mi.us
 dst.mi.us

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5972,6 +5972,7 @@ police.uk
 us
 dni.us
 isa.us
+nsn.us
 // Geographic Names
 ak.us
 al.us


### PR DESCRIPTION
I now have root zone file access for the .us TLD, so I have decided to update the entries for it as per #2265.

- `fed.us` - Removed as there is no existing DNS records under this name (at `fed.us` or any higher levels like `example.fed.us`)
- `kids.us` - There is a single website hosted under this which is at the root (http://kids.us) which shows the 2LD was shut down back in 2012, here is the link to the suspension document: https://www.ntia.doc.gov/files/ntia/publications/ustld_27_jun_2012_mod_012-1.pdf

I have not modified geographic names at this point as I have no effective way to filter them out at this point in time. However I have gone around and updated some comments in that section.