### PR TITLE
Remove Netfy Domains from public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14508,10 +14508,6 @@ o365.cloud.nospamproxy.com
 // Submitted by Philippe PITTOLI <security@netlib.re>
 netlib.re
 
-// Netfy Domains : https://netfy.domains
-// Submitted by Suranga Ranasinghe <security@mavicsoft.com>
-netfy.app
-
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>
 netlify.app


### PR DESCRIPTION
Removed entries for Netfy Domains from the public suffix list.

When checking around the list, I see this domain is expired and should be removed from the list.

'https://netfy.app/' cannot access.
'https://expireddomains.com/domain/netfy.domains/' the netfy.domains is expired.