### PR TITLE
Remove onavstack.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12404,10 +12404,6 @@ translated.page
 myfritz.link
 myfritz.net
 
-// AVStack Pte. Ltd. : https://avstack.io
-// Submitted by Jasper Hugo <jasper@avstack.io>
-onavstack.net
-
 // AW AdvisorWebsites.com Software Inc : https://advisorwebsites.com
 // Submitted by James Kennedy <domains@advisorwebsites.com>
 *.awdev.ca


### PR DESCRIPTION
Removed entries related to AVStack Pte. Ltd. from the public suffix list.

- added by #1299 merged on May 26, 2021
- onavstack.net **expired in August 2025**
- Organization Website: https://avstack.io defunct
- re-registered on `Creation Date: 2025-10-28T12:16:50Z`

```
   Domain Name: ONAVSTACK.NET
   Registry Domain ID: 3033500682_DOMAIN_NET-VRSN
   Registrar WHOIS Server: whois.porkbun.com
   Registrar URL: http://porkbun.com
   Updated Date: 2025-10-28T14:11:59Z
   Creation Date: 2025-10-28T12:16:50Z
   Registry Expiry Date: 2026-10-28T12:16:50Z
```

- email sent to jasper@avstack.io on 2025-12-09 pending response