### PR TITLE
Brave Submissions to the Public Suffix List - Q4 2025

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12497,6 +12497,8 @@ square7.net
 // Submitted by Andrea Brancaleoni <abrancaleoni@brave.com>
 brave.app
 *.s.brave.app
+brave.dev
+*.s.brave.dev
 brave.io
 *.s.brave.io
 


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

**Previous submission**: https://github.com/publicsuffix/list/pull/2375

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)
 - MAKE SURE UPDATE THE FOLLOWING LIST WITH YOUR LIMITATIONS! REMOVE ENTRIES WHICH DO NOT APPLY AS WELL AS REMOVING THIS LINE!

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://brave.com/.well-known/security.txt

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

**Organization Website:** https://brave.com

**Submitter:** Andrea Brancaleoni

**Role:** Security Engineer at Brave Software

Brave Software is a technology company that focuses on enhancing the privacy and security of web users. Brave's primary product is the Brave browser available at https://brave.com. Besides the browser, Brave also includes an independent Search engine available at https://search.brave.com.

I manage security and operations, ensuring our organizational practices align with our core mission of providing enhanced online privacy and security.

## Reason for PSL Inclusion

**Number of users this request is being made to serve:** 100+ Million of users (current)

This is a continuation of our previous submission for `brave.io`, and `brave.app` domains, as we expand our infrastructure to include `brave.dev` and its subdomains.

We believe that the inclusion of our domain(s) in the PSL is of utmost importance for several significant reasons:

1. **Cookie Security**: Having our domain(s) on the PSL will ensure that each subdomain is treated separately, minimizing potential security risks. We plan, in particular, to store any user-generated content in its eTLD+1 (img-proxies - e.g. `img-proxy.search.s.brave.dev`, s3 proxied buckets- e.g. `userimages.creators.s.brave.dev`)

2. **Third-party Integrations**: Our platform frequently integrates with various services, proxying services to preserve users' privacy. Inclusion in the PSL would simplify the process while maintaining a high standard of transparency when hosted on brave domains.

3. **Migration Strategy**: As part of our long-term domain strategy and in light of the uncertain future of the `.io` TLD (https://every.to/p/the-disappearance-of-an-internet-domain), we are expanding our use of `.dev` domains alongside our existing `.app` domains for critical infrastructure and services.

All our private section domain names adhere to a long-term registration policy, with current registration terms extending beyond 2 years. We pledge to maintain a registration term of more than one year at all times to ensure our continued presence on the PSL.

The `brave.dev` domain is registered with a multi-year term and will be maintained in accordance with PSL requirements.

## DNS Verification

```
dig +short TXT _psl.brave.dev
"https://github.com/publicsuffix/list/pull/2668"

dig +short TXT _psl.s.brave.dev
"https://github.com/publicsuffix/list/pull/2668"
```
