### PR TITLE
Remove lk3.ru (#1149)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14981,10 +14981,6 @@ srv.us
 gh.srv.us
 gl.srv.us
 
-// PE Ulyanov Kirill Sergeevich : https://airy.host
-// Submitted by Kirill Ulyanov <k.ulyanov@airy.host>
-lk3.ru
-
 // Peplink | Pepwave : http://peplink.com/
 // Submitted by Steve Leung <steveleung@peplink.com>
 mypep.link


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] DNS verification via dig

Hello!

Due to the termination of work on the project and, taking into account the theoretical point of view, the inappropriateness of the domain on the list, I ask that information about my domains and me be removed from the list.

A TXT record for this PR has been added to the domain zone:

```
% dig _pls.lk3.ru TXT +short @8.8.8.8
"https://github.com/publicsuffix/list/pull/2682"
```