### PR TITLE
UPDATE HOSTBIP DOMAIN NAMES (2025) -biz.gl

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13770,7 +13770,6 @@ hoplix.shop
 // HOSTBIP REGISTRY : https://www.hostbip.com/
 // Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
 orx.biz
-biz.gl
 biz.ng
 co.biz.ng
 dl.biz.ng


### PR DESCRIPTION
## Description of Organization
'HostBip' is a 'PDNR' (Private Domain Name Registry), allowing 3rd parties to register domain names in a variety of domain name extensions/suffixes. This pull request disclaims BIZ.GL (#770) which we longer operate registry services for.

**Organization Website:** https://www.hostbip.com
