### PR TITLE
Add ip.zstaticcdn.com and app.zstaticcdn.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15760,4 +15760,9 @@ enterprisecloud.nu
 // Submitted by Gx1.org <security@gx1.org>
 zone.id
 
+// zstatic: https://zstaticcdn.com
+// Submitted by Ziwen WANG <admin@zstaticcdn.com>
+ip.zstaticcdn.com
+app.zstaticcdn.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)
 - MAKE SURE UPDATE THE FOLLOWING LIST WITH YOUR LIMITATIONS! REMOVE ENTRIES WHICH DO NOT APPLY AS WELL AS REMOVING THIS LINE!

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  Email: abuse@zstaticcdn.com

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Zstatic (ZstaticCDN) is a China-based open-source content delivery network (CDN) project similar to cdnjs, designed to address the unique connectivity challenges in the Chinese internet environment. We provide CDN services for JavaScript libraries, CSS frameworks, and other web assets to improve website performance for Chinese users. I am the lead developer and maintainer of the Zstatic project, representing our non-profit initiative aimed at improving web performance across China's internet ecosystem.

**Organization Website:**

https://zstaticcdn.com

We need to add ip.zstaticcdn.com and app.zstaticcdn.com to the PSL to enhance security for our users. These subdomains are used by different end-users who can create their own content areas, and we need to ensure proper cookie isolation between these user spaces. Without PSL inclusion, cookies set by one user's content could potentially be accessible to another user's content within the same subdomain hierarchy, creating a security vulnerability.

Specifically, ip.zstaticcdn.com serves as a network quality monitoring project that is widely used in various scripts and communities, such as the [xykt/NetQuality](https://github.com/xykt/NetQuality) project. This service allows developers to implement performance monitoring and diagnostics across the Chinese internet, with each user having their own isolated subdomain for testing and monitoring purposes.

Meanwhile, app.zstaticcdn.com provides users with the ability to create their own hosting services based on these monitoring capabilities, allowing them to accelerate code delivery with personalized configurations. Users operate within their own subdomains (e.g., user1.app.zstaticcdn.com, user2.app.zstaticcdn.com), and we need to clearly establish these as public suffixes to prevent cookie confusion and potential security issues between different users sharing the same service infrastructure.

Our domain has been [recognized by Cloudflare Radar](https://radar.cloudflare.com/domains/domain/zstaticcdn.com) as being among the top 5000 domains globally, which we believe confirms its significance and justifies the need for proper distinction in the Public Suffix List.

The domains have registration periods extending beyond two years, and we commit to maintaining these entries for as long as they remain active services within our platform. Our team will actively monitor DNS records and ensure the _psl records remain in place.

**Number of users this request is being made to serve:** Approximately 300 active users (current count)

## DNS Verification
```
dig +short TXT _psl.ip.zstaticcdn.com
"https://github.com/publicsuffix/list/pull/2427"

dig +short TXT _psl.app.zstaticcdn.com
"https://github.com/publicsuffix/list/pull/2427"
```