### PR TITLE
Add co.de to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15941,4 +15941,8 @@ enterprisecloud.nu
 // Submitted by Gx1.org <security@gx1.org>
 zone.id
 
+// KV GmbH : https://nic.co.de
+// Submitted by KV GmbH <registry@kv-gmbh.de>
+co.de
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15945,4 +15945,5 @@ enterprisecloud.nu
 // Zone.ID: https://zone.id
 // Submitted by Gx1.org <security@gx1.org>
 zone.id
+
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15941,7 +15941,7 @@ enterprisecloud.nu
 // Submitted by Gx1.org <security@gx1.org>
 zone.id
 
-// KV GmbH : https://nic.co.de
+// KV GmbH : https://www.nic.co.de
 // Submitted by KV GmbH <registry@kv-gmbh.de>
 co.de
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14152,6 +14152,7 @@ oya.to
 
 // KV GmbH : https://www.nic.co.de
 // Submitted by KV GmbH <registry@kv-gmbh.de>
+// Abuse reports to <registry@kv-gmbh.de>
 co.de
 
 // Laravel Holdings, Inc. : https://laravel.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14150,6 +14150,10 @@ krellian.net
 // Submitted by DisposaBoy <security@oya.to>
 oya.to
 
+// KV GmbH : https://www.nic.co.de
+// Submitted by KV GmbH <registry@kv-gmbh.de>
+co.de
+
 // Laravel Holdings, Inc. : https://laravel.com
 // Submitted by André Valentin <security@laravel.com>
 laravel.cloud
@@ -15940,9 +15944,4 @@ enterprisecloud.nu
 // Zone.ID: https://zone.id
 // Submitted by Gx1.org <security@gx1.org>
 zone.id
-
-// KV GmbH : https://www.nic.co.de
-// Submitted by KV GmbH <registry@kv-gmbh.de>
-co.de
-
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization  
* [x] Robust Reason for PSL Inclusion  
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__  

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.  
* [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found:  
https://www.nic.co.de/impressum

Or directly :

contact - registry@kv-gmbh.de
abuse - registry@kv-gmbh.de or abuse@kv-gmbh.de

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

KV GmbH is a German-based company operating the second-level domain `co.de`. We provide a commercial subdomain registration service under `*.co.de`, allowing individuals, businesses, and resellers to register third-level domains like `mybrand.co.de`, `johnsmith.co.de`, and so on. This allows meaningful namespace usage without the need for their own top-level domain.

We operate a DNS and domain management infrastructure and are the authoritative registry for this namespace. We provide public delegation, automation, and long-term subdomain support.

The submitter is a developer working directly on the DNS and web infrastructure of KV GmbH, responsible for maintaining zone records, operational continuity, and public policy conformance.

**Organization Website:**  
https://www.nic.co.de

---

## Reason for PSL Inclusion

Our company actively delegates subdomains under `co.de` to unaffiliated third parties through a public and commercial interface. Since users register their own independent subdomains (e.g., `alice.co.de`, `blog123.co.de`), these should be treated by browsers and services as distinct registrable units. Inclusion in the PUBLIC SUFFIX LIST (in the PRIVATE section) ensures proper handling of:

- Cookie isolation across subdomain users
- Web security boundaries
- Certificate issuance (e.g., Let's Encrypt)
- Search indexing and CNAME-based CDNs

`co.de` has been registered for more than 10 years and will continue to be renewed. The `_psl` TXT record is already configured and will be maintained for verification.

We are **not** requesting this entry to bypass rate limits of third-party services. We are aware of the responsibilities of listing and commit to maintaining the DNS records and abuse contact over time.

**Number of users this request is being made to serve:**  
Currently over 7000 delegated subdomains with active usage, and growing.

---


## DNS Verification

```
dig +short TXT _psl.co.de
"https://github.com/publicsuffix/list/pull/2539"
```

This record will be retained for the entire duration of our listing in the Public Suffix List.


## Previous Pull Requests
https://github.com/publicsuffix/list/pull/1967
