### PR TITLE
Update `pro.typeform.com` contact email

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15472,7 +15472,7 @@ diskstation.org
 typedream.app
 
 // Typeform : https://www.typeform.com
-// Submitted by Sergi Ferriz <sergi.ferriz@typeform.com>
+// Submitted by Typeform <ops@typeform.com>
 pro.typeform.com
 
 // Uberspace : https://uberspace.de


### PR DESCRIPTION
We would like to update the contact email for `pro.typeform.com`, which was added in https://github.com/publicsuffix/list/pull/1457. Thank you!

```
dig +short TXT _psl.pro.typeform.com
"https://github.com/publicsuffix/list/pull/2404"
```