### PR TITLE
Remove `obl.ong`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14477,10 +14477,6 @@ nyc.mn
 // Submitted by the prvcy.page Registry Team <info@o3o.foundation>
 prvcy.page
 
-// Obl.ong : https://obl.ong
-// Submitted by Reese Armstrong <team@obl.ong>
-obl.ong
-
 // Observable, Inc. : https://observablehq.com
 // Submitted by Mike Bostock <dns@observablehq.com>
 observablehq.cloud


### PR DESCRIPTION
This PR proposes to remove the `obl.ong` entry from the PSL. It was added by #1830 on 2023-08-11

The project appears to be defunct for > 30 days and no longer in active use:

1. Domain returns SERVFAIL [responses](https://www.nslookup.io/domains/obl.ong/dns-records/#cloudflare) consistently when checked against multiple DNS resolvers (1.1.1.1, 8.8.8.8) for at least 30 days
2. No working website found via site:obl.ong searches
3. Required `_psl.obl.ong` TXT record is [not maintained](https://www.nslookup.io/domains/_psl.obl.ong/dns-records/#cloudflare) as required for PSL inclusion
4. Domain was only added in August 2023, so it does not qualify for exemption from the _psl TXT record maintenance requirement
5. Expires  2026-11-04 < 2 years from now

Multiple attempts were made to contact the domain owners before proposing removal:

1. Email sent to contact address listed in PSL on 2024-12-29
2. GitHub mention/tag to original committer
3. Email sent to committer's personal email on 2024-12-29

No response received to any contact attempts

DNS checks performed show consistent SERVFAIL responses:

```
$  dig obl.ong @1.1.1.1
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 9897

$  dig obl.ong @8.8.8.8
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 59545
```
