### PR TITLE
Update `ug`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5941,15 +5941,21 @@ zp.ua
 zt.ua
 
 // ug : https://www.registry.co.ug/
+// https://www.registry.co.ug, https://whois.co.ug
+// Confirmed by registry <support@i3c.co.ug> 2025-01-20
 ug
 ac.ug
 co.ug
 com.ug
+edu.ug
 go.ug
+gov.ug
+mil.ug
 ne.ug
 or.ug
 org.ug
 sc.ug
+us.ug
 
 // uk : https://www.iana.org/domains/root/db/uk.html
 // Submitted by registry <Michael.Daly@nominet.org.uk>


### PR DESCRIPTION
Steps taken:

1. From https://www.iana.org/domains/root/db/ug.html, I identified the registry website http://www.registry.co.ug
2. I found the email address support@registry.co.ug, support@i3c.co.ug
3. I sent emails to support@registry.co.ug, support@i3c.co.ug
4. I received a response from `Francis Ntuuwa <fntuuwa@gc.i3c.co.ug>`

[email.eml.txt](https://github.com/user-attachments/files/18482983/email.eml.txt)

```
Hello,

Thank you for your inquiry regarding the second-level domains under .ug.

This is the list of second-level domains (SLDs) available under .ug.
.com.ug
.ug
.co.ug
.org.ug
.edu.ug
.mil.ug
.gov.ug
.go.ug
.us.ug
.sc.ug
.ne.ug
.or.ug
.ac.ug

The information on our websites, https://www.registry.co.ug and https://whois.co.ug, is indeed authoritative and up-to-date regarding the public suffixes we support.

Incase of any further questions, don't hesitate to contact us.

Kind regards,
```

**Note**: 
- Moving forward, I will make sure to always CC Jothan on outbound emails from this account for outreach purposes.

---

Since sites using the `.ug` top-level domain exist (https://www.google.com/search?q=site%3Aug), consolidating entries to `*.ug` is not a feasible solution.