### PR TITLE
Add edu.fj and id.fj to Fiji ccTLD section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1100,13 +1100,14 @@ fi
 // completely removed.
 aland.fi
 
-// fj : http://domains.fj/
-// Submitted by registry <garth.miller@cocca.org.nz> 2020-02-11
+// fj : https://www.iana.org/domains/root/db/fj.html
 fj
 ac.fj
 biz.fj
 com.fj
+edu.fj
 gov.fj
+id.fj
 info.fj
 mil.fj
 name.fj


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

## Summary
This PR adds two new second-level domains under the .fj (Fiji) country-code top-level domain:

edu.fj
id.fj

## Description of Organization
I am submitting this PR as an individual (Anton Trye <anton@anton.nz>) on behalf of the .fj registry operator (University of the South Pacific, USP) with whom I am in contact via email and phone. The registry team should implement the required DNS validation records once this PR is created. Domains are registered at https://www.domains.fj/ (verified via https://www.iana.org/domains/root/db/fj.html as the registrar, administered by USP).

USP has sole authority over domain registration and has opened up .edu.fj and .id.fj. They are contactable via phone +6793232117 and email: domreg@usp.ac.fj

We can also perform secondary validation if the registrar becomes unresponsive. I appreciate the scope and effort requirements of manual verification - I intend to rely on DNS validation but I'm not sure if the registrar is interested in compliance.

<img width="400" height="auto" alt="fj_domains" src="https://github.com/user-attachments/assets/a2ccc05d-b8c3-44ae-a573-330aa147b528" />

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [ ] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact: USP Registrar <domreg@usp.ac.fj>**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found: https://www.whois.fj/

**Organization Website:** https://www.domains.fj/

## Reason for PSL Inclusion

I am making this PR for cookie security as both domains are under open registration

**Number of users this request is being made to serve:**
Unknown, upper bound being every .edu.fj user.

## DNS Verification

These are pending and do not resolve yet.

```
dig +short TXT _psl.edu.fj
"https://github.com/publicsuffix/list/pull/2607"
```

```
dig +short TXT _psl.id.fj
"https://github.com/publicsuffix/list/pull/2607"
```
