### PR TITLE
remove `curv.dev`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12531,10 +12531,6 @@ on.crisp.email
 // Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
 *.cryptonomic.net
 
-// Curv UG : https://curv-labs.de/
-// Submitted by Marvin Wiesner <Marvin@curv-labs.de>
-curv.dev
-
 // cyber_Folks S.A. : https://cyberfolks.pl
 // Submitted by Bartlomiej Kida <security@cyberfolks.pl>
 cfolks.pl


### PR DESCRIPTION
Originally added in #968.

Reasons for removal:
- `_psl.curv.dev` TXT record no longer resolves, which provokes the that idea that PSL status is no longer required, as this TXT record was present when the domain was added to the PSL.
- No results on Google or Bing for `site:curv.dev`, despite the reason for inclusion being that customer websites will be on this domain.
- Few results show up from a subdomain scan, most of which do not resolve properly, if at all: https://subdomainfinder.c99.nl/scans/2024-12-10/curv.dev (also, it is well below our required threshold for inclusion)
- Very few results show up when searching for SSL certificates under the domain: https://crt.sh/?q=curv.dev&exclude=expired&group=none

It is quite evident this domain is not being actively used and should be able to be safely removed.