### PR TITLE
Remove altoadige.it from the public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1653,7 +1653,6 @@ agrigento.it
 al.it
 alessandria.it
 alto-adige.it
-altoadige.it
 an.it
 ancona.it
 andria-barletta-trani.it


### PR DESCRIPTION
altoadige.it is a domain associated to a newspaper in the north of italy. It was created before the regional suffixes.

# Public Suffix List (PSL) Removal

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Exclusion
* [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

## Description of Organization

Alto Adige is an Italian local daily newspaper, based in [Bolzano](https://en.wikipedia.org/wiki/Bolzano). It is sold in [South Tyrol](https://en.wikipedia.org/wiki/South_Tyrol) and since 1999 also in the [province of Belluno](https://en.wikipedia.org/wiki/Province_of_Belluno). Prior to 2000, the newspaper was published with three local editions, for South Tyrol, [Trentino](https://en.wikipedia.org/wiki/Trentino) and Belluno, when was subdivided with two new local newspapers: Trentino and Corriere delle Alpi.

**Organization Website:**

https://www.altoadige.it/

## Reason for PSL Exclusion

The altoadige.it is not a suffix, and exists before the regional suffix were created. It cause trouble to parse this domain is many system.

**Number of users this request is being made to serve:**
<!-- Identify if this is current or an estimate. -->

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.altoadige.it
# nothing return
```