### PR TITLE
Add `*.auiusercontent.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11329,6 +11329,10 @@ adobeioruntime.net
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 africa.com
 
+// AgentbaseAI Inc. : https://assistant-ui.com
+// Submitted by Simon Farshid <security@assistant-ui.com>
+*.auiusercontent.com
+
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
   - None

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://auiusercontent.com (abuse@auiusercontent.com)

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

AgentbaseAI Inc. (operating as assistant-ui) is a Y Combinator W25 company that builds open-source React/TypeScript components for AI chat interfaces. Our SDK enables developers to embed ChatGPT-style chat UIs in their applications. The SDK has over 500,000 monthly [npm downloads](https://www.npmjs.com/package/@assistant-ui/react), is used by over 2k [GitHub repositories](https://github.com/assistant-ui/assistant-ui/network/dependents), including several large enterprises.

We are not building AI apps ourselves—we provide the infrastructure that enables other developers to build AI-powered applications. Our SDK allows these developers to integrate third-party app ecosystems like MCP Apps and OpenAI Apps SDK into their chat interfaces.

This PSL submission is for `auiusercontent.com`, a domain we operate as a public utility service for secure rendering of untrusted web content. This domain is intentionally separate from our primary domain (`assistant-ui.com`) and is used exclusively for sandboxed iframe content serving.

I am Simon Farshid, CEO and founder of AgentbaseAI Inc. and core maintainer of assistant-ui.

**Organization Website:** https://assistant-ui.com

---

## Reason for PSL Inclusion

Our SDK enables developers to integrate [MCP Apps](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx) and [OpenAI Apps SDK](https://platform.openai.com/docs/apps) applications into their chat interfaces. These app ecosystems allow third parties to create interactive widgets that render inside a chat conversation. The apps provide HTML/JavaScript payloads that must be displayed in iframes, but the content comes from untrusted third parties and requires strong browser-enforced isolation.

### Why a PSL Entry is Required

We are implementing an open-source version of Google's [SafeContentFrame](https://bughunters.google.com/blog/6715529872080896/beyond-sandbox-domains-rendering-untrusted-web-content-with-safecontentframe) pattern. The linked blog post explains in detail why a PSL entry is necessary for this security architecture. In summary, a PSL entry enables browser-enforced isolation for:

1. **Storage partitioning** — Each piece of untrusted content receives an isolated storage context, preventing cross-app data leakage
2. **Cookie isolation** — Cookies set by one app cannot be read by another app
3. **Process isolation** — Browsers like Chrome use PSL entries for Site Isolation decisions

### Why Alternatives Don't Work

We initially used sandbox iframes with opaque origins (`sandbox="allow-scripts"`), but this breaks essential web platform features that apps legitimately need:

- **CORS fails** — Opaque origins cannot make credentialed cross-origin requests
- **Cookies don't work** — `document.cookie` is inaccessible
- **Storage APIs are restricted** — localStorage/sessionStorage throw errors
- **OAuth flows break** — Popup-based authentication requires a real origin

Third-party apps legitimately need these capabilities to function. For example, an app might fetch data from an external API with user credentials, or implement an OAuth login flow.

We want compatibility with apps written for OpenAI's Apps SDK. OpenAI employs a similar mechanism on the `*.oaiusercontent.com` PSL entry. We would not be able to support all OpenAI Apps SDK apps with an opaque origin iframe.

### Why Wildcard Entry (`*.auiusercontent.com`)

We are registering `*.auiusercontent.com` rather than a single domain to allow customer-specific eTLDs (e.g. *.scf-app1.auiusercontent.com`.

### Precedent

This usage pattern is established by major platforms:

- **Google** uses `*.usercontent.goog` for SafeContentFrame (the architecture we are implementing)
- **OpenAI** uses `*.oaiusercontent.com` for rendering Apps SDK content

Both entries exist in the PSL today and are used for the same technical reasons we describe here.

### Alternatives We Evaluated

| Approach | Why It Doesn't Work |
|----------|---------------------|
| Opaque origin sandbox | Breaks CORS, cookies, storage APIs |
| Single subdomain | No isolation between apps |
| data: URLs | No network access, no cookies |
| blob: URLs | Inherits parent origin (no isolation) |
| Service workers | Cannot intercept cross-origin requests |

### A Note on Standards

We acknowledge that PSL is not the ideal long-term solution for this problem. A dedicated browser API or HTTP header for declaring "this domain hosts mutually-untrusting content" would be preferable. We employ iframe sandboxing, CSP and other HTTP headers to approximate this today but these do not yet come close to the security provided via a PSL entry. We are investigating contributing to standards work that would eliminate the need for PSL entries in this use case. However, our developers integrating MCP Apps and OpenAI Apps SDK need this capability today.

### Public Utility

We are hosting our SafeContentFrame implementation at `*.scf.auiusercontent.com` as a free, unauthenticated public utility service. It is available to any developer—not just assistant-ui customers—who needs to securely render untrusted HTML content.

**Demo:** https://assistant-ui.com/safe-content-frame

### Registration & Commitment

We have been in business for 1.5 years. The domain `auiusercontent.com` was registered on 2025-11-26 with expiration on 2028-11-26, satisfying the 2+ year registration requirement. We commit to maintaining registration in good standing and keeping the `_psl` TXT record in place.

### Scale

- **Estimated developers:** 10,000+
- **Estimated end-users:** 1M+ weekly active users across applications built with our SDK
- **Growth:** We expect adoption to grow as MCP Apps and OpenAI Apps SDK ecosystems mature

---

## DNS Verification

```
dig +short TXT _psl.auiusercontent.com
"https://github.com/publicsuffix/list/pull/2676"
```