### PR TITLE
Add eliv-cdn.kr

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14761,6 +14761,7 @@ priv.at
 // PROJECT ELIV : https://eliv.kr/
 // Submitted by PROJECT ELIV Domain Team <team@eliv.kr>
 c01.kr
+eliv-cdn.kr
 eliv-dns.kr
 mmv.kr
 vki.kr


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: 
https://abuse.eliv.kr/ (or [domain@abuse.eliv.kr](mailto:domain@abuse.eliv.kr))

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
PROJECT ELIV is a South Korea-based startup focused on providing domain registration and CDN services to support secure and reliable online infrastructure. The company collaborates with multiple domain registrars to streamline domain management and deploys CDN solutions to enhance website performance and security. This request aims to strengthen the security and stability of domains and subdomains for our customers.

I am the submitter, serving as the CTO of PROJECT ELIV, a for-profit business. My role involves overseeing the technical development and implementation of our domain registration and CDN services. In this submission, I represent PROJECT ELIV to request support or collaboration to improve the security and reliability of our domain and subdomain offerings.

**Organization Website:**
https://eliv.kr (for customers)  
https://eliv.digital (for company use)

## Reason for PSL Inclusion
PROJECT ELIV is a domain registrar that registers gTLDs and ccTLDs, such as .com and .net.

We operate a Content Delivery Network (CDN) business using Cloudflare and our proprietary CDN engine.

Initially, we used the domain eliv-dns.kr for our CDN service. However, as eliv-dns.kr is integrated with various other services, it has caused frequent confusion.

To address this, we plan to use the more intuitive domain eliv-cdn.kr. Therefore, we request registration with the Public Suffix List (PSL), and the eliv-cdn.kr domain will be maintained for the lifetime of PROJECT ELIV.

**Number of users this request is being made to serve:**
1,000+ (current and estimated)

## DNS Verification
```
dig +short TXT _psl.eliv-cdn.kr
"https://github.com/publicsuffix/list/pull/2479"
```