### PR TITLE
AWS Submissions to the Public Suffix List - Q4 2025

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12297,7 +12297,7 @@ lambda-url.us-west-2.on.aws
 
 // AWS Transfer Family web apps
 // Submitted by AWS Security <psl-maintainers@amazon.com>
-// Reference: 57a658c4-8899-410c-aa24-5b01e4a178d2
+// Reference: 9265cdd3-f017-42ab-98bb-08bf427d3fc9
 transfer-webapp.af-south-1.on.aws
 transfer-webapp.ap-east-1.on.aws
 transfer-webapp.ap-northeast-1.on.aws
@@ -12310,6 +12310,7 @@ transfer-webapp.ap-southeast-2.on.aws
 transfer-webapp.ap-southeast-3.on.aws
 transfer-webapp.ap-southeast-4.on.aws
 transfer-webapp.ap-southeast-5.on.aws
+transfer-webapp.ap-southeast-7.on.aws
 transfer-webapp.ca-central-1.on.aws
 transfer-webapp.ca-west-1.on.aws
 transfer-webapp.eu-central-1.on.aws
@@ -12323,6 +12324,7 @@ transfer-webapp.eu-west-3.on.aws
 transfer-webapp.il-central-1.on.aws
 transfer-webapp.me-central-1.on.aws
 transfer-webapp.me-south-1.on.aws
+transfer-webapp.mx-central-1.on.aws
 transfer-webapp.sa-east-1.on.aws
 transfer-webapp.us-east-1.on.aws
 transfer-webapp.us-east-2.on.aws


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.


### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example) 
 _AWS does not submit suffixes to the Public Suffix List to work around rate-limits of any third-party products or tooling._

 * [X] This request was _not_ submitted with the objective of working around other third-party limits
 _Please see the Reason section below for objectives in this pull request._

* [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms

* [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

 * [X] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [X] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  [Report Abusive Activity from Amazon Web Services Resources](https://support.aws.amazon.com/#/contacts/report-abuse)
   
---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies etc. and the rollback timing, etc is acceptable. *Proceed*.

---

Description of Organization
====

Amazon Web Services (AWS) is the world’s most comprehensive and broadly adopted cloud, offering over 200 fully featured services from data centers globally. 
More information about AWS is available on our website:
[What is AWS?](https://aws.amazon.com/what-is-aws/)

**Organization Website:** 
[AWS Homepage](https://aws.amazon.com)

Reason for PSL Inclusion
====

These features/services have been identified by AWS Security and AWS service
teams as supporting different distinct customers/resources across shared
DNS suffixes. Adding these suffixes to the PSL is expected to improve the
security posture of customers using our services. This may include:

- impact to the Same-Origin Policy in modern browsers (cookies + others)
- representation of these domains to the CA/Browser Forum
- any other use-cases of the PSL which may benefit from updated information about multi-tenant AWS services

**Number of users this request is being made to serve:**

These changes are expected to impact all customers using these AWS services.
This includes both AWS-internal and external customers. Specific user counts
for these listed features/services are not publicly available.

Services/Features in PR:
====

- Amazon Cognito
- Amazon S3
- AWS Transfer Family web apps

DNS Verification via dig
=======
<details>
<summary>DNS query results</summary>

```
auth.cognito-idp.eusc-de-east-1.on.amazonwebservices.eu: dig +short -t TXT _psl.auth.cognito-idp.eusc-de-east-1.on.amazonwebservices.eu
"https://github.com/publicsuffix/list/pull/2656"



s3-website.dualstack.us-gov-east-1.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.us-gov-east-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/2656"



s3-website.dualstack.us-gov-west-1.amazonaws.com: dig +short -t TXT _psl.s3-website.dualstack.us-gov-west-1.amazonaws.com
"https://github.com/publicsuffix/list/pull/2656"



transfer-webapp.ap-southeast-7.on.aws: dig +short -t TXT _psl.transfer-webapp.ap-southeast-7.on.aws
"https://github.com/publicsuffix/list/pull/2656"



transfer-webapp.mx-central-1.on.aws: dig +short -t TXT _psl.transfer-webapp.mx-central-1.on.aws
"https://github.com/publicsuffix/list/pull/2656"
```

</details>