### PR TITLE
remove `drud.io` and `drud.us`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12684,11 +12684,6 @@ durumis.com
 // Submitted by Ricardo Padilha <rpadilha@drobo.com>
 mydrobo.com
 
-// Drud Holdings, LLC. : https://www.drud.com/
-// Submitted by Kevin Bridges <kevin@drud.com>
-drud.io
-drud.us
-
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org


### PR DESCRIPTION
Pointed out in #2345, domain was originally added in #234.

Reasons for removal:
- Both domains have a registration date, post addition to the PSL, indicating new registrants have taken control of them.
	- drud.io: 2021-05-11
	- drud.us: 2021-02-10
- drud.us' registrant is `Tom Van Goethem` associated with the organisation `VaGoSec`, which is completely different to the original registrant.
- drud.io's registrant is redacted, however it is extremely unlikely it is still associated with the same organisation.
- Both new registrations are at completely different registrars, so I would doubt that the same company is controlling them.

These domains should be safe to remove.