### PR TITLE
Update `.no` section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4511,8 +4511,6 @@ bievat.no
 bievát.no
 bindal.no
 birkenes.no
-bjarkoy.no
-bjarkøy.no
 bjerkreim.no
 bjugn.no
 bodo.no
@@ -4789,7 +4787,6 @@ herøy.møre-og-romsdal.no
 sande.møre-og-romsdal.no
 moskenes.no
 moss.no
-mosvik.no
 muosat.no
 muosát.no
 naamesjevuemie.no


### PR DESCRIPTION
Removed entries for 'bjarkoy.no', 'bjarkøy.no', and 'mosvik.no' from the public suffix list.

- Confirmed by registry `Norid <info@norid.no>`  at `Dato: 03.11.2025`
- Consistent with https://www.norid.no/en/om-domenenavn/regelverk-for-no/ 
- Email cc'd @simon-friedberger and @dnsguru 

---

> Changes to the domain name policy 7 May 2013
> Norid is doing a minor spring cleanup in the domain name policy, effective on 7 May. Among other things, we will add a new domain into the geographical name tree, while a couple of others will be removed because the municipalities they belonged to have merged into new units. These domains will be released and may be registered on the usual first-come, first-served basis.
> 
> Timing
> The revised domain name policy will be in effect starting on 7 May, at 10 AM, Norwegian time. From that point on, the released domains can be registered.
> 
> Appendix A
> Even though numeric domains have no particular association to telephone numbers, telephone numbers used as national emergency numbers or the equivalent are regarded as a special case in which society has a strong interest in avoiding confusion and misuse with the resulting consequences for life and health.
> 
> When numerical domain names launched in 2008, six domains were added to appendix A, and the insitutions responsible had five year deadline to register the following domains:
> 
> 110	
> 112	
> 113	
> 141	
> 1412	
> 02800
> The reservation deadline is now past, all the domains have been registered, and will now be removed from the appendix.
> 
> In June 2009 another two domains were reserved. At the time, it was not decided which insitutions the domains should belong with and because of this, the domains have not been published in the appendix. This has now been decided upon, and the domains will now be added to the appendix:
> 
> 116000 Post- og teletilsynet
> 116123 Mental Helse
> The insitutions responsible must register the domain names by 30 October 2014.
> 
> Mosvik municipality merged with Inderø municipality on 1 January 2012. Bjarkøy municipality merged with Harstad municipality on 1 January 2013. The following geographical second-level domains have no subdomains registered, and will therefore be released to the name pool:
> 
> bjarkoy.no
> bjarkoey.no
> bjarkøy.no
> mosvik.no