### PR TITLE
Add: ccwu.cc, cc.cd,us.ci, and update DNSHE entry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12917,8 +12917,8 @@ jozi.biz
 // Submitted by DNSHE Team <support@dnshe.com>
 ccwu.cc
 cc.cd
-de5.net
 us.ci
+de5.net
 
 // DNShome : https://www.dnshome.de/
 // Submitted by Norbert Auler <mail@dnshome.de>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

### Checklist of required steps

* [x] Description of Organization  
* [x] Robust Reason for PSL Inclusion  
* [x] DNS verification via dig  
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).  
### Submitter affirms the following:
* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
* [x] This request was _not_ submitted with the objective of working around other third-party limits.  
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.  
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.  
* [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.  
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.  
* [x] Abuse contact information (email or web form) is available and easily accessible.  
- Abuse Email: [abuse@dnshe.com](mailto:abuse@dnshe.com)  
  URL where abuse contact or abuse reporting form can be found:  
  https://www.dnshe.com/domainabuse/index.html  

---
  For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [x] Yes, I understand. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. Proceed anyways.

---

## Description of Organization

**DNSHE** provides a free public subdomain service for developers, small projects, and hobby use through the domains it operates, such as **ccwu.cc** and **cc.cd，us.ci**.
Users can apply for and manage subdomains, while DNSHE maintains control of the root DNS zone for all applicable domains, abuse handling, and technical operations.

- Organization Website: [https://www.dnshe.com](https://www.dnshe.com)  
- Support Email: [support@dnshe.com](mailto:support@dnshe.com)  
- Abuse Report Page: [https://www.dnshe.com/domainabuse/index.html](https://www.dnshe.com/domainabuse/index.html)
DNSHE maintains the DNS infrastructure for cc.cd, ccwu.cc, and us.ci and ensures continuous service availability, security, and responsiveness to abuse reports.

---

## Reason for PSL Inclusion

This pull request adds **ccwu.cc,cc.cd** and **us.ci**, which are publicly available subdomain registries operated by **DNSHE**.

The inclusion is required to ensure proper browser behavior, cookie isolation, and security separation between independently managed subdomains.
Since users can register subdomains freely, each subdomain must be treated as a separate site at the browser level.

This request is **not intended** to bypass Cloudflare, Let's Encrypt rate limits, or any third-party restrictions.
DNSHE operates its own authoritative DNS infrastructure and does not rely on Cloudflare or external CDNs.

- Active subdomains: Growing daily across ccwu.cc, cc.cd, and us.ci.
Public SSL certificates can be verified at:
[https://crt.sh/?q=ccwu.cc](https://crt.sh/?q=ccwu.cc)
[https://crt.sh/?q=cc.cd](https://crt.sh/?q=cc.cd)
[https://crt.sh/?q=us.ci](https://crt.sh/?q=us.ci)
Domain registration is valid for more than **2 years** and renews automatically

DNSHE commits to maintaining this PSL entry, keeping the `_psl` TXT record active, and ensuring that contact details remain valid and monitored.



## Number of Users

Active subdomains: **1000+**, increasing daily.  
Each subdomain represents an independent project or user-managed deployment.

---

## DNS Verification
```shell
dig +short TXT _psl.ccwu.cc
"https://github.com/publicsuffix/list/pull/2677"
dig +short TXT _psl.cc.cd
"https://github.com/publicsuffix/list/pull/2677"
dig +short TXT _psl.us.ci
"https://github.com/publicsuffix/list/pull/2677"
