### PR TITLE
remove Diher Solutions section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12638,11 +12638,6 @@ ondigitalocean.app
 // Submitted by Edward Hsing <contact@digitalplat.org>
 us.kg
 
-// Diher Solutions : https://diher.solutions
-// Submitted by Didi Hermawan <mail@diher.solutions>
-rss.my.id
-diher.solutions
-
 // Discord Inc : https://discord.com
 // Submitted by Sahn Lam <slam@discordapp.com>
 discordsays.com


### PR DESCRIPTION
In the original PR (#1393) adding these domains, the author stated that different customers will be allocated subdomains of these domains.

However it does not seem the domains are being used by other parties, especially as there doesn't seem to be any subdomain usage.

- No subdomains are found on diher.solutions or rss.my.id when searching using a subdomain finder: https://subdomainfinder.c99.nl/
- When searching `site:diher.solutions` on Google the only site that shows up is the root domain which appears to be a personal site, not a web hosting service which was what the submitter was intending for these domains to be used for.
- When searching `site:rss.my.id` on Google only results from the root domain are shown, no subdomains are found, it appears to just be a personal blog.
- Certificate logs only show active SSLs for the root domain, no subdomains for `diher.solutions`: https://crt.sh/?q=diher.solutions&exclude=expired
- Certificate logs for `rss.my.id` do have SSLs issued for `*.rss.my.id`, however there are no subdomains found when using other services, nor any that don't actively point to the root domain through a wildcard. It seems there is a wildcard DNS record setup to just point to the root domain so when you go to a subdomain, it shows the root website (e.g. https://exampletest123.rss.my.id)

It seems these domains are purely used for personal purposes, which is against our guidelines:
> The PSL is a globally used resource. PR submitters should understand that tens of millions, perhaps hundreds of millions of devices and uses may incorporate the change being requested, and need to consider if the request authentically merits such widespread inclusion. Expanding the file size even in small ways increases the overhead for everyone. File Size and scale of impact of a request is a consideration. Requests being minimal is important.

> Projects that are smaller in scale or are temporary or seasonal in nature will likely be declined. Examples of this might be private-use, sandbox, test, lab, beta, or other exploratory nature changes or requests. It should be expected that despite whatever site or service referred a requestor to seek addition of their domain(s) to the list, projects not serving more then thousands of users are quite likely to be declined.

I think these domains should be removed, and I believe they can be removed safely as there does not seem to be much evidence of usage.