### PR TITLE
Add XX.KG and QZZ.IO

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12680,7 +12680,9 @@ ondigitalocean.app
 
 // DigitalPlat : https://www.digitalplat.org/
 // Submitted by Edward Hsing <contact@digitalplat.org>
+qzz.io
 us.kg
+xx.kg
 dpdns.org
 
 // Discord Inc : https://discord.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of Required Steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

- [x] This request was _not_ submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges responsibility for maintaining the domains within their section.
- [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully read and followed.
- [x] A role-based email address has been used and this inbox is actively monitored.

**Abuse Contact:**

- [x] Abuse contact information is publicly available.  
URL: https://domain.digitalplat.org/abuse-report/  
https://github.com/DigitalPlatDev/FreeDomain?tab=readme-ov-file#-abuse-reporting  
Email: abusereport@digitalplat.org

- [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways.*

---

## Description of Organization

DigitalPlat is a global service platform providing free domain registration to individuals and open-source projects worldwide.

The service initially operated primarily under **us.kg**, and later expanded to include **dpdns.org** to offer a more stable and flexible option. Recently, we have further expanded our domain offerings with **xx.kg** and **qzz.io**, which are now actively available for user registrations.

DigitalPlat is fiscally sponsored by The Hack Foundation, a registered 501(c)(3) nonprofit organization (EIN: 81-2908499), and operates in alignment with public interest and internet freedom values.

**Organization Website:**  
https://digitalplat.org

---

## Reason for PSL Inclusion

Our domain offerings are actively used by global users for free subdomain registration, supporting personal websites, open-source communities, and small projects.

- **us.kg** was previously accepted into PSL via [PR #1755](https://github.com/publicsuffix/list/pull/1755)
- **dpdns.org** was accepted via [PR #2414](https://github.com/publicsuffix/list/pull/2414)

Following this, we have launched two new suffixes — **xx.kg** and **qzz.io** , which are now available for public registration via our unified dashboard.

All four domains are part of our long-term plan and already serve an active user base. Adding these to the PSL will help ensure proper cookie isolation, secure browser behaviors, and prevent cross-user data leakage across unrelated subdomains.

**Number of users affected:**  
Over 200,000 active subdomains, and growing.

---
```
## DNS Verification

To verify domain ownership and control, the following `_psl` TXT records have been published:

dig +short TXT _psl.xx.kg 
"https://github.com/publicsuffix/list/pull/2462"

dig +short TXT _psl.qzz.io 
"https://github.com/publicsuffix/list/pull/2462"

```
We commit to maintaining these records indefinitely.  