### PR TITLE
Add Emergent domains (*.emergent.cloud )

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13283,7 +13283,6 @@ elementor.cool
 // Emergent : https://emergent.sh
 // Submitted by Tilakraj Desai <tilakraj@emergent.sh>
 *.emergent.cloud
-*.emergent.host
 
 // En root‽ : https://en-root.org
 // Submitted by Emmanuel Raviart <emmanuel@raviart.com>


### PR DESCRIPTION
## Summary
Add wildcard entries for Emergent platform domains to the Public Suffix List.

## Domains
- `*.emergent.cloud`


## Rationale
Emergent operates a cloud platform where we create unique subdomains for each of our users' applications. Each user application receives its own subdomain in the format `<app>.emergent.cloud` .

These wildcard entries are required for domain security isolation between different user applications. Without PSL entries:
- Cookies set on `*.emergent.cloud` could be shared across all user applications
- One user's application could potentially access session data from another user's application
- Cross-site security boundaries between different user environments would be compromised

Adding these wildcards ensures that each user application subdomain (`app1.emergent.cloud`, `app2.emergent.cloud`, etc.) is treated as a separate registrable domain, providing proper security isolation.

## Validation
- Domains are owned by Emergent
- DNS TXT records will be set:
  - `_psl.emergent.cloud` TXT "https://github.com/publicsuffix/list/pull/2659"
- Entries follow PSL formatting guidelines
- Alphabetically sorted in PRIVATE DOMAINS section

## Contact
Submitted by tilakraj-emergent <tilakraj@emergent.cloud>