### PR TITLE
Remove *.uberspace.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15677,7 +15677,6 @@ pro.typeform.com
 
 // Uberspace : https://uberspace.de
 // Submitted by Moritz Werner <mwerner@jonaspasche.com>
-*.uberspace.de
 uber.space
 
 // UDR Limited : http://www.udr.hk.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

As the checklist template is tailored to _additions_ to the list, I am not following it as this PR is about a _removal_.

Our original PR was https://github.com/publicsuffix/list/pull/616 in 2018. At that time we handed out subdomains in the form `USER.HOST.uberspace.de` to our users. We ended this practice years ago and moved all user-generated content to subdomains of the separate domain "uber.space" which is already included on the PSL since 2017, so cookie isolation for `*.uberspace.de` is no longer needed.