### PR TITLE
remove `localhostcert.net`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14094,9 +14094,8 @@ ggff.net
 *.user.localcert.dev
 
 // LocalCert : https://localcert.net
-// Submitted by William Harrison <psl@localcert.net>
+// Submitted by William Harrison <security@localcert.net>
 localcert.net
-localhostcert.net
 
 // Localtonet : https://localtonet.com/
 // Submitted by Burak Isleyici <support@localtonet.com>


### PR DESCRIPTION
We will be moving all subdomains across to `localcert.net` as part of our infra rewrite, so we do not intend to renew or keep this domain name.

I'm also updating the email contact.

Last PR was authored by me: #2309