### PR TITLE
Add `canvacode.com` and `canva-hosted-embed.com` to to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12446,6 +12446,8 @@ cafjs.com
 canva-apps.cn
 my.canvasite.cn
 canva-apps.com
+canva-hosted-embed.com
+canvacode.com
 rice-labs.com
 canva.run
 my.canva.site


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps
 
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.canva.com/en_au/help/report-content/
  Email: abuse@canva.com (monitored)

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Canva is an online graphic design platform with support for presentations, still graphics, videos and other similar features.

Canva has a platform as a service (PaaS) offering called Canva Code (distinct from other Canva PaaS offers such as Canva Websites, however, interrelated - Canva Code artefacts can be embedded via an iframe in Canva Websites) that hosts AI-generated Canva Code (simply HTML/JS/CSS bundled into a single file).

I am a Software Engineer at Canva.

**Organization Website:**

- https://www.canva.com/
- We're also available in China at https://www.canva.cn/

**Previous Addition PRs:**

https://github.com/publicsuffix/list/pull/2605
https://github.com/publicsuffix/list/pull/1627
https://github.com/publicsuffix/list/pull/1739

## Reason for PSL Inclusion

Canva Code provisions user-created applications on unique subdomains to ensure strict isolation and prevent cookies from being set on the parent registrable domain. We operate two production domains for Canva Code:

- `<canva_code_id>.canva-hosted-embed.com`
- `<canva_code_id>.canvacode.com`

Each published Canva Code artefact is served from its own subdomain (for example, `artefact-a.canva-hosted-embed.com` or `artefact-b.canvacode.com`). These domains are actively maintained components of Canva’s platform architecture. PSL entries are requested so this isolation model is respected consistently across user agents and cookie stores.

**Number of users this request is being made to serve:**

There are ~220 million monthly active users of Canva.

Canva Code currently has over 1 million monthly users and growing.

## DNS Verification

```
> dig TXT _psl.canva-hosted-embed.com +short
"https://github.com/publicsuffix/list/pull/2617"
```

```
> dig TXT _psl.canvacode.com +short
"https://github.com/publicsuffix/list/pull/2617"
```

```
> dig +short TXT _psl.canva.com
"https://github.com/publicsuffix/list/pull/1627"
"https://github.com/publicsuffix/list/pull/1739"
"https://github.com/publicsuffix/list/pull/2477"
"https://github.com/publicsuffix/list/pull/2605"
"https://github.com/publicsuffix/list/pull/2617"
```

```
> dig +short TXT _psl.canva.cn
"https://github.com/publicsuffix/list/pull/1627"
"https://github.com/publicsuffix/list/pull/1739"
"https://github.com/publicsuffix/list/pull/2477"
"https://github.com/publicsuffix/list/pull/2605"
"https://github.com/publicsuffix/list/pull/2617"
```

- the domain name(s) submitted have at least 2 years of registration period left in them at the time of submitting the name

```
> whois canva-hosted-embed.com | grep Expiration
Registrar Registration Expiration Date: 2029-02-12T04:52:10Z
> whois canvacode.com | grep Expiration
Registrar Registration Expiration Date: 2028-12-17T01:08:31Z
```

- we commit to maintaining their registration in good standing with more than a year left in their term.

## Results of Syntax Checker (`make test`)

<details>
<summary>Click to expand code</summary>

```
make test
cd linter;                                \
	  ./pslint_selftest.sh;                     \
	  ./pslint.py ../public_suffix_list.dat;
-n test_allowedchars:
OK
-n test_dots:
OK
-n test_duplicate:
OK
-n test_exception:
OK
-n test_NFKC:
OK
-n test_punycode:
OK
-n test_section1:
OK
-n test_section2:
OK
-n test_section3:
OK
-n test_section4:
OK
-n test_spaces:
OK
-n test_wildcard:
OK
test -d libpsl || git clone --depth=1 https://github.com/rockdaboot/libpsl;   \
	  cd libpsl;                                                                    \
	  git pull;                                                                     \
	  echo "EXTRA_DIST =" >  gtk-doc.make;                                          \
	  echo "CLEANFILES =" >> gtk-doc.make;                                          \
	  autoreconf --install --force --symlink;
Already up to date.
autopoint: using AM_GNU_GETTEXT_REQUIRE_VERSION instead of AM_GNU_GETTEXT_VERSION
glibtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
glibtoolize: linking file 'build-aux/ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
glibtoolize: linking file 'm4/libtool.m4'
glibtoolize: linking file 'm4/ltoptions.m4'
glibtoolize: linking file 'm4/ltsugar.m4'
glibtoolize: linking file 'm4/ltversion.m4'
glibtoolize: linking file 'm4/lt~obsolete.m4'
configure.ac:1: warning: file 'version.txt' included several times
configure.ac:4: warning: file 'version.txt' included several times
aclocal.m4:842: AM_INIT_AUTOMAKE is expanded from...
configure.ac:4: the top level
configure.ac:369: warning: file 'version.txt' included several times
configure.ac:10: installing 'build-aux/compile'
configure.ac:4: installing 'build-aux/missing'
fuzz/Makefile.am: installing 'build-aux/depcomp'
cd libpsl && ./configure -q -C --enable-runtime=libicu --enable-builtin=libicu --with-psl-file=/Users/lex/work/list/public_suffix_list.dat --with-psl-testfile=/Users/lex/work/list/tests/tests.txt && make -s clean && make -s check -j4
configure: WARNING: --enable-builtin=libicu is deprecated, use --enable-builtin (enabled by default)
config.status: creating po/Makefile
Making clean in po
Making clean in include
Making clean in src
rm -f ./so_locations
Making clean in tools
Making clean in fuzz
Making clean in tests
Making clean in msvc
Making check in po
Making check in include
Making check in src
  CC       libpsl_la-psl.lo
  CC       libpsl_la-lookup_string_in_fixed_set.lo
  CCLD     libpsl.la
Making check in tools
  CC       psl.o
  CCLD     psl
Making check in fuzz
  CC       libpsl_fuzzer.o
  CC       main.o
  CC       libpsl_load_fuzzer.o
  CC       libpsl_load_dafsa_fuzzer.o
  CCLD     libpsl_icu_fuzzer
  CCLD     libpsl_icu_load_dafsa_fuzzer
  CCLD     libpsl_icu_load_fuzzer
PASS: libpsl_icu_load_dafsa_fuzzer
PASS: libpsl_icu_fuzzer
PASS: libpsl_icu_load_fuzzer
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 3
# PASS:  3
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in tests
  CC       test-is-public.o
  CC       common.o
  CC       test-is-cookie-domain-acceptable.o
  CC       test-is-public-all.o
  CC       test-is-public-builtin.o
  CC       test-registrable-domain.o
  CCLD     test-is-public
  CCLD     test-is-public-all
  CCLD     test-is-public-builtin
  CCLD     test-registrable-domain
  CCLD     test-is-cookie-domain-acceptable
PASS: test-is-public
PASS: test-is-public-builtin
PASS: test-is-public-all
PASS: test-is-cookie-domain-acceptable
PASS: test-registrable-domain
============================================================================
Testsuite summary for libpsl 0.21.5
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in msvc
```
</details>