### PR TITLE
merge `Harrison Network` into `William Harrison`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13642,10 +13642,6 @@ günstigliefern.de
 // Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
 häkkinen.fi
 
-// Harrison Network : https://hrsn.net
-// Submitted by William Harrison <psl@hrsn.net>
-hrsn.dev
-
 // Hashbang : https://hashbang.sh
 hashbang.sh
 
@@ -15673,6 +15669,7 @@ wmflabs.org
 // William Harrison : https://wharrison.com.au
 // Submitted by William Harrison <psl@wharrison.com.au>
 wdh.app
+hrsn.dev
 
 // Windsurf : https://windsurf.com
 // Submitted by Douglas Chen <psl@windsurf.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15667,7 +15667,7 @@ wmcloud.org
 wmflabs.org
 
 // William Harrison : https://wharrison.com.au
-// Submitted by William Harrison <psl@wharrison.com.au>
+// Submitted by William Harrison <security@wharrison.com.au>
 wdh.app
 hrsn.dev
 


### PR DESCRIPTION
Merging to reduce size and to use a sole contact method instead. Nothing on the domain itself (like use-case) has been changed.

I've also updated the contact email address.

Last PR was authored by me: #2208