### PR TITLE
Added work.gd

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16163,5 +16163,7 @@ zone.id
 // ZoneABC : https://zoneabc.net
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
+// Submited by NV Store team <nvstore74@gmail.com>
+work.gd
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Title:

Add work.gd to the Public Suffix List

Description:

I am requesting that work.gd be added to the Public Suffix List.

Reason for inclusion:
The domain work.gd is used as a base domain for creating user-generated subdomains (e.g., username.work.gd). For security and isolation of user data (cookies, storage, etc.), services relying on the PSL need to recognize work.gd as a public suffix.

Adding work.gd ensures consistent behavior across browsers, hosting platforms (e.g., Vercel), and other PSL-dependent software.

Verification:
I am the owner/operator of the work.gd domain and can confirm it functions as a multi-tenant root domain where users or applications generate subdomains.

No conflicting entries exist for .gd or related subdomains in the PSL.

Checklist:

 I have reviewed the PSL submission guidelines

 The domain hosts user-created subdomains

 The change contains only one domain entry

 The change is alphabetically sorted