### PR TITLE
remove `4u.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14289,10 +14289,6 @@ netfy.app
 // Submitted by Jessica Parsons <jessica@netlify.com>
 netlify.app
 
-// Neustar Inc.
-// Submitted by Trung Tran <Trung.Tran@neustar.biz>
-4u.com
-
 // NFSN, Inc. : https://www.NearlyFreeSpeech.NET/
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
 nfshost.com


### PR DESCRIPTION
Reasons for removal:
- No subdomains found on Google: `site:4u.com`
- No active subdomains found using a [subdomain finder](https://subdomainfinder.c99.nl/scans/2024-12-19/4u.com)
- No SSL certificates found for any subdomains excluding `www.4u.com`: https://crt.sh/?q=4u.com&exclude=expired&match=all

I believe they are either no longer issuing subdomains of this domain or the domain may have changed registrants. This domain was likely added pre-GitHub as I could not find any PRs for it.

I think this domain can be removed safely, unless anyone has any comments regarding it. cc @groundcat