### PR TITLE
Add xtooldevice.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15937,6 +15937,10 @@ cistron.nl
 demon.nl
 xs4all.space
 
+// xTool : https://xtool.com
+// Submitted by Echo <admin@xtool.com>
+xtooldevice.com
+
 // Yandex.Cloud LLC : https://cloud.yandex.com
 // Submitted by Alexander Lodin <security+psl@yandex-team.ru>
 yandexcloud.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization  
* [x] Robust Reason for PSL Inclusion  
* [x] DNS verification via dig  
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).  
* [x] This request was _not_ submitted with the objective of working around other third-party limits.  
* [x] The submitter acknowledges responsibility to maintain the domains within their section.  
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were read and understood.  
* [x] The submission follows the [guidelines on formatting and sorting](https://github.com/publicsuffix/list/wiki/Format).  
* [x] A role-based email address is used and monitored.  
* [x] Abuse contact is available and accessible.  
* [x] I understand the risk of propagation and rollback timing. Proceed anyway.  

---

## Description of Organization

xTool (https://www.xtool.com) is a technology company focusing on digital fabrication and intelligent hardware, including laser engravers, cutting machines, and printing equipment.  

`xtooldevice.com` is operated by xTool as a dedicated domain for configuring and accessing our laser engraving machines and DTF printing devices. This domain is used by end-user devices and companion applications for secure connectivity.  

Submitter: Engineering team at xTool, responsible for device networking, firmware integration, and platform infrastructure.  
Contact: `admin@xtool.com`

**Organization Website:**  
https://www.xtool.com  

---

## Reason for PSL Inclusion

The domain `xtooldevice.com` should be listed in the PRIVATE section of the PSL to ensure secure handling of cookies, storage, and browser-based isolation mechanisms.  

- Devices and users are provisioned unique subdomains (e.g. `a.xtooldevice.com`, `b.xtooldevice.com`).  
- These subdomains represent **mutually untrusted contexts**; without PSL isolation, cookies or local storage may be incorrectly shared across devices.  

### Stability & Long-Term Maintenance

- `xtooldevice.com` is set with **automatic renewal**, ensuring continuity and long-term validity.  
- To demonstrate ownership and continuity, we also provide a `_psl` TXT record for both `xtooldevice.com` and our main corporate domain `xtool.com`.  
- This confirms both domains are operated by the same organization.  

We hereby commit to:  
- Maintaining the domain for the long term (renewal always ≥ 2 years).  
- Keeping the `_psl` TXT record in place.  
- Responding to inquiries at `admin@xtool.com`.  

**Number of users this request is being made to serve:**  
Tens of thousands of end-user devices (current, growing rapidly).  

---

## DNS Verification

```
dig +short TXT _psl.xtooldevice.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.xtool.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

(Replace `XXXX` with the actual PR number after submission.)  

---
