### PR TITLE
Remove TwoDNS entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15851,22 +15851,6 @@ tunnelmole.net
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
 tuxfamily.org
 
-// TwoDNS : https://www.twodns.de/
-// Submitted by TwoDNS-Support <support@two-dns.de>
-dd-dns.de
-dray-dns.de
-draydns.de
-dyn-vpn.de
-dynvpn.de
-mein-vigor.de
-my-vigor.de
-my-wan.de
-syno-ds.de
-synology-diskstation.de
-synology-ds.de
-diskstation.eu
-diskstation.org
-
 // Typedream : https://typedream.com
 // Submitted by Putri Karunia <putri@typedream.com>
 typedream.app


### PR DESCRIPTION
Removed entries related to TwoDNS from the public suffix list.

- added by https://github.com/publicsuffix/list/pull/328
- all domains not resolving
- service discontinued on December 20, 2024 as per https://www.twodns.de/
- email sent on 2025-12-09 TwoDNS-Support <support@two-dns.de> pending reply

---

> ### TwoDNS will be discontinued on December 20, 2024!
> 
> #### 29 Nov 09:26
> 
> November 2024 - Dear Users and Customers,  
> we would like to inform you that our dynamic DNS service “TwoDNS” will be discontinued as of **December 20, 2024**. TwoDNS has always been a free service. However, due to new guidelines and an increase in abuse attempts, operating the service is no longer cost-effective. This decision was made after careful consideration and was not an easy one for us.
> 
> Important details about the discontinuation:
> 
> Discontinuation of the service: From **December 20, 2024**, updates for dynamic IP addresses will no longer be supported. Existing DNS records will be deleted and will no longer be resolvable.
> 
> Access and administration: From the date mentioned, access to the TwoDNS administration portal will be blocked.
> 
> Alternative solutions: We recommend that you start looking for a replacement service in good time to avoid any possible interruptions to your DNS supply. If you are a DrayTek device user, we recommend DrayDDNS.
> 
> What should you do?
> 
> 1) Find an alternative dynamic DNS service provider, such as DrayDDNS.  
> 2) Update your DNS settings with your new provider.  
> 3) Notify all parties involved of the change to avoid communication failures.
> 
> For further information or assistance, our support team will be happy to help until **December 20, 2024**.
> 
> We are currently examining whether and how the service could continue to be operated with a payment model. If you are interested in continuing to use TwoDNS with a payment model, please send us an email to **[pay@two-dns.de](mailto:pay@two-dns.de)** with the subject line: interested.
> 
> If you are interested in continuing to operate the service or taking over domains, please send us an email with your request and contact details to **[support@two-dns.de](mailto:support@two-dns.de)**.
> 
> We thank you for your trust in TwoDNS and apologize for any inconvenience this change may cause.
> 
> Best regards,  
> Your TwoDNS team