### PR TITLE
Add icp0.io /  icp1.io / caffeine.site / caffeine.website for Internet Computer domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12674,6 +12674,7 @@ icp0.io
 *.raw.icp0.io
 icp1.io
 *.raw.icp1.io
+icp-api.io
 caffeine.site
 caffeine.website
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12666,6 +12666,17 @@ dedyn.io
 deta.app
 deta.dev
 
+// Dfinity Foundation: https://dfinity.org/
+// Submitted by Dfinity Team <domains@dfinity.org>
+ic0.app
+*.raw.ic0.app
+icp0.io
+*.raw.icp0.io
+icp1.io
+*.raw.icp1.io
+caffeine.site
+caffeine.website
+
 // dhosting.pl Sp. z o.o. : https://dhosting.pl/
 // Submitted by Michal Kokoszkiewicz <bok@dhosting.pl>
 dfirma.pl

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12677,6 +12677,8 @@ icp1.io
 icp-api.io
 caffeine.site
 caffeine.website
+caffeine.ai
+id.ai
 
 // dhosting.pl Sp. z o.o. : https://dhosting.pl/
 // Submitted by Michal Kokoszkiewicz <bok@dhosting.pl>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12668,7 +12668,6 @@ deta.dev
 
 // Dfinity Foundation: https://dfinity.org/
 // Submitted by Dfinity Team <domains@dfinity.org>
-ic0.app
 *.raw.ic0.app
 icp0.io
 *.raw.icp0.io
@@ -12676,7 +12675,6 @@ icp1.io
 *.raw.icp1.io
 icp-api.io
 caffeine.site
-caffeine.website
 caffeine.ai
 id.ai
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12666,7 +12666,6 @@ deta.dev
 
 // Dfinity Foundation: https://dfinity.org/
 // Submitted by Dfinity Team <domains@dfinity.org>
-*.raw.ic0.app
 icp0.io
 *.raw.icp0.io
 icp1.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12702,14 +12702,14 @@ deta.dev
 
 // Dfinity Foundation: https://dfinity.org/
 // Submitted by Dfinity Team <domains@dfinity.org>
+caffeine.ai
+id.ai
+icp-api.io
 icp0.io
 *.raw.icp0.io
 icp1.io
 *.raw.icp1.io
-icp-api.io
 caffeine.site
-caffeine.ai
-id.ai
 
 // dhosting.pl Sp. z o.o. : https://dhosting.pl/
 // Submitted by Michal Kokoszkiewicz <bok@dhosting.pl>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
Contact email: `domains@dfinity.org`
**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://dfinity.org/bug-bounty
  <!-- Provide the URL where an Internet user can access the abuse contact information -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
Request submitted by Slawomir Babicz, Infrastructure Security Engineer at Dfinity Foundation. 

Dfinity is a not-for-profit organization, a major contributor to the Internet Computer blockchain. The Internet Computer is a general-purpose blockchain that hosts canister smart contracts. It is designed to provide a World Computer that can replace traditional IT and host a new generation of Web3 services and applications that run solely from the blockchain, without the need for traditional IT. It can also play the role of Web3 orchestrator, by interacting with traditional blockchains.

**Organization Website:**
https://dfinity.org/ , https://internetcomputer.org/

## Reason for PSL Inclusion

- Content deployed on `icp0.io`, and `icp1.io` consists of unique subdomains represented as 28-byte hashes. Each subdomain corresponds to a separate website with distinct owners. Due to exposing ICP to the world, some individuals may create inappropriate content, but the community and the DFINITY Foundation actively monitor and filter such content.

- Inclusion in the PSL will help treat subdomains as separate entities, effectively isolating cookies and sensitive information between different websites.

- Inclusion in the PSL enhances the reputation and credibility of `icp0.io`, and `icp1.io` domains. It demonstrates their commitment to industry standards and best practices, promoting trust among users, businesses, and organizations interacting with these domains.

- Including `icp0.io`, `icp-api.io`, `id.ai` and `icp1.io` in the PSL will enhance trust and bolster security measures.

- Domains `caffeine.site`, `caffeine.ai` will be utilized specifically to showcase decentralized applications (dAPPs) built on the ICP blockchain, highlighting innovation and development within the ICP ecosystem.

**Number of users this request is being made to serve:**
1000000

## DNS Verification
```
❯ dig TXT +short _psl.icp0.io @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig TXT +short _psl.raw.icp0.io @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig TXT +short _psl.raw.ic0.app @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig TXT +short _psl.icp1.io @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig TXT +short _psl.caffeine.site @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig TXT +short _psl.raw.icp1.io @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig TXT +short _psl.icp-api.io @1.1.1.1
"https://github.com/publicsuffix/list/pull/2424"
❯ dig _psl.caffeine.ai TXT +short
"https://github.com/publicsuffix/list/pull/2424"
❯ dig _psl.id.ai TXT +short
"https://github.com/publicsuffix/list/pull/2424"
```
