### PR TITLE
update `.az` section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -287,9 +287,10 @@ com.aw
 ax
 
 // az : https://www.iana.org/domains/root/db/az.html
-// https://whois.az/?page_id=10
+// Confirmed via https://whois.az/?page_id=10 2024-12-11
 az
 biz.az
+co.az
 com.az
 edu.az
 gov.az
@@ -300,7 +301,6 @@ name.az
 net.az
 org.az
 pp.az
-pro.az
 
 // ba : http://nic.ba/users_data/files/pravilnik_o_registraciji.pdf
 ba

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -301,6 +301,9 @@ name.az
 net.az
 org.az
 pp.az
+// No longer available for registration, however domains exist as of 2024-12-11
+// see https://whois.az/?page_id=783
+pro.az
 
 // ba : http://nic.ba/users_data/files/pravilnik_o_registraciji.pdf
 ba


### PR DESCRIPTION
The [IANA page](https://www.iana.org/domains/root/db/az.html) shows `whois.az` as the authoritative source for the TLD.

List confirmed via https://whois.az/?page_id=10 section 2.2

`pro.az` is no longer available for registration, however according to the [statistics page](https://whois.az/?page_id=783) it still has some registered domains. We will keep it for legacy reasons.