### PR TITLE
remove `spacekit.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15145,10 +15145,6 @@ srht.site
 apps.lair.io
 *.stolos.io
 
-// SpaceKit : https://www.spacekit.io/
-// Submitted by Reza Akhavan <spacekit.io@gmail.com>
-spacekit.io
-
 // SparrowHost : https://sparrowhost.in/
 // Submitted by Anant Pandey <info@sparrowhost.in>
 ind.mom


### PR DESCRIPTION
Pointed out in #2345, originally added in #166.

Reasons for removal:
- Domain was added to the PSL in 2016, however it was registered on `2022-05-10` according to WHOIS.
- The nameservers of the domain appear to point to parking nameservers: `a.dns.park.io` `b.dns.park.io`
- The domain is listed for sale on https://park.io according to the webpage on the domain: http://spacekit.io/

This domain should be able to be safely removed.