### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -740,6 +740,7 @@ cat
 
 // cc : https://www.iana.org/domains/root/db/cc.html
 cc
+e-nova.cc
 
 // cd : https://www.iana.org/domains/root/db/cd.html
 // https://www.nic.cd


### PR DESCRIPTION
Add e-nova.cc to the Public Suffix List

This PR proposes adding e-nova.cc to the Public Suffix List (PSL). The domain should be included as it is being used in various applications, and including it in the PSL will ensure accurate handling of subdomains and DNS operations related to this domain.

Please review and consider merging this change into the list. Thank you!