### PR TITLE
remove `secaas.hk`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13741,10 +13741,6 @@ homesklep.pl
 *.id.pub
 *.kin.pub
 
-// Hong Kong Productivity Council: https://www.hkpc.org/
-// Submitted by SECaaS Team <summchan@hkpc.org>
-secaas.hk
-
 // Hoplix : https://www.hoplix.com
 // Submitted by Danilo De Franco<info@hoplix.shop>
 hoplix.shop


### PR DESCRIPTION
Domain was added in #1138, in 2020, however the registration date for the domain is 07-05-2024, it is clear it is no longer controlled by the original registrant and should be removed.

The current registrant is shown to be `YMHC CHARITABLE FOUNDATION`, which is a completely different organisation. This domain should be safe to remove.