### PR TITLE
removing cloud66.zone as it is redundant now

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12494,7 +12494,6 @@ cloudns.us
 // Submitted by Khash Sajadi <khash@cloud66.com>
 c66.me
 cloud66.ws
-cloud66.zone
 
 // CloudAccess.net : https://www.cloudaccess.net/
 // Submitted by Pawel Panek <noc@cloudaccess.net>


### PR DESCRIPTION
This is a removal request for cloud66.zone as it is now redundant. This was raised by https://github.com/publicsuffix/list/pull/797#issuecomment-2887869190 