### PR TITLE
remove 611.to

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11269,9 +11269,6 @@ cc.ua
 inf.ua
 ltd.ua
 
-// 611 blockchain domain name system : https://611project.net/
-611.to
-
 // A2 Hosting
 // Submitted by Tyler Hall <sysadmin@a2hosting.com>
 a2hosted.com


### PR DESCRIPTION
The reasons are as follows：

1. First, the main website [611project.net](https://611project.net/)，it seems to have turned into a gambling site.

2. Secondly, 611.to has no DNS record at all (that is, it is inaccessible).

3. Finally, there is no contact email in the list 611.to.

The original PR is [#1037](https://github.com/publicsuffix/list/pull/1037) submitted by [@611project](https://github.com/611project) 

<img width="1872" height="979" alt="Image_1753721380503" src="https://github.com/user-attachments/assets/46340adc-fc4c-4399-b5da-d8713db01d65" />