### PR TITLE
Add Cloudflare Subdomain Notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Iteration back and forth will delay PR review or inclusion. Be extremely thoroug
 
 ## Important Notices
 
+### 2025-05-27
+Were you directed here to add subdomain(s) to your **Cloudflare** accounts? Please work directly with Cloudflare for subdomain-related questions and account limitations. The PSL is **NOT** intended as a workaround for Cloudflare's subdomain restrictions. 
+
+Consult [Cloudflare's subdomain setup documentation](https://developers.cloudflare.com/dns/zone-setups/subdomain-setup/) or contact Cloudflare directly for subdomain setup questions. Only submit to PSL if your domain truly meets our criteria outlined in [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines).
+
 ### 2024-07-26
 We are sending emails asking for confirmation if certain entries are still required or need updating.
 


### PR DESCRIPTION
This PR adds a notice to the README.md file addressing the recent surge of PSL requests from users attempting to bypass Cloudflare's subdomain limitations on free accounts, similar to the existing Google AdSense notice.

## Background

There has been a significant increase in PSL submissions from domain registrants who have been directed by Cloudflare community moderators (https://www.google.com/search?q=site%3Acommunity.cloudflare.com+%22public+suffix+list%22+AND+%22subdomain%22&ie=UTF-8) or other online forums to add their domains to the PSL simply to enable subdomain management on Cloudflare accounts. 

This misuse of the PSL:

1. Creates unnecessary burden on volunteers & maintainers
2. Potentially harms websites through improper PSL entries
3. Misrepresents the purpose of the PSL

## Rationale

This notice serves to redirect Cloudflare-specific issues back to Cloudflare :)
