### PR TITLE
Added support.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14845,7 +14845,7 @@ mypep.link
 // Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
 perspecta.cloud
 
-// Plain: https://www.plain.com/
+// Plain : https://www.plain.com/
 // Submitted by Jesús Hernández <security@plain.com>
 support.site
 


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible
  URL where abuse contact or abuse reporting form can be found: help@plain.com

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization
[Plain](https://www.plain.com) is a customer support software for companies who sell their services/products to other companies. As part of our feature offering, we give our customers the ability to create help centers.

These help centers are hosted by Plain, while our customers control their contents. 

When a customer creates a help center on Plain, they can choose a subdomain under *.support.site. For instance,`acme.support.site`

We want to avoid any potential issues derived from this multi-tenant setup and hence are requesting `support.site` to be included in this list.

This submission is made by @jesushernandez , Staff Engineer at Plain.

**Organization Website:**
[https://www.plain.com](https://www.plain.com)

## Reason for PSL Inclusion
Several of our customers are reporting problems while trying to access help centers (hosted under `support.site`). The usual error they see is `ERR_SSL_PROTOCOL_ERROR`. However, all these domains have valid certificates, issued by Let's Encrypt

We are working with our cloud provider to get to the bottom of this and they have advised us to include `support.site` in the public suffix list. Both our provider and us believe that this problem is being caused by intermediaries (e.g. ISPs, firewalls) and not them (our provider) or our own technology stack to provide this service.

Having `support.site` in this list effectively isolates tenants from each other, which is what we need.

**Number of users this request is being made to serve:**
Hundreds of users (companies) who are already customers of us and use our help center product. These companies serve hundreds of thousands of users themselves.

## DNS Verification
```
dig +short TXT _psl.support.site
"https://github.com/publicsuffix/list/pull/2594"
```