### PR TITLE
Remove Hakaran group domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13578,14 +13578,6 @@ grayjayleagues.com
 günstigbestellen.de
 günstigliefern.de
 
-// Hakaran group : http://hakaran.cz
-// Submitted by Arseniy Sokolov <security@hakaran.cz>
-fin.ci
-free.hr
-caa.li
-ua.rs
-conf.se
-
 // Häkkinen.fi : https://www.häkkinen.fi/
 // Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
 häkkinen.fi


### PR DESCRIPTION
Originally added in
- #733

Steps:
- I attempted to email `security@hakaran.cz` on 2024-09-05, but it was unreachable.
- The organization's website, `http://hakaran.cz`, is not working.
- I tried [tagging](https://github.com/publicsuffix/list/pull/733#issuecomment-2332990195) the requester on 2024-09-05 in the initial GitHub PR, but received no response.
- No subdomains were observed (CT, Google) for all domains, except for `free.hr`, which seems to have changed ownership (`GRANSY d.o.o.` from WHOIS no longer match `Hakaran group`) and is no longer owned by the initial requesting organization.
- `fin.bj` has already expired and is now available for registration. According to WHOIS: `Domain Status: No Object Found`.
- @wdhdev @fakeboboliu might have more information if you would like to share your other findings. Thanks to @fakeboboliu for reminding me about this.

These indications strongly suggest this no longer belongs to the original requester, and the original organization is out of operation. The domains are no longer with them. I have exhausted all means to contact the original requester; no response after 3 months should be ample time for a missing-in-action status.

If the current registrant/owner of any of these domains would like to keep them in the PSL, they should submit an inclusion request to PSL or update their contact info with reasonable rationales, `_psl` records, expiration, abuse contact info, etc. - we would treat it as equivalent to a brand new PSL inclusion request with all requirements and criteria applicable.