### PR TITLE
Add statichost.eu domain for user websites `statichost.page`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15475,6 +15475,10 @@ novecore.site
 // Submitted by Jacob Lee <jacob@stdlib.com>
 api.stdlib.com
 
+// statichost.eu : https://www.statichost.eu
+// Submitted by Eric Selin <admin@statichost.eu>
+statichost.page
+
 // stereosense GmbH : https://www.involve.me
 // Submitted by Florian Burmann <publicsuffix@involve.me>
 feedback.ac


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  - Potential effect of PSL inclusion: limiting corrective action due to e.g. phishing attempts to the respective subdomain rather that the whole `statichost.page` domain (e.g. Google Safe Browsing blacklisting). This is in no way related to working around rate limiting or any other per-domain limits that the operators of such services may have in place. To be clear: we have and will moderate user content in exactly the same way regardless of PSL inclusion, and as such, this is not a "work around" per se.
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://www.statichost.eu/abuse/

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

statichost.eu offers static website hosting for its users. All sites are provided with a `*.statichost.page` subdomain, in addition to the ability to add custom domains. statichost.eu is focused on privacy and mainly targets the European market. It is similar to services such as GitHub Pages and surge.sh, as well as Netlify and Vercel.

I, the submitter, am the founder of statichost.eu.

**Organization Website:**
https://www.statichost.eu

## Reason for PSL Inclusion
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare, etc.) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also reference any past issues or PRs 
specifically related to this submission or section.

Provide three or more sentences here that describe the purpose 
for which your PR should be included in the PSL. There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Each site is provided with a `*.statichost.page` subdomain, e.g. `techtransparency.statichost.page` and `gobybike.statichost.page` represent separate sites. Since these subdomains are controlled by different users, we need `statichost.page` to be on the PSL to ensure that cookies are restricted to the individual subdomains and cannot be set for the main `statichost.page` domain. This is critical for maintaining the security and privacy of our customers.

Furthermore, inclusion on the PSL serves as an additional signal that these subdomains are run by different entities. For instance, in the case of fraud or abuse, it should ideally limit any corrective action (such as Google Safe Browsing flagging content as dangerous) to a specific subdomain instead of the entire `statichost.page` domain.

The `statichost.page` domain has a registration term of over five years (expires in 2031), and will maintain a term of more than one year in any case.

**Number of users this request is being made to serve:**
Tens of thousands of users or more.

The direct impact of this request is to the visitors to sites that primarily use their `*.statichost.page` domain (instead of a custom domain). However, this has the potential to affect the visitors of other sites on the statichost.eu platform as well (through Google Safe Browsing, for instance).

To clarify, all existing customer subdomains will be moved to the `statichost.page` domain.

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->

```
dig +short TXT _psl.statichost.page
"https://github.com/publicsuffix/list/pull/2611"
```