### PR TITLE
remove `aaa.vodka`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11231,10 +11231,6 @@ ltd.ua
 a2hosted.com
 cpserver.com
 
-// AAA workspace : https://aaa.vodka
-// Submitted by Kirill Rezraf <admin@aaa.vodka>
-aaa.vodka
-
 // Acorn Labs : https://acorn.io
 // Submitted by Craig Jellick <domains@acorn.io>
 *.on-acorn.io


### PR DESCRIPTION
Originally added in #1795.

Reasons for removal:
- No website loads on https://aaa.vodka, which is specified as the company URL
- The contact email address does not exist as there are no MX records at `aaa.vodka` (pointed out by @groundcat in https://github.com/publicsuffix/list/pull/1795#discussion_r1746293949, however he received no response)
- No sites found on Google when searching `site:aaa.vodka`
- Only one subdomain found using a subdomain finder: https://subdomainfinder.c99.nl/scans/2024-12-11/aaa.vodka
  - It is worth noting, the subdomain found `nugget.aaa.vodka`, seems to be a very simple static website, and it is also worth pointing out the domain is added as a zone on Cloudflare as it has Cloudflare NS records, I believe the original request may have just been used to evade Cloudflare's restrictions on subdomain zones.
- The user originally said users would host websites under the domain, however no sites are found, except for one, which does not meet our requirements.
- A few active SSL certificates are found for < 5 subdomains, all which appear to be auto-generated by Cloudflare. All of the hostnames found are active as zones on Cloudflare.

It appears the original request was created with malicious intent, in order to evade restrictions set by Cloudflare, which is against our guidelines:
> We do not accept entries that have the objective of getting around limitations that have been put in place by a vendor to protect internet users. The PSL is not a 'workaround', and Pull Requests that appear to be doing this should expect to be declined. Be thorough and candid with the rationale furnished with the request.

The author of the original PR stated that they have 10,000 users, however it is quite evident they do not. 

I believe we can safely remove this domain as it appears to only have been added with malicious intent. @groundcat did originally try to contact the owner through a GitHub comment regarding the invalid email address around 3 months ago however received no response.