### PR TITLE
add `edu.vg`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6271,7 +6271,9 @@ tec.ve
 web.ve
 
 // vg : https://www.iana.org/domains/root/db/vg.html
+// Confirmed by registry <tld.ops@centralnic.com> 2025-01-10
 vg
+edu.vg
 
 // vi : https://www.iana.org/domains/root/db/vi.html
 vi


### PR DESCRIPTION
Email sent to gmalone@trc.vg; tld.ops@centralnic.com on 2024-12-10 (the contacts listed on the [IANA page](https://www.iana.org/domains/root/db/vg.html)), received a reply on 2025-01-10 from tld.ops@centralnic.com. 

Email forwarded to @simon-friedberger and @dnsguru.

```
Adam Russell (CentralNic Registry) 
10 Jan 2025, 09:42 UTC 
Hi William,
 
Firstly, thank you for your voluntary work and secondly:
Apologies for the delayed response, our ticket handler didnt like the formatting and your ticket ended up in a catch-all bucket.
 
The only one I have is edu.vg
 
Regards,
Adam
```