### PR TITLE
add PSL Sandbox

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13594,6 +13594,15 @@ häkkinen.fi
 // Submitted by William Harrison <psl@hrsn.net>
 hrsn.dev
 
+// Harrison Network - PSL Sandbox : https://sandbox.psl.hrsn.dev
+// Submitted by William Harrison <psl@hrsn.net>
+!ignored.sub.wc.psl.hrsn.dev  
+!ignored.wc.psl.hrsn.dev
+!ignored.sub.psl.hrsn.dev  
+*.sub.wc.psl.hrsn.dev  
+*.wc.psl.hrsn.dev  
+sub.psl.hrsn.dev
+
 // Hashbang : https://hashbang.sh
 hashbang.sh
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13596,12 +13596,12 @@ hrsn.dev
 
 // Harrison Network - PSL Sandbox : https://sandbox.psl.hrsn.dev
 // Submitted by William Harrison <psl@hrsn.net>
-!ignored.sub.wc.psl.hrsn.dev
-!ignored.wc.psl.hrsn.dev
-!ignored.sub.psl.hrsn.dev
 *.sub.wc.psl.hrsn.dev
+!ignored.sub.wc.psl.hrsn.dev
 *.wc.psl.hrsn.dev
+!ignored.wc.psl.hrsn.dev
 sub.psl.hrsn.dev
+!ignored.sub.psl.hrsn.dev
 
 // Hashbang : https://hashbang.sh
 hashbang.sh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13594,14 +13594,6 @@ häkkinen.fi
 // Submitted by William Harrison <psl@hrsn.net>
 hrsn.dev
 
-// Harrison Network - PSL Sandbox : https://sandbox.psl.hrsn.dev
-// Submitted by William Harrison <psl@hrsn.net>
-sub.psl.hrsn.dev
-*.wc.psl.hrsn.dev
-!ignored.wc.psl.hrsn.dev
-*.sub.wc.psl.hrsn.dev
-!ignored.sub.wc.psl.hrsn.dev
-
 // Hashbang : https://hashbang.sh
 hashbang.sh
 
@@ -14690,6 +14682,14 @@ priv.at
 // Protonet GmbH : http://protonet.io
 // Submitted by Martin Meier <admin@protonet.io>
 protonet.io
+
+// PSL Sandbox : https://psl.hrsn.dev
+// Submitted by William Harrison <psl@hrsn.net>
+sub.psl.hrsn.dev
+*.wc.psl.hrsn.dev
+!ignored.wc.psl.hrsn.dev
+*.sub.wc.psl.hrsn.dev
+!ignored.sub.wc.psl.hrsn.dev
 
 // Publication Presse Communication SARL : https://ppcom.fr
 // Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13601,7 +13601,6 @@ hrsn.dev
 *.wc.psl.hrsn.dev
 !ignored.wc.psl.hrsn.dev
 sub.psl.hrsn.dev
-!ignored.sub.psl.hrsn.dev
 
 // Hashbang : https://hashbang.sh
 hashbang.sh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13596,11 +13596,11 @@ hrsn.dev
 
 // Harrison Network - PSL Sandbox : https://sandbox.psl.hrsn.dev
 // Submitted by William Harrison <psl@hrsn.net>
-!ignored.sub.wc.psl.hrsn.dev  
+!ignored.sub.wc.psl.hrsn.dev
 !ignored.wc.psl.hrsn.dev
-!ignored.sub.psl.hrsn.dev  
-*.sub.wc.psl.hrsn.dev  
-*.wc.psl.hrsn.dev  
+!ignored.sub.psl.hrsn.dev
+*.sub.wc.psl.hrsn.dev
+*.wc.psl.hrsn.dev
 sub.psl.hrsn.dev
 
 // Hashbang : https://hashbang.sh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13596,11 +13596,11 @@ hrsn.dev
 
 // Harrison Network - PSL Sandbox : https://sandbox.psl.hrsn.dev
 // Submitted by William Harrison <psl@hrsn.net>
-*.sub.wc.psl.hrsn.dev
-!ignored.sub.wc.psl.hrsn.dev
+sub.psl.hrsn.dev
 *.wc.psl.hrsn.dev
 !ignored.wc.psl.hrsn.dev
-sub.psl.hrsn.dev
+*.sub.wc.psl.hrsn.dev
+!ignored.sub.wc.psl.hrsn.dev
 
 // Hashbang : https://hashbang.sh
 hashbang.sh


### PR DESCRIPTION
The goal for this section of the PSL is to create a sandbox for testing the affects of different rules on the PSL.

This implements #1349.

The sandbox hasn't been deployed yet, however once these entries are listed I will deploy one so users can test out various differences domains have for when they are on the PSL.

Note: I have added these under subdomains of psl.hrsn.dev in order to prevent any potential problems or overlaps with the existence of the `hrsn.dev` rule. Also, I've added this in a new section as I would like these entries to remain as a separate "project" to Harrison Network specifically.

It also might be worth noting that these will be the first exception rules `!` in the private section. 

All `_psl` TXT records have been put in place for the corresponding names.