### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15661,6 +15661,10 @@ now.sh
 // Submitted by Adnan RIHAN <hostmaster@v-info.info>
 v-info.info
 
+// VistaBlog : https://vistablog.ir/
+// Submitted by Hossein Piri <info@vistablog.ir>
+vistablog.ir
+
 // Viva Republica, Inc. : https://toss.im/
 // Submitted by Deus Team <deus@toss.im>
 deus-canvas.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization  
* [x] Robust Reason for PSL Inclusion  
* [x] DNS verification via dig  

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)  
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)  
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)  
 - _None of the above limits are the reason for this request._  

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.  
* [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.  

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:  
  https://vistablog.ir/contact-us

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Vistablog is a website builder and content hosting platform that enables users to quickly create and publish personal or business websites. It provides a user-friendly interface for designing web pages, managing content, and deploying custom sites under unique subdomains of `vistablog.ir`. The platform has powered over 11,000 user-created websites and is focused on making website creation accessible to everyone without the need for technical expertise.

**Organization Website:**  
https://vistablog.ir

---

### Reason for PSL Inclusion

Vistablog is an Iranian website builder platform that allows users to easily create and host websites under subdomains of `vistablog.ir`. As of now, more than 11,000 user-generated websites have been created on the platform.

Each user is given a unique subdomain such as `username.vistablog.ir`, where they have full control over the content, files, and cookies of their site. Because each subdomain is controlled independently by different users, they must be treated as separate origins for security and cookie scope.

Therefore, `vistablog.ir` should be included in the Public Suffix List.

I am an engineer working on the Vistablog platform.

**Number of users this request is being made to serve:**  
Approximately 40,000 daily visitors and 200,000 requests or visits per month.
11,312 active subdomains

---

## DNS Verification
```
dig +short TXT _psl.vistablog.ir
"https://github.com/publicsuffix/list/pull/2508"
```
