### PR TITLE
remove `iliadboxos.it`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13739,7 +13739,6 @@ iki.fi
 // iliad italia : https://www.iliad.it
 // Submitted by Marios Makassikis <mmakassikis@freebox.fr>
 ibxos.it
-iliadboxos.it
 
 // Incsub, LLC : https://incsub.com/
 // Submitted by Aaron Edwards <sysadmins@incsub.com>


### PR DESCRIPTION
Domain name has expired as of `2024-12-14`.

It still appears to [have some use](https://subdomainfinder.c99.nl/scans/2024-12-15/iliadboxos.it), however if it isn't renewed in ~7 days I would say it should be removed.