### PR TITLE
Add *.square.site for Block, Inc.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12283,6 +12283,10 @@ blackbaudcdn.net
 // Submitted by Luke Bratch <luke@bratch.co.uk>
 of.je
 
+// Block, Inc. : https://block.xyz
+// Submitted by Jonathan Boice <security@block.xyz>
+*.square.site
+
 // Blue Bite, LLC : https://bluebite.com
 // Submitted by Joshua Weiss <admin.engineering@bluebite.com>
 bluebite.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12285,7 +12285,7 @@ of.je
 
 // Block, Inc. : https://block.xyz
 // Submitted by Jonathan Boice <security@block.xyz>
-*.square.site
+square.site
 
 // Blue Bite, LLC : https://bluebite.com
 // Submitted by Joshua Weiss <admin.engineering@bluebite.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig (will be added after PR number is assigned)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

* [x] We are listing *any* third-party limits that we seek to work around in our rationale
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: https://squareup.com/help/us/en/contact

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

## Description of Organization

Block, Inc. (formerly Square, Inc.) is a global technology company focused on financial services and digital payments. We provide tools and services that enable businesses of all sizes to accept payments, manage their operations, and grow their business. The submitter is a security engineer at Block, responsible for maintaining our domain infrastructure and security posture. Our platform provides hosted e-commerce solutions through our square.site service, which allows merchants to create and manage their online stores.

**Organization Website:** https://block.xyz

## Reason for PSL Inclusion

We are requesting the inclusion of `*.square.site` in the PSL to ensure proper security isolation between our merchants' websites. Square provides each seller with their own subdomain (e.g., seller1.square.site, seller2.square.site) where they can host their online store. By including this entry in the PSL, we ensure:

1. Cookie isolation between different merchants' domains, preventing potential cross-site security issues
2. Proper SSL certificate issuance and validation for each merchant subdomain
3. Clear domain boundaries for security features like Content Security Policy (CSP)

This wildcard entry is crucial for our multi-tenant architecture where each merchant needs their own isolated domain space, similar to how other platforms like GitHub Pages (*.github.io) and Netlify (*.netlify.app) operate.

The domain is managed by our core infrastructure team and will be maintained indefinitely as it's a critical part of our e-commerce platform. We confirm that the domain registration will be maintained for more than 2 years and we will maintain the _psl TXT record as required.

**Number of users this request is being made to serve:** >14 million active merchants (current)

## DNS Verification

Once a PR number is assigned, we will add the following TXT record:

`_psl.square.site TXT "https://github.com/publicsuffix/list/pull/2385"`
