### PR TITLE
add dotname.kr, img.or.kr (Dotname Korea Corp)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12689,10 +12689,10 @@ online.th
 shop.th
 
 // Dotname Korea Corp : https://dotname.co.kr/
-// Submitted by JunHo Han seiha@dotname.co.kr
+// Submitted by JunHo Han <seiha@dotname.co.kr>
+co.onl
 dotname.kr
 img.or.kr
-dnstool.net
 
 // DrayTek Corp. : https://www.draytek.com/
 // Submitted by Paul Fang <mis@draytek.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12688,6 +12688,12 @@ dnshome.de
 online.th
 shop.th
 
+// Dotname Korea Corp : https://dotname.co.kr/
+// Submitted by JunHo Han seiha@dotname.co.kr
+dnstool.net
+dotname.kr
+img.or.kr
+
 // DrayTek Corp. : https://www.draytek.com/
 // Submitted by Paul Fang <mis@draytek.com>
 drayddns.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12690,9 +12690,9 @@ shop.th
 
 // Dotname Korea Corp : https://dotname.co.kr/
 // Submitted by JunHo Han seiha@dotname.co.kr
-dnstool.net
 dotname.kr
 img.or.kr
+dnstool.net
 
 // DrayTek Corp. : https://www.draytek.com/
 // Submitted by Paul Fang <mis@draytek.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig (To be completed by the submitter)
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook
 * [X] This request was _not_ submitted with the objective of working around other third-party limits.
 * [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [X] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [X] Abuse contact information (email or web form) is available and easily accessible.
  `https://dotname.co.kr/` (abuse@dotnamekorea.com)  

---

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

Dotname Korea Corp is a South Korea-based domain registration and management service provider, offering registration, hosting, and DNS management services for a variety of TLDs (Top-Level Domains). In the early 2000s, it partnered with KISA (Korea Internet & Security Agency) to become one of the first entities to sell South Korea's ccTLD, `.kr`. Subsequently, it obtained ICANN registrar accreditation (IANA ID 1132) and now sells dozens of gTLDs, such as `.com` and `.net`. The company focuses on providing comprehensive digital infrastructure services, including domain registration, DNS management, web hosting, and media hosting, to both individual and business customers in the Korean market.

I am the submitter of this request, assumed to be a member of Dotname Korea Corp’s network engineering team. My role involves establishing domain management policies and submitting our domains to the PSL to ensure a secure and efficient domain usage environment for our customers. This submission is part of the company’s official domain management strategy.

**Organization Website:**  
`https://dotname.co.kr`

## Reason for PSL Inclusion

Dotname Korea Corp seeks to include the domains `dotname.kr`, and `img.or.kr` in the PSL to enhance the security and reliability of the domain services we provide to our customers. These domains are integral to our core services, and their inclusion in the PSL will ensure proper domain boundary recognition in browser cookie settings and certificate issuance. Specifically, this registration aims to prevent cookie misuse at the parent domain level for subdomains we issue, comply with certificate issuance policies from authorities like Let’s Encrypt, and optimize domain-specific configurations with CDN services like Cloudflare.

dotname.kr` is the default domain provided to customers who purchase our web hosting services, offered in the format `customerID.dotname.kr`. `img.or.kr` serves as the default domain for customers subscribing to our image and video hosting services, structured as `customerID.img.or.kr`. Each of these domains maintains a registration term of at least two years, and we commit to ensuring a minimum of one year remaining in the future. This request is not intended to bypass any third-party limits, and there is no prior PSL submission history related to these domains.

**Number of users this request is being made to serve:**  
Each domain processes an average of over 250 queries per second, and this request is expected to serve approximately 40,000 users (based on current customer estimates).  

## DNS Verification

Below are example DNS TXT records for each domain to be submitted. The actual pull request number must be added after creating the PR on GitHub, so the submitter will need to complete this section.

```
dig +short TXT _psl.dotname.kr
"https://github.com/publicsuffix/list/pull/2408"
```

```
dig +short TXT _psl.img.or.kr
"https://github.com/publicsuffix/list/pull/2408"
```