### PR TITLE
ht addition

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1336,6 +1336,7 @@ coop.ht
 edu.ht
 firm.ht
 gouv.ht
+gov.ht
 info.ht
 med.ht
 net.ht


### PR DESCRIPTION
We respectfully request that the Public Suffix List include the second‑level domain gov.ht. The Haitian government, through an officially sanctioned agreement with NIC Haiti and a contracted DNS provider (TimeNIC Inc.), is establishing gov.ht as a resilient backup namespace for core ministries (e.g., health, finance, education) to complement the existing gouv.ht domain. Adding gov.ht to the PSL will enforce cookie and storage isolation across these independent government sites, mitigating cross‑site tracking and significantly reducing the attack surface exploited by phishing actors that currently abuse the unprotected namespace. W