### PR TITLE
Add val.run

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15568,8 +15568,8 @@ v.ua
 
 // Val Town, Inc : https://val.town/
 // Submitted by Tom MacWright <security@val.town>
-web.val.run
 val.run
+web.val.run
 
 // Vercel, Inc : https://vercel.com/
 // Submitted by Max Leiter <security@vercel.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15568,8 +15568,8 @@ v.ua
 
 // Val Town, Inc : https://val.town/
 // Submitted by Tom MacWright <security@val.town>
-express.val.run
 web.val.run
+val.run
 
 // Vercel, Inc : https://vercel.com/
 // Submitted by Max Leiter <security@vercel.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:** security@val.town

* [x] Abuse contact information (email or web form) is available and easily accessible. URL where abuse contact or abuse reporting form can be found: https://docs.val.town/contact-us/contact-us/

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

I am Tom MacWright and I represent Val Town, Inc. Val Town is a social website for writing small programs in TypeScript that can power websites and APIs. These programs automatically get subdomains of val.run where user-submitted and controlled code can run.

Organization Website:  https://val.town/

## Reason for PSL Inclusion

Users' code runs within separate subdomains of web.val.run and val.run. Because their code can be arbitrary TypeScript/JavaScript handlers, they can issue and receive cookies, and we want to ensure that those cookies are fully isolated between different applications. We also issue LetsEncrypt certificates for each wildcard user subdomain. We have previously requested PSL inclusion at #1964: this PR removes one of those domains that we no longer use and adds another.

Number of users this request is being made to serve: 40,500 (current)

## DNS Verification

```
$ dig +short TXT _psl.val.run
"https://github.com/publicsuffix/list/pull/2432"
```