### PR TITLE
Add Developed Methods LLC to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12785,24 +12785,12 @@ deta.dev
 
 // Developed Methods LLC : https://methods.dev
 // Submitted by Patrick Lorio <security@playit.gg>
-playit.buzz
-playit.cafe
-playit.city
-playit.fan
-playit.game
 *.at.ply.gg
 d6.ply.gg
 joinmc.link
-playit.love
-playit.ooo
-minecraft.party
-terraria.party
 playit.plus
 *.at.playit.plus
 with.playit.plus
-terraria.pro
-playit.pub
-playit.quest
 
 // Dfinity Foundation: https://dfinity.org/
 // Submitted by Dfinity Team <domains@dfinity.org>


### PR DESCRIPTION
# Description of Organization
Developed Methods LLC
[AS400519](https://whois.arin.net/rest/asn/AS400519)
[Org ID: DML-136](https://whois.arin.net/rest/org/DML-136.html)

runs its own network to offer network tunneling services to help people make their self-hosted services public. We're primarily focused on game servers. You can find [our IPs here](https://github.com/playit-cloud/network).

Organization Website: [methods.dev](https://methods.dev).
Product Website: [playit.gg](https://playit.gg).

I am the owner of Developed Methods LLC and am making this request for inclusion in the PSL.

# Reason of this Pull Request
Developed Methods LLC operates https://playit.gg.
* Playit is used by ~45,000 server hosts each week.
* Users are assigned tunnels which interacts with [a program](https://github.com/playit-cloud/playit-agent) running on that user's computer. Client traffic is received at one of our edge servers and "tunneled" based to the user's tunnel to the program running on their computer so they can serve the connection.
* All user tunnels are assigned a random prefix on `*.at.ply.gg`, `*.at.playit.plus`, `with.playit.plus`, and/or `joinmc.link` (suffix depends on service type and network routing). For example:
  * A user might have a Minecraft server assigned the domain `random-name.joinmc.link`
  * A user might have a [FoundryVTT](https://foundryvtt.com/) server assigned the domain `random-name.sea.at.playit.plus` or `random-name.with.playit.plus`.
  * Note: our DNS server determisticlly maps words to IPs on [our network](https://github.com/playit-cloud/network).
* Our paid users are able to create custom subdomains on the other suffixes included in this PR.

Many of our users are beginning to utilize our service for making self-hosted websites public. It would be very helpful if browsers could correctly manage those subdomains (cookies, highlighting the subdomain, sorting by subdomain and not all the domain). We also want these domains to be recognized as a known public suffixes too to avoid abuse on one prefix from affecting many thousands of unrelated users.

## DNS verification via dig

### Checklist for myself
```
DOMAIN             |  expires in 2+ years (5) |  whois guard removed     |
===================|==========================|==========================|
playit.buzz        |  yes                     |  yes                     |
playit.cafe        |  yes                     |  yes                     |
playit.city        |  yes                     |  yes                     |
playit.fan         |  yes                     |  yes                     |
playit.game        |  yes                     |  yes                     |
ply.gg             |  yes (not shown in whois)|  yes (missing email)     |
joinmc.link        |  yes                     |  yes                     |
playit.love        |  yes                     |  yes                     |
playit.ooo         |  yes                     |  yes                     |
minecraft.party    |  yes                     |  yes                     |
terraria.party     |  yes                     |  yes                     |
playit.plus        |  yes                     |  yes                     |
terraria.pro       |  yes                     |  yes (missing email)     |
playit.pub         |  yes                     |  yes                     |
playit.quest       |  yes                     |  yes                     |
```

> Some of the domains are missing my email in the whois record (patrick@methods.dev). I am not sure if this is due to the TLD's practices or a failure on my part. Domains are under email `patrick@methods.dev` and `security@playit.gg` is being used in PSL. If needed I can update whois records to be `security@playit.gg`.

### DNS verification via dig
* [x] DNS verification via dig
```
dig +short -t txt _psl.playit.buzz
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.cafe
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.city
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.fan
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.game
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.sea.at.ply.gg # example *.at.ply.gg
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.at.ply.gg
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.d6.ply.gg
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.joinmc.link
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.love
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.ooo
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.minecraft.party
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.terraria.party
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.plus
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.sea.at.playit.plus # example *.at.playit.plus
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.at.playit.plus
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.with.playit.plus
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.terraria.pro
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.pub
"https://github.com/publicsuffix/list/pull/2641"

dig +short -t txt _psl.playit.quest
"https://github.com/publicsuffix/list/pull/2641"
```

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - We are currently not reaching any third-party limits (that I'm aware of).
 - We have plans to offer dedicated HTTPs tunnels where users can terminate their own TLS connections for their assigned prefix. I could imagine this feature would cause limits to be hit on services like Let's Encrypt without PSL inclusion.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.

 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

 * [x] Abuse contact information (email or web form) is available and easily accessible.
  - We point people to `abuse@playit.gg` for abuse on playit [see footer of playit.gg](https://playit.gg), and at [ply.gg](http://ply.gg), [github.com/playit-cloud/network](https://github.com/playit-cloud/network).
  - We point people to `security@playit.gg` for security issues [see footer of playit.gg](https://playit.gg), and at [github.com/playit-cloud/security-disclosures](https://github.com/playit-cloud/security-disclosures).
  - whois for domains yields `patrick@methods.dev` which is monitored
  - whois on any of our IPs yields our ARIN contact and email `patrick@methods.dev` which is monitored.

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

