### PR TITLE
Add frp.gs to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13608,6 +13608,10 @@ freemyip.com
 // Submitted by Victor Pupynin <hallo@frusky.de>
 *.frusky.de
 
+// frp.gs : https://www.frp.gs
+// Submitted by SAID BESADA TSUMA <admin@frp.gs>
+frp.gs
+
 // FunkFeuer - Verein zur Förderung freier Netze : https://www.funkfeuer.at
 // Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
 wien.funkfeuer.at


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)

 * [ ] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://www.frp.gs

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

I am the individual registry operator for **frp.gs**. 
**frp.gs** is a public subdomain registry service designed for developers, open-source projects, and homelab enthusiasts. The service provides free, permanent subdomains (e.g., `*.frp.gs`) to the community, allowing users to expose their services or host static sites. As the operator, I manage the infrastructure, DNS resolution, and abuse handling to ensure a safe environment for all tenants.

**Organization Website:**
https://www.frp.gs

## Reason for PSL Inclusion

We are requesting inclusion in the PRIVATE section of the Public Suffix List for the following critical security and architectural reasons:

1.  **Cookie Isolation (Security):** Since `*.frp.gs` subdomains are controlled by different, mutually untrusted users, it is vital to prevent one user (e.g., `attacker.frp.gs`) from reading or setting cookies for another user (e.g., `victim.frp.gs`) or the parent domain. PSL inclusion establishes the necessary security boundary.
2.  **Site Isolation:** Modern browsers use the PSL to determine trust boundaries for features like cross-origin resource sharing and process isolation.
3.  **Cloudflare Integration:** Many of our users wish to use Cloudflare for their subdomains. Without PSL inclusion, Cloudflare treats `frp.gs` as the atomic entity, preventing users from adding their specific subdomains (e.g., `project.frp.gs`) to their own Cloudflare accounts as distinct zones.

I confirm that the domain `frp.gs` has more than 2 years of registration remaining and I am committed to maintaining it long-term.

**Number of users this request is being made to serve:**
Estimated 100+ initial users (Service is newly launched and open for public registration).

## DNS Verification



```
dig +short TXT _psl.frp.gs "https://github.com/publicsuffix/list/pull/2685"
```