### PR TITLE
Enhance the commitment to authenticity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ your domain(s) directly with that third-party, and it is inappropriate
 to submit entries to the PSL as a means to work around those limits or 
 restrictions.
 -->
-
+ * [ ] As the submitter, I, on behalf of our organization/company, hereby commit that all information provided in this PR is true and accurate, and that there has been no misrepresentation of the reasons for PSL inclusion or fabrication of service user numbers. Should a trust crisis arising from the foregoing result in our domain’s prolonged exclusion from the PSL, our organization/company will assume full responsibility.
  * [ ] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
  - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)


### PR DESCRIPTION
> * [x] As the submitter, I, on behalf of our organization/company, hereby commit that all information provided in this PR is true and accurate, and that there has been no misrepresentation of the reasons for PSL inclusion or fabrication of service user numbers. Should a trust crisis arising from the foregoing result in our domain’s prolonged exclusion from the PSL, our organization/company will assume full responsibility.

Hello everyone, Recently, in my spare time outside of work, I’ve been actively participating in the PSL project as a volunteer, helping to review the domains submitted in pull requests. After reviewing multiple cases, I’ve found that when submitters honestly state their reasons for being included in the PSL and accurately report the number of users of their service, it often helps the review process go more smoothly.

However, I’ve also noticed that a few submitters have concealed their true reasons for requesting inclusion in the PSL or exaggerated their user base, which has made the investigation process more difficult. I believe honesty is especially important in this context.

Therefore, I suggest updating the pull_request_template to include a statement of truthfulness. For cases where submitters intentionally hide accurate information, I recommend that the inclusion request be appropriately delayed. I hope you’ll consider whether this suggestion is reasonable.