### PR TITLE
Remove glitch.me

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13577,10 +13577,6 @@ gitlab.io
 gitapp.si
 gitpage.si
 
-// Glitch, Inc : https://glitch.com
-// Submitted by Mads Hartmann <mads@glitch.com>
-glitch.me
-
 // Global NOG Alliance : https://nogalliance.org/
 // Submitted by Sander Steffann <sander@nogalliance.org>
 nog.community


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

The Glitch hosting service was shut down on July 8, 2025, so there is no longer any need for `glitch.me` to be included in the PSL.

ref: https://blog.glitch.com/post/goodbye-glitch

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Removal
* [X] DNS verification via dig

* [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Fastly, Inc. acquired Glitch a number of years ago, and has been operating the service and its DNS zones since the acquisition. In July of 2025 Fastly shut down most of the Glitch service (in particular the project-hosting portion which benefited from PSL inclusion), and the remainder will be shut down at the end of 2025.

**Organization Website:**
https://fastly.com

## Reason for PSL Removal
As noted above, there is no longer any need for `glitch.me` to be included in the PSL.

## DNS Verification
```
kpfleming@kpfleming:~$ dig +short TXT _psl.glitch.me
"https://github.com/publicsuffix/list/pull/2565"
```