### PR TITLE
add bank.in and fin.in to the public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1447,6 +1447,7 @@ in
 ac.in
 ai.in
 am.in
+bank.in
 bihar.in
 biz.in
 business.in
@@ -1460,6 +1461,7 @@ delhi.in
 dr.in
 edu.in
 er.in
+fin.in
 firm.in
 gen.in
 gov.in


### PR DESCRIPTION
# Add `bank.in` and `fin.in` to the Public Suffix List

## Description

This pull request proposes adding two new public suffixes:

bank.in
fin.in


These domains have been introduced by the Reserve Bank of India (RBI) to improve security and reduce cyber fraud in the Indian banking and financial sector.

## Background and Rationale

- The RBI has officially designated `bank.in` as the exclusive internet domain for Indian banks and `fin.in` for non-bank financial companies (NBFCs) and fintech firms, as part of a national effort to curb financial fraud and improve cybersecurity.  
- The Institute for Development and Research in Banking Technology (IDRBT) has been appointed as the exclusive registrar to manage registrations under these domains.  
- These domains are managed under the authority of the National Internet Exchange of India (NIXI) and the Ministry of Electronics and Information Technology (MeitY).  
- The RBI has issued notifications and press releases outlining the launch, policy, and migration timeline, with banks expected to migrate to `bank.in` by October 31, 2025.

## References

- RBI official notification:  
  https://rbidocs.rbi.org.in/rdocs/notification/PDFs/NT2898A050AD36214AFAA5D63AC889B3FD4C.PDF

- IDRBT announcement on domain management:  
  https://www.idrbt.ac.in/wp-content/uploads/2025/04/btMoneyToday.pdf

- RBI press release on domain rollout:  
  https://www.rbi.org.in/Scripts/BS_PressReleaseDisplay.aspx?prid=59693

## Additional Notes

- These domains will function as public suffixes allowing banks and eligible financial entities to register subdomains, enabling proper domain delegation and security measures.
