### PR TITLE
Add 072.qzz.io and 836.qzz.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9,6 +9,9 @@
 
 // ===BEGIN ICANN DOMAINS===
 
+072.qzz.io
+836.qzz.io
+
 // ac : http://nic.ac/rules.htm
 ac
 com.ac

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9,9 +9,6 @@
 
 // ===BEGIN ICANN DOMAINS===
 
-072.qzz.io
-836.qzz.io
-
 // ac : http://nic.ac/rules.htm
 ac
 com.ac

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11241,6 +11241,9 @@ zuerich
 
 // (Note: these are in alphabetical order by company name)
 
+072.qzz.io
+836.qzz.io
+
 // .KRD : https://nic.krd
 co.krd
 edu.krd


### PR DESCRIPTION
**Registrant:** skydns

**Registry URL:** https://dash.skydns.qzz.io

**Justification:**

This pull request adds two domains: `072.qzz.io` and `836.qzz.io`.

Our service, available at https://dash.skydns.qzz.io, allows any user to register subdomains under these domains. Adding them to the Public Suffix List is essential to enforce cookie isolation between different user-created subdomains (e.g., `user-a.2938.com` and `user-b.2938.com`) and prevent security vulnerabilities.

**Please note:** The website is in Chinese.

The site has also been tested with Google Chrome's auto-translate feature and remains functional.

**Test account:** admin@skydns.qzz.io
**Password:** 09876543