### PR TITLE
Remove `servers.run`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14251,10 +14251,6 @@ loginline.site
 // Submitted by Heiki Lõhmus <hostmaster@lohmus.me>
 lohmus.me
 
-// Lokalized : https://lokalized.nl
-// Submitted by Noah Taheij <noah@lokalized.nl>
-servers.run
-
 // Lovable : https://lovable.dev
 // Submitted by Fabian Hedin <security@lovable.dev>
 lovable.app


### PR DESCRIPTION
Domain Expired. 
Removal confirmed by initial requestor @ntaheij at https://github.com/publicsuffix/list/pull/2116#issuecomment-3273350701