### PR TITLE
Remove ind.mom from PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15285,10 +15285,6 @@ srht.site
 apps.lair.io
 *.stolos.io
 
-// SparrowHost : https://sparrowhost.in/
-// Submitted by Anant Pandey <info@sparrowhost.in>
-ind.mom
-
 // SpeedPartner GmbH : https://www.speedpartner.de/
 // Submitted by Stefan Neufeind <info@speedpartner.de>
 customer.speedpartner.de


### PR DESCRIPTION
Hey there, we are requesting to delist ths .ind.mom suffix from the PSL due to closing of our Registry business. As we are not able to add more suffixes requested by our current registrars. We are not able to make more profit and have lost our invested moneys on premium domains due to not being added on suffix for our future plans.