### PR TITLE
Kerolasa/golangci lint

### DIFF
--- a/tools/internal/githistory/history.go
+++ b/tools/internal/githistory/history.go
@@ -55,6 +55,9 @@ func GetPRInfo(gitPath string) (*History, error) {
 		`--grep=^Merge pull request #\d+ from`,
 		"--pretty=%H@%P@%s",
 		"master")
+	if err != nil {
+		return nil, err
+	}
 
 	ret := &History{
 		GitPath: toplevel,

--- a/tools/internal/parser/clean.go
+++ b/tools/internal/parser/clean.go
@@ -418,7 +418,5 @@ func rewriteSuffixesMetadata(s *Suffixes) {
 		emailStr := strings.TrimSpace(fmt.Sprintf("%s <%s>", m.Name, m.Address))
 		out.Text = append(out.Text, strings.TrimSpace(fmt.Sprintf("Submitted by %s", emailStr)))
 	}
-	for _, o := range inf.Other {
-		out.Text = append(out.Text, o)
-	}
+	out.Text = append(out.Text, inf.Other...)
 }

--- a/tools/internal/parser/diff.go
+++ b/tools/internal/parser/diff.go
@@ -263,7 +263,7 @@ func (d *differ) markChanged(paths ...[]Block) {
 pathLoop:
 	for _, path := range paths {
 		for _, b := range path {
-			if b.info().isUnchanged == false {
+			if !b.info().isUnchanged {
 				// We never mark a node as changed in isolation, we
 				// always propagate the change to all its
 				// parents. Therefore, we can stop the upwards

--- a/tools/internal/parser/errors.go
+++ b/tools/internal/parser/errors.go
@@ -21,7 +21,7 @@ type ErrInvalidUnicode struct {
 }
 
 func (e ErrInvalidUnicode) Error() string {
-	return fmt.Sprintf("%s: invalid Unicode character(s)", e.SourceRange.LocationString())
+	return fmt.Sprintf("%s: invalid Unicode character(s)", e.LocationString())
 }
 
 // ErrSectionInSuffixBlock reports that a comment within a suffix
@@ -31,7 +31,7 @@ type ErrSectionInSuffixBlock struct {
 }
 
 func (e ErrSectionInSuffixBlock) Error() string {
-	return fmt.Sprintf("%s: section delimiter not allowed in suffix block comment", e.SourceRange.LocationString())
+	return fmt.Sprintf("%s: section delimiter not allowed in suffix block comment", e.LocationString())
 }
 
 // ErrUnclosedSection reports that a file section was not closed
@@ -41,7 +41,7 @@ type ErrUnclosedSection struct {
 }
 
 func (e ErrUnclosedSection) Error() string {
-	return fmt.Sprintf("%s: section %q is missing its closing marker", e.Section.SourceRange.LocationString(), e.Section.Name)
+	return fmt.Sprintf("%s: section %q is missing its closing marker", e.Section.LocationString(), e.Section.Name)
 }
 
 // ErrNestedSection reports that a file section is being started while
@@ -53,7 +53,7 @@ type ErrNestedSection struct {
 }
 
 func (e ErrNestedSection) Error() string {
-	return fmt.Sprintf("%s: section %q is nested inside section %q (%s)", e.SourceRange.LocationString(), e.Name, e.Section.Name, e.Section.SourceRange.LocationString())
+	return fmt.Sprintf("%s: section %q is nested inside section %q (%s)", e.LocationString(), e.Name, e.Section.Name, e.Section.LocationString())
 }
 
 // ErrUnstartedSection reports that section end marker was found
@@ -64,7 +64,7 @@ type ErrUnstartedSection struct {
 }
 
 func (e ErrUnstartedSection) Error() string {
-	return fmt.Sprintf("%s: end marker for non-existent section %q", e.SourceRange.LocationString(), e.Name)
+	return fmt.Sprintf("%s: end marker for non-existent section %q", e.LocationString(), e.Name)
 }
 
 // ErrMismatchedSection reports that a file section was started
@@ -76,7 +76,7 @@ type ErrMismatchedSection struct {
 }
 
 func (e ErrMismatchedSection) Error() string {
-	return fmt.Sprintf("%s: section %q (%s) closed with wrong name %q", e.SourceRange.LocationString(), e.Section.Name, e.Section.SourceRange.LocationString(), e.EndName)
+	return fmt.Sprintf("%s: section %q (%s) closed with wrong name %q", e.LocationString(), e.Section.Name, e.Section.LocationString(), e.EndName)
 }
 
 // ErrUnknownSectionMarker reports that a line looks like a file section
@@ -87,7 +87,7 @@ type ErrUnknownSectionMarker struct {
 }
 
 func (e ErrUnknownSectionMarker) Error() string {
-	return fmt.Sprintf("%s: unknown kind of section marker", e.SourceRange.LocationString())
+	return fmt.Sprintf("%s: unknown kind of section marker", e.LocationString())
 }
 
 // MissingEntityName reports that a block of suffixes does not have a
@@ -97,7 +97,7 @@ type ErrMissingEntityName struct {
 }
 
 func (e ErrMissingEntityName) Error() string {
-	return fmt.Sprintf("%s: suffix block has no owner name", e.Suffixes.SourceRange.LocationString())
+	return fmt.Sprintf("%s: suffix block has no owner name", e.Suffixes.LocationString())
 }
 
 // ErrMissingEntityEmail reports that a block of suffixes does not have a
@@ -107,7 +107,7 @@ type ErrMissingEntityEmail struct {
 }
 
 func (e ErrMissingEntityEmail) Error() string {
-	return fmt.Sprintf("%s: suffix block has no contact email", e.Suffixes.SourceRange.LocationString())
+	return fmt.Sprintf("%s: suffix block has no contact email", e.Suffixes.LocationString())
 }
 
 // ErrInvalidSuffix reports that a suffix suffix is not a valid PSL
@@ -119,7 +119,7 @@ type ErrInvalidSuffix struct {
 }
 
 func (e ErrInvalidSuffix) Error() string {
-	return fmt.Sprintf("%s: invalid suffix %q: %v", e.SourceRange.LocationString(), e.Suffix, e.Err)
+	return fmt.Sprintf("%s: invalid suffix %q: %v", e.LocationString(), e.Suffix, e.Err)
 }
 
 type ErrCommentPreventsSuffixSort struct {
@@ -127,7 +127,7 @@ type ErrCommentPreventsSuffixSort struct {
 }
 
 func (e ErrCommentPreventsSuffixSort) Error() string {
-	return fmt.Sprintf("%s: comment prevents full sorting of suffixes", e.SourceRange.LocationString())
+	return fmt.Sprintf("%s: comment prevents full sorting of suffixes", e.LocationString())
 }
 
 type ErrCommentPreventsSectionSort struct {
@@ -135,7 +135,7 @@ type ErrCommentPreventsSectionSort struct {
 }
 
 func (e ErrCommentPreventsSectionSort) Error() string {
-	return fmt.Sprintf("%s: comment prevents full sorting of PSL section", e.SourceRange.LocationString())
+	return fmt.Sprintf("%s: comment prevents full sorting of PSL section", e.LocationString())
 }
 
 type ErrDuplicateSection struct {

--- a/tools/internal/parser/exceptions.go
+++ b/tools/internal/parser/exceptions.go
@@ -19,20 +19,10 @@ func exemptFromContactInfo(entity string) bool {
 	return slices.Contains(missingEmail, entity)
 }
 
-// exemptFromSorting reports whether the block owned by entity is
-// exempt from the sorting requirement that normally applies in the
-// private domains section.
-func exemptFromSorting(entity string) bool {
-	return slices.Contains(incorrectSort, entity)
-}
-
 // exemptFromTXT reports whether the given domain name is exempt from
 // the requirement to have a _psl TXT record.
 func exemptFromTXT(domain domain.Name) bool {
-	if missingTXT.Has(domain.String()) {
-		return true
-	}
-	return false
+	return missingTXT.Has(domain.String())
 }
 
 // adjustTXTPR returns a PR number to use instead of prNum for
@@ -71,10 +61,6 @@ var missingEmail = []string{
 	".pl domains (grandfathered)",
 	"QA2",
 }
-
-// incorrectSort are entities in the private domains section that are
-// allowed to be in the wrong sort order.
-var incorrectSort = []string{}
 
 // missingTXT are the domains that are exempt from the _psl TXT record
 // requirement.

--- a/tools/internal/parser/parser.go
+++ b/tools/internal/parser/parser.go
@@ -263,7 +263,7 @@ func (p *parser) parseSection() *Section {
 			if tok.Name != ret.Name {
 				p.addError(ErrMismatchedSection{tok.SourceRange, tok.Name, ret})
 			}
-			ret.SourceRange.LastLine = tok.SourceRange.LastLine
+			ret.LastLine = tok.LastLine
 			return ret
 		case tokenSectionUnknown:
 			p.next()
@@ -416,7 +416,7 @@ func (p *parser) parseComment() *Comment {
 	for {
 		if tok, ok := p.peek().(tokenComment); ok {
 			p.next()
-			ret.SourceRange = ret.SourceRange.merge(tok.SourceRange)
+			ret.SourceRange = ret.merge(tok.SourceRange)
 			ret.Text = append(ret.Text, tok.Text)
 		} else {
 			return ret

--- a/tools/internal/parser/validate.go
+++ b/tools/internal/parser/validate.go
@@ -232,7 +232,8 @@ func validateTXTRecords(ctx context.Context, b Block, client *github.Repo, prHis
 		start(collect.NoError(func() txtResult { return checker.checkTXT(wild, wild.Domain) }))
 	}
 
-	group.Wait()
+	err := group.Wait()
+	checker.errs = append(checker.errs, err)
 
 	// PR verification. Now that TXT lookups are complete,
 	// checker.prExpected has a list of PRs, and the list of changes
@@ -247,7 +248,8 @@ func validateTXTRecords(ctx context.Context, b Block, client *github.Repo, prHis
 	for prNum, info := range checker.prExpected {
 		start(collectPR.NoError(func() []error { return checker.checkPR(prNum, info) }))
 	}
-	group.Wait()
+	err = group.Wait()
+	checker.errs = append(checker.errs, err)
 
 	return checker.errs
 }

--- a/tools/internal/parser/write.go
+++ b/tools/internal/parser/write.go
@@ -17,7 +17,10 @@ func (l *List) MarshalPSL() []byte {
 
 func writeBlockPSL(w io.Writer, b Block) {
 	f := func(msg string, args ...any) {
-		fmt.Fprintf(w, msg+"\n", args...)
+		_, err := fmt.Fprintf(w, msg+"\n", args...)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	switch v := b.(type) {
@@ -72,7 +75,10 @@ func writeBlockDebug(w io.Writer, b Block, indent string) {
 		changemark = "!!"
 	}
 	f := func(msg string, args ...any) {
-		fmt.Fprintf(w, indent+msg+"\n", args...)
+		_, err := fmt.Fprintf(w, indent+msg+"\n", args...)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	src := b.SrcRange()

--- a/tools/newgtlds.go
+++ b/tools/newgtlds.go
@@ -342,6 +342,7 @@ func getData(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	//nolint:errcheck
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {

--- a/tools/newgtlds_test.go
+++ b/tools/newgtlds_test.go
@@ -530,6 +530,13 @@ func TestDatFileString(t *testing.T) {
 	}
 }
 
+func removeOrComplain(t *testing.T, file string) {
+	err := os.Remove(file)
+	if err != nil {
+		t.Errorf("could not remove file: %s", err)
+	}
+}
+
 func TestReadDatFile(t *testing.T) {
 	mustWriteTemp := func(t *testing.T, content string) string {
 		tmpfile, err := os.CreateTemp("", "dat")
@@ -550,7 +557,7 @@ func TestReadDatFile(t *testing.T) {
 		"bar",
 	}, "\n")
 	noHeaderFile := mustWriteTemp(t, noHeaderContent)
-	defer os.Remove(noHeaderFile)
+	defer removeOrComplain(t, noHeaderFile)
 
 	noFooterContent := strings.Join([]string{
 		"foo",
@@ -558,7 +565,7 @@ func TestReadDatFile(t *testing.T) {
 		"bar",
 	}, "\n")
 	noFooterFile := mustWriteTemp(t, noFooterContent)
-	defer os.Remove(noFooterFile)
+	defer removeOrComplain(t, noFooterFile)
 
 	multiHeaderContent := strings.Join([]string{
 		"foo",
@@ -570,7 +577,7 @@ func TestReadDatFile(t *testing.T) {
 		"bar",
 	}, "\n")
 	multiHeaderFile := mustWriteTemp(t, multiHeaderContent)
-	defer os.Remove(multiHeaderFile)
+	defer removeOrComplain(t, multiHeaderFile)
 
 	invertedContent := strings.Join([]string{
 		"foo",
@@ -580,7 +587,7 @@ func TestReadDatFile(t *testing.T) {
 		"bar",
 	}, "\n")
 	invertedFile := mustWriteTemp(t, invertedContent)
-	defer os.Remove(invertedFile)
+	defer removeOrComplain(t, invertedFile)
 
 	validContent := strings.Join([]string{
 		"foo",                    // Index 0
@@ -590,7 +597,7 @@ func TestReadDatFile(t *testing.T) {
 		"bar",                    // Index 4
 	}, "\n")
 	validFile := mustWriteTemp(t, validContent)
-	defer os.Remove(validFile)
+	defer removeOrComplain(t, validFile)
 
 	testCases := []struct {
 		name            string
@@ -665,7 +672,10 @@ func TestProcess(t *testing.T) {
 		return func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, content)
+			_, err := fmt.Fprintln(w, content)
+			if err != nil {
+				t.Errorf("could not print: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request addresses all golangci-lint warnings in this repository. One could say some of the changes are overly pedantic, but that should be fine. It is better to get rid of all the warnings, so that the lint tooling can catch regressions if and when they happen. The golangci-lint i used is v2.