### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5630,12 +5630,14 @@ gov.sg
 net.sg
 org.sg
 
-// sh : http://nic.sh/rules.htm
+// sh : http://nic.sh/rules.htm https://www.nic.sh/free-domain-for-saint-helena-residents.htm 
 sh
+co.sh
 com.sh
 gov.sh
 mil.sh
 net.sh
+nom.sh
 org.sh
 
 // si : https://www.iana.org/domains/root/db/si.html


### PR DESCRIPTION
on [NIC.SH](https://nic.sh/) you can see that .co.sh and .nom.sh are offered as registrable domains (same as .com.sh, .org.sh, etc).

so i added .co.sh and .nom.sh under the SH section so the PSL matches what the registry actually allows.

i hope this was correct formatting