### PR TITLE
remove `platter-app.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14652,9 +14652,8 @@ us.platform.sh
 *.platformsh.site
 *.tst.site
 
-// Platter: https://platter.dev
+// Platter : https://platter.dev
 // Submitted by Patrick Flor <patrick@platter.dev>
-platter-app.com
 platter-app.dev
 platterp.us
 


### PR DESCRIPTION
Pointed out in #2345, domain was originally added in #935.

Reasons for removal:
- Domain was added to the PSL over 4 years ago, however according to WHOIS it was registered `2023-06-16`, indicating the owner has changed. (The registrant contacts compared to the other entries in this block are completely different companies)
- Domain is listed for sale on HugeDomains.com, indicating no usage: https://www.hugedomains.com/domain_profile.cfm?d=platter-app&e=com
	- In WHOIS, the domain's registrant name is listed as `Domain Admin / This Domain is For Sale`.

It is evident this domain lapsed and has been picked up by a new company. This domain should be safe to remove.

I had a look at the other domains in this section (only via WHOIS) and they all appear to still be registered to the same company.