### PR TITLE
Add afhz.org to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9,6 +9,9 @@
 
 // ===BEGIN ICANN DOMAINS===
 
+// afhz.org : submitted by KRhero <support@afhz.org>
+afhz.org
+
 // ac : http://nic.ac/rules.htm
 ac
 com.ac

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9,8 +9,7 @@
 
 // ===BEGIN ICANN DOMAINS===
 
-// afhz.org : submitted by KRhero <support@afhz.org>
-afhz.org
+
 
 // ac : http://nic.ac/rules.htm
 ac
@@ -13091,6 +13090,9 @@ lp.dev
 // encoway GmbH : https://www.encoway.de
 // Submitted by Marcel Daus <cloudops@encoway.de>
 eu.encoway.cloud
+
+// afhz.org : submitted by KRhero <support@afhz.org>
+afhz.org
 
 // EU.org : https://eu.org/
 // Submitted by Pierre Beyssac <hostmaster@eu.org>


### PR DESCRIPTION
## Request to Add `afhz.org` to the Public Suffix List

**Domain:** `afhz.org`  
**Submitted by:** KRhero  
**Email:** support@afhz.org

### Justification:

We operate `afhz.org` as a platform where users can register and manage their own subdomains (e.g., `user1.afhz.org`, `user2.afhz.org`). Each subdomain is used as an independent user space, with separate authentication and session handling. For privacy and security reasons, we want browsers to treat these subdomains as separate origins.

By adding `afhz.org` to the Public Suffix List, we aim to prevent subdomain-level cookie leakage and enforce proper domain boundaries in line with browser security models.

### Confirmation:

- I confirm that I am authorized to request this change.
- I understand the implications of being added to the Public Suffix List.
- I control the domain and can verify ownership if required.

Thank you for maintaining the Public Suffix List.

— KRhero
