### PR TITLE
remove Danger Science section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12544,12 +12544,6 @@ cfolks.pl
 cyon.link
 cyon.site
 
-// Danger Science Group: https://dangerscience.com/
-// Submitted by Skylar MacDonald <skylar@dangerscience.com>
-platform0.app
-fnwk.site
-folionetwork.site
-
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>
 biz.dk


### PR DESCRIPTION
Reasons for removal:
- No active SSL certificates on `fwnk.site` or `folionetwork.site`: https://crt.sh/?q=fnwk.site&exclude=expired https://crt.sh/?q=folionetwork.site&exclude=expired
- Very few active SSL certificates found on `platform0.app`: https://crt.sh/?q=platform0.app&exclude=expired
  - I believe they may issue SSLs on a per domain basis, and only use wildcards on the occasion where no website exists using a wildcard (e.g. https://exampletest123.platform0.app)
- In the original PR #1074, the domains `fwnk.site` and `folionetwork.site` were intended to be used by https://folio.network, however the domain does not have any A/AAAA records, therefore it doesn't resolve.
- No results on Google or Bing for any of the domains when searching using `site:{domain}`.
- `_psl.fwnk.site` is missing, however for the other 2 domains it is still in place.

It is evident that `fwnk.site` and `folionetwork.site` are not in use any more. `platform0.app` does appear to get an extremely small amount of use, however it is nowhere near our threshold for inclusion and should be removed. I think these domains can be safely removed.