### PR TITLE
Add 1010819.xyz 0012311.xyz and lnstw.xyz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12336,6 +12336,12 @@ ecommerce-shop.pl
 // Submitted by Olivier Benz <olivier.benz@b-data.ch>
 b-data.io
 
+// Bago Domain : https://blueshoe.idv.tw/nic
+// Submitted by Jim Chang <jimjimcbyt@gmail.com>
+1010819.xyz
+0012311.xyz
+lnstw.xyz
+
 // Balena : https://www.balena.io
 // Submitted by Petros Angelatos <petrosagg@balena.io>
 balena-devices.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

Checklist of required steps

- [x] Description of Organization

- [x] Robust Reason for PSL Inclusion

- [x] DNS verification via dig

- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _psl TXT record in place in the respective zone(s).


Submitter affirms the following:

- [ ] This request was not submitted with the objective of working around other third-party limits.

- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.

- [x] The Guidelines were carefully read and understood, and this request conforms to them.

- [x] The submission follows the guidelines on formatting and sorting.

- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.


Abuse Contact:

- [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found:
https://1010819.xyz/contact (or just abuse@1010819.xyz)

- [x] Yes, I understand. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. Proceed anyways.



---

Description of Organization

Organization Website:
https://1010819.xyz

We are a non-profit organization that provides free subdomains to users, allowing them to set up websites or other online services without purchasing a domain. We manage multiple top-level domains, including 1010819.xyz, 0012311.xyz, and lnstw.xyz, ensuring that users can safely and reliably use their subdomains. As the submitter, I am responsible for the operation and maintenance of these domains, including DNS configuration and subdomain management.


---

Reason for PSL Inclusion

We request to include 1010819.xyz, 0012311.xyz, and lnstw.xyz in the Public Suffix List (PSL) so that users’ cookies, browser isolation, and other security mechanisms function correctly. Since we provide free subdomains for public use, if these domains are not listed in the PSL, browsers may treat subdomains as a single domain, causing cookie isolation issues or affecting login and authentication across subdomains.

Each of our domains will maintain at least two years of registration and continue to maintain the _psl TXT record for verification. These domains are solely used for free subdomain services, with no intention to circumvent third-party limits. Inclusion in the PSL ensures that our users receive proper security behavior in browsers and applications and avoids cookie conflicts or other security issues across subdomains.

Number of users this request is being made to serve:
Currently serving an estimated hundreds to thousands of users, with potential for growth as more people rely on these free subdomains.


---

DNS Verification

Please create the following TXT records in the DNS for each domain (replace XXXX with your GitHub PR number):

dig +short TXT _psl.1010819.xyz
"https://github.com/publicsuffix/list/pull/2598"

dig +short TXT _psl.0012311.xyz
"https://github.com/publicsuffix/list/pull/2598"

dig +short TXT _psl.lnstw.xyz
"https://github.com/publicsuffix/list/pull/2598"
