### PR TITLE
Add gitbook.io to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13554,7 +13554,7 @@ cdn-edges.net
 gsj.bz
 
 // GitBook Inc. : https://www.gitbook.com/
-// Submitted by Samy Pesse <samy@gitbook.com>
+// Submitted by Samy Pesse <devs@gitbook.com>
 gitbook.io
 
 // GitHub, Inc.


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale. None; this request does not attempt to bypass third-party limits.
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

GitBook is a documentation platform that helps product teams and developers create, review, and publish documentation. We provide both editing and hosting services for documentation, reference guides, api references, and knowledge bases. I am Samy Pesse, CTO of GitBook Inc., and I oversee GitBook’s infrastructure, application architecture, and reliability programs.

**Organization Website:** https://www.gitbook.com/

## Reason for PSL Inclusion

GitBook by default hosts customer workspaces and documentation sites at dedicated subdomains of `gitbook.io`, allowing organizations to publish secure resources without managing their own infrastructure. These subdomains can issue authentication cookies thta must be isolated from other tenants; adding `gitbook.io` will help on that maner. The domain is registered through GitBook Inc. with more than two years remaining on its registration, and we commit to maintaining that buffer and the `_psl` DNS records for the lifetime of the entry. We operate a global CDN and automated certificate provisioning for these subdomains.

**Number of users this request is being made to serve:** GitBook supports hundreds of thousands of active docs and well over millions of end users who access hosted documentation each month.

## DNS Verification

TXT verification has been published for the requested domain and will be updated to reference the final PR number immediately upon submission.

```
$ dig +short TXT _psl.gitbook.io
"https://github.com/publicsuffix/list/pull/XXXX"
```
