### PR TITLE
update `.bw` section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -679,10 +679,12 @@ org.bt
 bv
 
 // bw : https://www.iana.org/domains/root/db/bw.html
-// http://www.gobin.info/domainname/bw.doc
-// list of other 2nd level tlds ?
+// https://nic.net.bw/bw-name-structure
 bw
+ac.bw
 co.bw
+gov.bw
+net.bw
 org.bw
 
 // by : https://www.iana.org/domains/root/db/by.html


### PR DESCRIPTION
IANA page: https://www.iana.org/domains/root/db/bw.html

https://nic.net.bw is the listed registry site, and under https://nic.net.bw/bw-name-structure it has a list of all the 2LDs. This is an authoritative source and can be trusted.