### PR TITLE
remove `yombo.me`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15723,10 +15723,6 @@ official.academy
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com
 
-// Yombo : https://yombo.net
-// Submitted by Mitch Schwenk <mitch@yombo.net>
-yombo.me
-
 // Yunohost : https://yunohost.org
 // Submitted by Valentin Grimaud <security@yunohost.org>
 ynh.fr


### PR DESCRIPTION
Domain was originally added in #331, in 2016, however the registration date for the domain is 2023-11-30, suggesting that the domain lapsed (like the other 6 domains removed in #2173) and has changed registrants.

It should be safe to remove this domain.