### PR TITLE
remove `wdh.app` and `hrsn.au`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16013,8 +16013,6 @@ wmflabs.org
 
 // William Harrison : https://wharrison.com.au
 // Submitted by William Harrison <security@hrsn.net>
-wdh.app
-hrsn.au
 vps.hrsn.au
 hrsn.dev
 is-a.dev


### PR DESCRIPTION
* `wdh.app` is no longer used as all services have been migrated across to use `hrsn.dev` which is already on the PSL.
* `hrsn.au` was originally added to be used for client websites, however it has not ended up being used very much for that purpose, so I am removing it. `vps.hrsn.au` is still required however as per the original reasoning.

I am the owner and last modifier of this section. Both corresponding _psl TXT records have been removed, to show they are no needed in the PSL. All other _psl TXT records of other domains in this section have been kept as is.