### PR TITLE
remove: domains caffeine.ai id.ai icp-api.io from public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12770,9 +12770,6 @@ deta.dev
 
 // Dfinity Foundation: https://dfinity.org/
 // Submitted by Dfinity Team <domains@dfinity.org>
-caffeine.ai
-id.ai
-icp-api.io
 icp0.io
 *.raw.icp0.io
 icp1.io


### PR DESCRIPTION
Remove no longer needed domains:
- caffeine.ai
- id.ai
- icp-api.io

from the list, as we do not plan to offer public services on subdomains.


```
dig TXT +short _psl.icp-api.io @1.1.1.1
"https://github.com/publicsuffix/list/pull/2555"
dig _psl.caffeine.ai TXT +short @1.1.1.1
"https://github.com/publicsuffix/list/pull/2555"
dig _psl.id.ai TXT +short @1.1.1.1
"https://github.com/publicsuffix/list/pull/2555"
```
