### PR TITLE
remove `lab.ms`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13388,7 +13388,6 @@ usercontent.jp
 // Submitted by Tom Klein <tom@gentlent.com>
 gentapps.com
 gentlentapis.com
-lab.ms
 cdn-edges.net
 
 // GignoSystemJapan: http://gsj.bz


### PR DESCRIPTION
Originally added in #807, back in 2019.

Reasons for removal:
- The domain is no longer controlled by `Gentlent, Inc.`.
	- The domain's registration date via a WHOIS lookup is `2024-07-25`, which is very recent, when the domain was added to the PSL around 5 years ago. The new registrant's name is `Flame Lab Initiative` according to WHOIS, which is not the original registrants.

Should be safe to remove, as it is no longer owned by the original registrant.