### PR TITLE
Add c01.kr / eliv-dns.kr

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14727,6 +14727,11 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
+// PROJECT ELIV : https://eliv.kr/
+// Submitted by ELIV Team <team@eliv.kr>
+c01.kr
+eliv-dns.kr
+
 // Protonet GmbH : http://protonet.io
 // Submitted by Martin Meier <admin@protonet.io>
 protonet.io


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:  
  https://abuse.eliv.kr (or abuse@eliv.kr)

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

PROJECT ELIV is a domain and CDN startup based in South Korea. We collaborate with multiple KRNIC registrars to distribute domains and CDN services to our clients, enabling them to build secure and efficient online environments. 

I am the CTO of PROJECT ELIV, submitting this request to enhance the security and reliability of the domains and subdomains we provide to our customers.

**Organization Website:**  
https://eliv.kr (for customers)  
https://eliv.co.kr (for company use)

## Reason for PSL Inclusion

PROJECT ELIV plans to provide subdomains under `c01.kr` or `eliv-dns.kr` to customers using our CDN services. Beyond simple CDN offerings, we aim to offer these domains as free options for customers to enhance service accessibility. Inclusion in the PSL will ensure cookie security and consistency in subdomain management, benefiting our clients' security needs. The domains `c01.kr` and `eliv-dns.kr` currently have over two years of registration remaining and will be maintained accordingly. This request is a critical step to meet our clients’ security requirements and improve their user experience.

**Number of users this request is being made to serve:**  
10,000+ (current and estimated)

## DNS Verification

Below are examples of DNS TXT record verifications for the domains we wish to add. The actual PR number (XXXX) will be updated upon submission.

```
dig +short TXT _psl.c01.kr
"https://github.com/publicsuffix/list/pull/2403"
```

```
dig +short TXT _psl.eliv-dns.kr
"https://github.com/publicsuffix/list/pull/2403"
```
