### PR TITLE
remove `001www.com` and `now-dns.top`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14518,7 +14518,6 @@ notion.site
 dnsking.ch
 mypi.co
 n4t.co
-001www.com
 myiphost.com
 forumz.info
 soundcast.me
@@ -14531,7 +14530,6 @@ vpndns.net
 dynserv.org
 now-dns.org
 x443.pw
-now-dns.top
 ntdll.top
 freeddns.us
 


### PR DESCRIPTION
Both domains have had a hold status for an extended period of time, likely over 45 days, and the Now DNS project is still an active project however has appeared to make no attempt to remove the hold on these domains.

See #2322 for more information, specifically https://github.com/publicsuffix/list/issues/2322#issuecomment-2533488209.