### PR TITLE
remove `lelux.site`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14068,10 +14068,6 @@ leadpages.co
 lpages.co
 lpusercontent.com
 
-// Lelux.fi : https://lelux.fi/
-// Submitted by Lelux Admin <publisuffix@lelux.site>
-lelux.site
-
 // libp2p project : https://libp2p.io
 // Submitted by Interplanetary Shipyard <domains@ipshipyard.com>
 libp2p.direct


### PR DESCRIPTION
Domain was added in #849, in 2019, however the registration date of the domain is 2023-11-30, it is clear the domain lapsed and has changed registrants.

This domain should be safe to remove.