### PR TITLE
Add Webconnex SaaS platform domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15807,6 +15807,12 @@ wal.app
 webflow.io
 webflowtest.io
 
+// Webconnex : https://www.webconnex.com/
+// Submitted by Daniel Riley <daniel@webconnex.io>
+givingfuel.com
+redpodium.com
+regfox.com
+ticketspice.com
 // WebHare bv : https://www.webhare.com/
 // Submitted by Arnold Hendriks <info@webhare.com>
 *.webhare.dev


### PR DESCRIPTION
## Summary
Add four Webconnex SaaS platform domains to enable independent subdomain verification for META ad campaigns.

## Rationale
Webconnex needs their SaaS platform domains added to the Public Suffix List to address META Ad Campaign issues. Without PSL inclusion, customer subdomains cannot be verified independently for META ads, causing:
- Attribution problems 
- Higher ad costs
- Event de-duplication issues
- Reduced ad optimization effectiveness

## Domains Added
- `givingfuel.com` - Fundraising and donor management platform
- `redpodium.com` - Sports event registration platform  
- `regfox.com` - Event registration software
- `ticketspice.com` - Event ticketing platform

## Scale & Impact
- **60,000+ customers** across all platforms
- **$3+ billion** processed through these platforms
- Each platform provides customer subdomains (e.g., `customer.ticketspice.com`) that need to be treated as independent domains for:
  - Cookie policies
  - Security contexts
  - META ad domain verification

## DNS Validation
DNS TXT records will need to be added at:
- `_psl.givingfuel.com`
- `_psl.redpodium.com` 
- `_psl.regfox.com`
- `_psl.ticketspice.com`

Each record will contain the URL of this PR once created.

## Testing
✅ All changes pass PSL linter validation
✅ Correct alphabetical sorting maintained
✅ Format follows PSL guidelines