### PR TITLE
Add on-forge.com and on-vapor.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14094,7 +14094,6 @@ laravel.cloud
 on-forge.com
 on-vapor.com
 
-
 // LCube - Professional hosting e.K. : https://www.lcube-webhosting.de
 // Submitted by Lars Laehn <info@lcube.de>
 git-repos.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps
* [x]  Description of Organization
* [x]  Robust Reason for PSL Inclusion
* [x]  DNS verification via dig
* [x]  Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x]  We are listing _any_ third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
* [x]  This request was _not_ submitted with the objective of working around other third-party limits.
* [x]  The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
* [x]  The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x]  The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x]  A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:** [security@laravel.com](mailto:security@laravel.com)

* [x]  Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: [forge.laravel.com/docs/abuse](https://forge.laravel.com/docs/abuse) and [docs.vapor.build/abuse](https://docs.vapor.build/abuse)

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [x]  _Yes, I understand_. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. _Proceed anyways_.

## Description of Organization
Laravel the company is rooted in the open source world, authoring one of the most popular web application frameworks in the world. On the commercial side Laravel is focused on providing the best develop tooling we can, supporting the Laravel community. We are currently in the process of building additional features to Laravel Forge which is the context for this request, as users will be provided with *.on-forge.com subdomains to host their applications on. Similarily, Laravel Vapor has been providing users with an *.on-vapor.com domain for a few months now.

See [forge.laravel.com](https://forge.laravel.com) and [vapor.laravel.com](https://vapor.laravel.com) for information specific to these products.

**Organization Website:** [laravel.com](https://laravel.com)

## Reason for PSL Inclusion
Laravel provides managed hosting for user-generated web applications under subdomains. We would like to get included in the private section of the PSL to ensure proper security and domain handling.

* Cookie Security: Without inclusion in the PSL, browsers may treat Laravel Forge and Vapor domains as a single-origin domain, potentially allowing cookies to be shared between different user subdomains. This presents a security risk, as one user’s site could access another user’s cookies. Inclusion in the PSL ensures that each subdomain is treated as a separate site, preventing cross-user cookie access.
* Browser and Platform Compatibility: Many platforms and services (e.g., Chrome, Firefox, Let’s Encrypt, Cloudflare) use the PSL to define domain boundaries. Listing our Laravel Forge and Vapor domains in the PSL ensures compatibility with modern security policies.

Laravel commits to maintaining its _psl DNS TXT records and ensuring ongoing compliance with PSL guidelines.

**Number of users this request is being made to serve:**

- Laravel Forge - We're still in the process of building the new features into Forge, but all newly created applications will be given a free *.on-forge.com domain. We anticipate this to quickly ramp up to thousands of domains.
- Laravel Vapor - Vapor already actively uses on-vapor.com and is already serving over thousands of domains.

All customers are paying customers.

## DNS Verification
```
dig +short TXT _psl.on-forge.com
"https://github.com/publicsuffix/list/pull/2523"
```

```
dig +short TXT _psl.on-vapor.com
"https://github.com/publicsuffix/list/pull/2523"
```
