### PR TITLE
Update `.bd` in ICANN section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -331,7 +331,6 @@ tv.bb
 
 // bd : https://www.iana.org/domains/root/db/bd.html
 // Confirmed by registry <dgm.domain@btcl.gov.bd>
-
 bd
 ac.bd
 ai.bd


### PR DESCRIPTION
Organization Name:
Bangladesh Telecommunications Company Limited (BTCL)

Organization Website:
https://btcl.portal.gov.bd/

Submitter:
Joyeeta Sen Rimpee
Registry Operator, .bd Domain
Bangladesh Telecommunications Company Limited (BTCL)

Role-based Contact:
dgm.domain@btcl.gov.bd

Abuse Contact:
https://btcl.portal.gov.bd/contact

or email: dgm.domain@btcl.gov.bd

Organization Overview:
Bangladesh Telecommunications Company Limited (BTCL) is the state-owned national telecommunications provider of Bangladesh and the official operator of the country code top-level domain (ccTLD) .bd, delegated by IANA and managed under the authority of the Government of Bangladesh.
BTCL maintains the authoritative DNS infrastructure for .bd and .বাংলা, ensuring operational stability, DNSSEC deployment, and compliance with global Internet governance standards.

Reason for PSL Inclusion

BTCL has officially enabled second-level domain registrations directly under .bd (e.g., example.bd) in addition to the existing structured third-level domains (e.g., example.com.bd, example.net.bd).

This update ensures that modern Internet infrastructure and hosting services—including browsers, certificate authorities, cPanel, Cloudflare, and Let’s Encrypt—correctly recognize second-level .bd domains as registrable and valid.

The previous PSL configuration (*.bd) treated all subdomains as public registrable domains, which caused issues with cookie scope, HTTPS certificate validation, and domain recognition across major platforms.
The updated section below accurately represents the .bd namespace and preserves compatibility with both second-level and structured third-level registrations.

Proposed .bd Section:

// Bangladesh : https://btcl.gov.bd
bd
com.bd
net.bd
org.bd
edu.bd
gov.bd
ac.bd
mil.bd
tv.bd
co.bd
ai.bd
sch.bd
id.bd
it.bd 
info.bd

Number of users this request is being made to serve:
Currently serving approximately 50,000 registered domains under .bd, with continuous growth as BTCL introduces direct second-level registration to encourage local digital presence.

Third-party impact:
This submission is not intended to circumvent any third-party limits. However, the change will ensure proper functionality for:

SSL/TLS certificate issuance (Let’s Encrypt, DigiCert)

Hosting providers (cPanel, Plesk, Cloudflare)

Browser cookie scope handling (Chrome, Firefox, Safari)

Duration of registration:
All listed second-level and third-level zones are registry-controlled and maintained with long-term renewals exceeding 2 years.


Additional Acknowledgements

BTCL confirms:
Responsibility for ongoing maintenance of .bd and its subzones.
Open communication with PSL maintainers via dgm.domain@[btcl.gov.bd](https://btcl.portal.gov.bd/).
Active abuse reporting channel publicly listed on btclportal.gov.bd

Summary

This request aligns .bd with other ccTLDs (such as .uk, .in, .jp) that have transitioned to include second-level domain registrations.
It enhances domain usability, international compatibility, and DNS integrity across Bangladesh’s national domain space.

Submitted by:
Deputy General Manager
Registry Operator – .bd Domain
Bangladesh Telecommunications Company Limited (BTCL)
Email: dgm.domain@btcl.gov.bd, joyeetasen06@gmail.com