### PR TITLE
Add obj.ag to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15476,6 +15476,10 @@ unison-services.cloud
 virtual-user.de
 virtualuser.de
 
+// United States Writing Corporation : https://uswriting.co
+// Submitted by Andrew Sampson <security@obj.ag>
+obj.ag
+
 // UNIVERSAL DOMAIN REGISTRY : https://www.udr.org.yt/
 // see also: whois -h whois.udr.org.yt help
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@udr.org.yt>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] **Description of Organization**
* [x] **Robust Reason for PSL Inclusion**
* [x] **DNS verification** via `dig`
* [x] **Domain Renewal**: I confirm `obj.ag` has 2+ years left on its registration, and I will keep the `_psl` TXT record in place.

---

__Submitter affirms the following:__

* [x] **No third-party limit workaround**  
  This request was not submitted to circumvent third-party rate limits or restrictions.

* [x] **Responsibility for Maintenance**  
  I acknowledge it is my responsibility to maintain these entries (removing unused names, renewing the domain, keeping `_psl` DNS entries live, etc.). Noncompliance may lead to removal.

* [x] **Guidelines Read & Understood**  
  I have carefully read the [PSL Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) and confirm this request aligns with them.

* [x] **Formatting & Sorting**  
  The entries are placed in the **PRIVATE DOMAINS** section and sorted alphabetically based on the organization name comment.

* [x] **Role-based Email**  
  A role-based email address is provided below, actively monitored for PSL-related queries.

* [x] **Abuse Contact**  
  Abuse contact info is published on our site and is easily discoverable:
  - URL for abuse reporting: **[obj.ag](https://obj.ag)** 

---

> *I understand that once merged, there is no guaranteed timeline for downstream adoption by browsers or other PSL consumers. If a rollback is needed, it may also take an indefinite amount of time to propagate.*

---

## Description of Organization

**Organization Name:** United States Writing Corporation  
**Website:** [https://uswriting.co](https://uswriting.co)  

United States Writing Corporation (USWC) is building the https://objex.ai platform that lets creators, writers, and other users upload arbitrary files to be publicly accessible. I am the founder of USWC, responsible for domain. This request is submitted to ensure proper subdomain isolation for our users.

## Reason for PSL Inclusion

We allocate subdomains under `obj.ag` to our users so that each user’s uploaded content is served via a unique subdomain, for example `{id}.obj.ag`. Since multiple mutually untrusting users share the base domain, we need each subdomain to be recognized as its own “cookie boundary.” By listing `obj.ag` in the PSL, browsers and other PSL consumers will treat `1.obj.ag` distinctly from `2.obj.ag`, preventing unintended cookie or security policy overlap.

- The domain `obj.ag` has **more than two years** before expiration.
- We will keep `_psl.obj.ag` TXT records in DNS for verification and to signal ongoing PSL inclusion.

**Number of users served:** At the time of opening this PR, zero. However we have roughly ~5,000 waitlisted (not including their teams).

## DNS Verification 
```
dig +short TXT _psl.obj.ag
"https://github.com/publicsuffix/list/pull/2374"
```
---