### PR TITLE
Add `emprende.ve`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6268,6 +6268,7 @@ co.ve
 com.ve
 e12.ve
 edu.ve
+emprende.ve
 firm.ve
 gob.ve
 gov.ve


### PR DESCRIPTION
Adding `emprende.ve` to the `.ve` block of the ICANN section, as requested and verified by the .ve registry administrator Willians Rincones (wrincones@nic.ve). 

This addition has been confirmed through direct email correspondence with the registry, with maintainer @dnsguru CC'd for verification. 

The change helps facilitate and close #2389 (CC @dexterasperson)

```
From: "Willians Rincones" <wrincones@nic.ve>
Sent: 2/20/25 4:48 PM

Best regards, 

If we are requesting to add the emprende.ve area to the public list of suffixes, because it will be a commercial domain extension in the future in our organization, I am attentive to any information necessary to include undertake.ve in said list. 
Thanks for your prompt response.
```