### PR TITLE
Remove `mydrobo.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12829,10 +12829,6 @@ dreamhosters.com
 // Submitted by Infra Team <infra@durumis.com>
 durumis.com
 
-// Drobo : http://www.drobo.com/
-// Submitted by Ricardo Padilha <rpadilha@drobo.com>
-mydrobo.com
-
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org


### PR DESCRIPTION
- `mydrobo.com` expired for over 2 months

```
Domain Name: MYDROBO.COM
   Registry Domain ID: 1070140860_DOMAIN_COM-VRSN
   Registrar WHOIS Server: whois.networksolutions.com
   Registrar URL: http://networksolutions.com
   Updated Date: 2025-08-18T08:41:23Z
   Creation Date: 2007-07-06T22:13:11Z
   Registry Expiry Date: 2025-07-06T22:13:11Z
```

- GitHub mention received no response at https://github.com/publicsuffix/list/pull/84#issuecomment-3198472193
- Unable to reach the initial requestor by email

```
rpadilha@drobo.com
host d220386a.ess.barracudanetworks.com [209.222.82.255]
SMTP error from remote mail server after end of data:
550 permanent failure for one or more recipients (rpadilha@drobo.com:550 5.4.1 Recipient address rejected:
Access denied. For more information see https://aka.ms/EXOSm...)
```