### PR TITLE
remove airkitapps.com, airkitapps.eu, and airkitapps-au.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11323,12 +11323,6 @@ africa.com
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl
 
-// Airkit : https://www.airkit.com/
-// Submitted by Grant Cooksey <security@airkit.com>
-airkitapps.com
-airkitapps-au.com
-airkitapps.eu
-
 // Aiven : https://aiven.io/
 // Submitted by Aiven Security Team <security+appdomains@aiven.io>
 aiven.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

The Airkit service was shuttered on July 31, 2025 so there is no longer any need to be included in the PSL.

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Removal
* [X] DNS verification via dig
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization
[Salesforce acquired Airkit in October 2023](https://www.salesforce.com/news/stories/salesforce-signs-definitive-agreement-to-acquire-airkit-ai/), and has been operating the service since then.  In July of this year, we finished shuttering the service and no longer need to be included in the PSL.  I was the Chief Architect at the time of acquisition, and have continued as one of the operators of this property.

**Organization Website:**
https://airkit.ai/

## Reason for PSL Removal
Airkit infrastructure was torn down in July 2025, and a dangling entry in PSL represents an abuse risk if these domains expire.

## DNS Verification
Please note - this is a negative test because we want to remove the domain from PSL!
```bash
% dig +short TXT _psl.airkitapps.com
% dig +short TXT _psl.airkitapps-au.com
% dig +short TXT _psl.airkitapps.eu
%
```