### PR TITLE
Add ai.kr, io.kr, it.kr, me.kr

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3805,14 +3805,18 @@ rep.kp
 tra.kp
 
 // kr : https://www.iana.org/domains/root/db/kr.html
-// see also: http://domain.nida.or.kr/eng/registration.jsp
+// see also: https://krnic.kisa.or.kr/jsp/infoboard/law/domBylawsReg.jsp
 kr
 ac.kr
+ai.kr
 co.kr
 es.kr
 go.kr
 hs.kr
+io.kr
+it.kr
 kg.kr
+me.kr
 mil.kr
 ms.kr
 ne.kr


### PR DESCRIPTION
This PR is created to fix #2406 by adding four new second-level domains under South Korea's .kr TLD: `ai.kr`, `io.kr`, `it.kr`, and `me.kr`.

To quote @Renyu106 from #2406:

> the registry for South Korea’s .kr ccTLD. On March 5, 2025, KISA launched four new second-level domains—`ai.kr`, `io.kr`, `it.kr`, and `me.kr`—the first new additions in 22 years. These domains have been in preparation since 2024 and are now open for public registration.

I've verified these additions through multiple authoritative sources:

1. The Korean Internet & Security Agency (KISA) is the official registry for South Korea's .kr ccTLD according to IANA's database: https://www.iana.org/domains/root/db/kr.html

2. KISA's official registry website (http://www.nic.or.kr/) confirms these new second-level domains on their 3-depth domain page: https://www.nic.or.kr/jsp/customer/privacy_3depthDomain.jsp

3. KISA formally announced the March 5, 2025 launch of these four new second-level domains on their website: https://www.kisa.or.kr/401/form?postSeq=3401

These second-level domains are now open for public registration as of today (March 5, 2025).

![image](https://github.com/user-attachments/assets/0738fb86-ad3b-413f-bd21-0815434881e5)
