### PR TITLE
remove `TwoDNS` block

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15404,22 +15404,6 @@ site.transip.me
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
 tuxfamily.org
 
-// TwoDNS : https://www.twodns.de/
-// Submitted by TwoDNS-Support <support@two-dns.de>
-dd-dns.de
-dray-dns.de
-draydns.de
-dyn-vpn.de
-dynvpn.de
-mein-vigor.de
-my-vigor.de
-my-wan.de
-syno-ds.de
-synology-diskstation.de
-synology-ds.de
-diskstation.eu
-diskstation.org
-
 // Typedream : https://typedream.com
 // Submitted by Putri Karunia <putri@typedream.com>
 typedream.app


### PR DESCRIPTION
The service is shutting down tomorrow (20th December, 2024) according to their website: https://www.twodns.de/en

I will email them asking them to confirm this PR though.