### PR TITLE
Add *.magicloops.app to the Public Suffix List (PRIVATE section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14317,6 +14317,10 @@ luyani.net
 // Submitted by Damien Tournoud <dtournoud@magento.cloud>
 *.magentosite.cloud
 
+// Magic Loops : https://magicloops.dev/
+// Submitted by Adam Williams <security@magicloops.dev>
+*.magicloops.app
+
 // Mail.Ru Group : https://hb.cldmail.ru
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  [https://magicloops.app/abuse](https://magicloops.app/abuse)

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization
Magic Loops is a software platform that enables users to build, deploy, and share AI-driven applications and workflows.  
Each application runs in an isolated, user-owned environment accessible at a unique subdomain of `magicloops.app` (for example, `username.magicloops.app`).  

Magic Loops operates as a multi-tenant hosting platform for AI-generated and user-provided content, with strong separation between user data and execution environments. The company maintains its own infrastructure and DNS for the `magicloops.app` domain.  

The submitter, **Adam Williams**, is an authorized representative of Magic Loops and is responsible for infrastructure and platform operations, including DNS and security compliance.  

**Organization Website:**
[https://magicloops.dev](https://magicloops.dev)
  
_Note: the "builder" site is `.dev` and the "hosting" site is `.app`_
  
## Reason for PSL Inclusion
Magic Loops issues subdomains under `magicloops.app` to untrusted third-party users, each representing a distinct application or hosted AI workspace. These subdomains are independently owned and managed by users, not by Magic Loops itself.  

Without inclusion in the Public Suffix List, browsers treat all subdomains of `magicloops.app` as part of the same site for cookie and localStorage purposes. This creates potential privacy and security risks, including inadvertent cookie or storage sharing between users.  

By adding `*.magicloops.app` to the **PRIVATE** section of the PSL, browsers and libraries that rely on the list (including Chrome, Firefox, Safari, and others) will properly isolate each user’s subdomain as its own “site.” This isolation ensures that cookies, localStorage, and other origin-bound data cannot leak between different users' hosted apps.  

Magic Loops does not rely on this change to circumvent any rate limits or third-party restrictions (e.g., Cloudflare or Let’s Encrypt). The change is strictly for **cookie security and origin isolation**, consistent with the intended use of the PSL for multi-tenant hosting platforms.  

The domain `magicloops.app` is registered via Google Registry and has more than five years remaining in its registration term. Magic Loops will maintain active registration with at least one year remaining at all times.  

**Number of users this request is being made to serve:**
Currently thousands of weekly active users (100k+ apps created so far), with continued growth as the platform expands.

## DNS Verification

```
dig +short TXT _psl.magicloops.app
"https://github.com/publicsuffix/list/pull/2622"
```