### PR TITLE
Add biz.gh and net.gh SLD to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1134,10 +1134,12 @@ org.gg
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
 gh
+biz.gh
 com.gh
 edu.gh
 gov.gh
 mil.gh
+net.gh
 org.gh
 
 // gi : http://www.nic.gi/rules.html


### PR DESCRIPTION
# PR Description:
This PR proposes the inclusion of biz.gh and net.gh as entries in the Public Suffix List.

# Reason for Addition:
biz.gh and net.gh are official second-level domains under the .gh ccTLD for Ghana. The Ghana Domain Name Registry delegates these domains and are commonly used by businesses and network-related entities, respectively.

# References:
Ghana Domain Name Registry: https://www.nic.gh/

Example usage: clickmobile.biz.gh, sancfis.net.gh
