### PR TITLE
chore: Add reference link to .ve

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6326,6 +6326,7 @@ net.vc
 org.vc
 
 // ve : https://registro.nic.ve/
+// https://nic.ve/site/user-agreement -> under "III. Clasificación de Nombres de Dominio"
 // Submitted by registry nic@nic.ve and nicve@conatel.gob.ve
 ve
 arts.ve


### PR DESCRIPTION
Added the URL to the comments for '.ve' domains.

https://github.com/publicsuffix/list/pull/2592#issuecomment-3452907928