### PR TITLE
ADD int.yt to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14121,6 +14121,10 @@ iserv.host
 // Submitted by Ispmanager infrastructure team <infrastructure@ispmanager.com>
 ispmanager.name
 
+// Intent : https://int.yt/
+// Submitted by James Woods admin@int.yt
+int.yt
+
 // Jelastic, Inc. : https://jelastic.com/
 // Submitted by Ihor Kolodyuk <ik@jelastic.com>
 mel.cloudlets.com.au


### PR DESCRIPTION
---

# **Public Suffix List (PSL) Submission — int.yt (UPDATED)**

### Checklist of required steps

* [x] Description of Organization

* [x] Robust Reason for PSL Inclusion

* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] We are listing any third-party limits that we seek to work around in our rationale.
  (No third-party rate limits apply to this request.)

* [x] This request was **not** submitted with the objective of working around third-party limits.

* [x] We acknowledge responsibility to maintain the domain in good standing, keep the `_psl` TXT record active, maintain contact email addresses, and update/remove entries as needed. Failure to maintain these may result in removal.

* [x] The Guidelines were carefully read and understood.

* [x] The submission follows the formatting and sorting rules.

* [x] A role-based email address is used and monitored within 30 days:
  **[[admin@int.yt](mailto:admin@int.yt)](mailto:admin@int.yt)**, **[[abuse@int.yt](mailto:abuse@int.yt)](mailto:abuse@int.yt)**

---

# **Abuse Contact**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact is available:
**[https://int.yt/abuse.html](https://int.yt/abuse.html)**

---

# **Description of Organization**

Intent FreeDomain operates a free DNS and subdomain hosting service under the domain **int.yt**. Our service allows users to create and manage personal subdomains such as `user1.int.yt` for testing, small projects, learning, prototyping, and other non-commercial uses. We provide DNS management, automatic abuse controls, and HTTPS support.

The organization focuses on lightweight, privacy-respecting domain hosting with strict anti-spam and anti-fraud controls. To prevent abuse, our backend uses IP-based detection, multi-account filtering, and automated account banning to ensure safe operation of the service.

The submitter represents the administrative operator of the **int.yt** domain and is responsible for DNS, backend systems, user authentication, and abuse handling procedures.

**Organization Website:**
[https://int.yt/](https://int.yt/)

---

# **Reason for PSL Inclusion**

The **int.yt** domain serves as the parent namespace for user-controlled subdomains. Each subdomain is owned by a different user, and they are intended to behave as separate, isolated registrable entities. Without inclusion in the Public Suffix List, browsers may mis-treat `*.int.yt` as a single domain, which can:

* incorrectly group unrelated users under the same eTLD+1,
* cause cross-subdomain cookie leakage,
* break session isolation,
* cause security boundary issues,
* impact certificate scoping or SameSite/cookie policies.

PSL inclusion ensures proper behavior in browsers, security libraries, certificate tooling, and other eTLD-aware systems. We confirm that **int.yt** has more than two years remaining on registration and the `_psl` TXT record will be maintained permanently.

No third-party rate limits are being bypassed. This request exists solely to ensure correct cookie, isolation, and security behavior for all user-controlled subdomains.

---

# **Number of users this request is being made to serve**

* **Existing users:** ~10
* **Expected users:** ~10,000 (projection based on planned service scaling)

---

# **DNS Verification**

After this PR is created, we will publish the following TXT record:

```
_psl.int.yt   TXT   "https://github.com/publicsuffix/list/pull/XXXX"
```

(XXXX will be updated with the actual PR number once known.)
This record will remain in place for as long as the domain remains listed.

---

# **Additional Verification URLs**

* Homepage: [https://int.yt/](https://int.yt/)
* About: [https://int.yt/about.html](https://int.yt/about.html)
* Contact: [https://int.yt/contact.html](https://int.yt/contact.html)
* Terms: [https://int.yt/terms.html](https://int.yt/terms.html)
* Abuse: [https://int.yt/abuse.html](https://int.yt/abuse.html)
* Support: [https://int.yt/support.html](https://int.yt/support.html)

Role-based emails:
**[[admin@int.yt](mailto:admin@int.yt)](mailto:admin@int.yt)**
**[[abuse@int.yt](mailto:abuse@int.yt)](mailto:abuse@int.yt)**

---

# **Rollback & Propagation Understanding**

* [x] Yes, I understand.
  Adding `int.yt` to the PSL will change cookie, certificate, and browser behavior.
  Rollback delays are acceptable. Proceed anyway.

---

# **End of Submission**

---