### PR TITLE
Add convex.app and convex.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12550,9 +12550,9 @@ ctfcloud.net
 
 // Convex : https://convex.dev/
 // Submitted by James Cowling <security@convex.dev>
-convex.site
 convex.app
 convex.cloud
+convex.site
 
 // Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
 // Submitted by George Georgievsky <gug@cctld.ru>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12551,6 +12551,8 @@ ctfcloud.net
 // Convex : https://convex.dev/
 // Submitted by James Cowling <security@convex.dev>
 convex.site
+convex.app
+convex.cloud
 
 // Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
 // Submitted by George Georgievsky <gug@cctld.ru>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://www.convex.dev/security

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Convex is a cloud-hosted backend application platform that companies use to build and run full-stack web applications. The platform includes a database, compute engine, authentication, file storage, and more. Developers use Convex to build dynamic apps with real-time data and scalable APIs.

Convex serves both frontend and backend infrastructure on behalf of its customers. The frontend content (such as static sites or web apps) is served via one subdomain pattern, and backend APIs and object storage are served via another. These are isolated from Convex's own corporate sites.

I am an engineer at Convex submitting this request on behalf of the company.

**Organization Website:**  
https://convex.dev/

## Reason for PSL Inclusion

This submission adds two additional Convex-owned domains to the PSL:

- `convex.app`, which serves static frontend content for Convex customers on subdomains (e.g., `<site>.convex.app`); similar to `vercel.app` or `pages.dev`.  
- `convex.cloud`, which serves API endpoints, functions, and customer-owned object storage on subdomains (e.g., `<project>.convex.cloud`).  

Both domains operate in a similar fashion to `convex.site`, which was accepted in [PR #1767](https://github.com/publicsuffix/list/pull/1767). All three are used to serve content and functionality on behalf of end users and customers, not Convex itself.

These subdomains represent untrusted user-generated code and content. For privacy and security reasons—particularly around cookie isolation and scope—it is important that browsers and services treat each subdomain of these domains separately.

Both domains are registered through at least 2027 and will continue to maintain more than one year remaining on registration. The `_psl` TXT records will be maintained and kept up to date.

**Number of users this request is being made to serve:**  
100,000+ 

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
```
dig +short TXT _psl.convex.cloud
"https://github.com/publicsuffix/list/pull/2436"
```
```
dig +short TXT _psl.convex.app
"https://github.com/publicsuffix/list/pull/2436"
```

