### PR TITLE
Add dpdns.org

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12672,8 +12672,8 @@ ondigitalocean.app
 
 // DigitalPlat : https://www.digitalplat.org/
 // Submitted by Edward Hsing <contact@digitalplat.org>
-dpdns.org
 us.kg
+dpdns.org
 
 // Discord Inc : https://discord.com
 // Submitted by Sahn Lam <slam@discordapp.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12672,6 +12672,7 @@ ondigitalocean.app
 
 // DigitalPlat : https://www.digitalplat.org/
 // Submitted by Edward Hsing <contact@digitalplat.org>
+dpdns.org
 us.kg
 
 // Discord Inc : https://discord.com


### PR DESCRIPTION
# **Public Suffix List (PSL) Submission**

### **Checklist of Required Steps**
* [x] Description of Organization  
* [x] Robust Reason for PSL Inclusion  
* [x] DNS verification via dig  

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).  

__Submitter affirms the following:__  
* [x] This request was _not_ submitted with the objective of working around other third-party limits.  
* [x] The submitter acknowledges responsibility for maintaining the domains within their section.  
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully read and followed.  
* [x] A role-based email address has been used and this inbox is actively monitored.  

**Abuse Contact:**  
* [x] Abuse contact information is publicly available.  
  URL: https://domain.digitalplat.org/abuse-report/  
  https://github.com/DigitalPlatDev/FreeDomain?tab=readme-ov-file#-abuse-reporting

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways.*  

---

## **Description of Organization**
DigitalPlat is an organization providing free domain registration services. We initially operated under US.KG NIC, offering subdomains for users and projects. DigitalPlat is fiscally sponsored by The Hack Foundation, a 501(c)(3) nonprofit (EIN: 81-2908499).  

Due to external stability concerns with the ccltd .kg registry, we are introducing dpdns.org as a more reliable domain while continuing to manage us.kg with stricter registration requirements.  

**Organization Website:**  
https://digitalplat.org  

---

## **Reason for PSL Inclusion**
Previously, us.kg was added to the PSL under [PR #1755](https://github.com/publicsuffix/list/pull/1755). However, due to .kg registry-related stability issues, we have migrated all existing subdomains to dpdns.org, which provides a more stable and secure alternative.  

- dpdns.org is now our primary domain, ensuring stable and secure domain management. All users have been migrated to this domain.  
- us.kg will continue to be available in the near future with stricter registration requirements due to changes in ccTLD policies and stability concerns.  
- Adding dpdns.org to the PSL is crucial for maintaining proper cookie isolation, preventing unauthorized cross-domain access, and ensuring consistent browser security policies. Without PSL inclusion, services using subdomains under dpdns.org may face cookie mismanagement and security risks.

**Number of users affected:**  
153,904 active subdomains.  

---
```
## **DNS Verification**
To verify ownership of dpdns.org, we have set up a TXT record at `_psl.dpdns.org`:

dig +short TXT _psl.dpdns.org 
"https://github.com/publicsuffix/list/pull/2414"
```
We commit to maintaining these records indefinitely.  