### PR TITLE
Add traidep.site to PRIVATE section for free public subdomain service

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15609,6 +15609,10 @@ typedream.app
 // Submitted by Typeform <ops@typeform.com>
 pro.typeform.com
 
+// ThangLeDev Free Subdomain : https://sub.thangle.io.vn
+// Submitted by Thang Le <admin@traidep.site>
+traidep.site
+
 // Uberspace : https://uberspace.de
 // Submitted by Moritz Werner <mwerner@jonaspasche.com>
 *.uberspace.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
Mail: admin@traidep.site

---

## Description of Organization

**Organization Website:** https://traidep.site

ThangLeDev is an independent developer providing free subdomain services for individuals and developers in Vietnam. The platform allows users to register subdomains like `yourname.traidep.site` via a web dashboard.  
This service is often used for API testing, development staging, and small personal projects.  

I am Thang Le, the owner of `traidep.site`, submitting this request as the domain administrator. I manage all DNS and server configurations and directly handle user requests on the service.

---

## Reason for PSL Inclusion

We provide subdomains under `traidep.site` to multiple mutually-untrusting parties through a public registration system (https://sub.thangle.io.vn). Each subdomain is owned and managed by a different user. For security reasons (especially cookie isolation between subdomains), inclusion in the PSL PRIVATE section is required.  

The domain `traidep.site` is registered until at least **2027**, and we commit to maintaining more than one year of registration going forward. The `_psl` DNS TXT record has been added and will remain in place for future validation.

This is not an attempt to bypass any third-party limitations. Instead, it is intended to ensure proper isolation of subdomains for cookie security and related browser behaviors.

**Number of users this request is being made to serve:** ~2,000 active users (as of July 2025)

---

## DNS Verification

dig +short TXT _psl.traidep.site
"https://github.com/publicsuffix/list/pull/1234"

(The above TXT record has been added and will remain active.)

$ dig TXT _psl.traidep.site
_psl.traidep.site. 300 IN TXT "https://github.com/publicsuffix/list/pull/1234"

---

## Abuse Contact

Abuse contact information (email) is available and easily accessible:  
**admin@traidep.site**