### PR TITLE
chore: update website URL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15568,7 +15568,7 @@ toolforge.org
 wmcloud.org
 wmflabs.org
 
-// William Harrison : https://wdh.gg
+// William Harrison : https://wharrison.com.au
 // Submitted by William Harrison <william@harrison.id.au>
 wdh.app
 


### PR DESCRIPTION
I may end up deprecating wdh.gg at some point so I am just putting my direct website link, also it just redirects to my website anyways.