### PR TITLE
Remove en-root.fr

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13301,10 +13301,6 @@ emergent.cloud
 preview.emergentagent.com
 emergent.host
 
-// En root‽ : https://en-root.org
-// Submitted by Emmanuel Raviart <emmanuel@raviart.com>
-en-root.fr
-
 // Enalean SAS : https://www.enalean.com
 // Submitted by Enalean Security Team <security@enalean.com>
 mytuleap.com


### PR DESCRIPTION
Removed comments and the domain 'en-root.fr' from the public suffix list.

- Organization Website: https://en-root.org/ defunct
- en-root.fr domain expired 2025-10-30, clientHold
- registry deletion on 2025-11-27
- confirmation email sent 2025-12-09
- Confirmed https://github.com/publicsuffix/list/pull/910#issuecomment-3636240437

```
domain:                        en-root.fr
status:                        REDEMPTION
pending:                       DELETE
eppstatus:                     clientRenewProhibited
eppstatus:                     clientHold
eppstatus:                     inactive
eppstatus:                     pendingDelete
hold:                          YES
holder-c:                      ANO00-FRNIC
admin-c:                       O95-FRNIC
tech-c:                        TCP8-FRNIC
registrar:                     SCALEWAY
Expiry Date:                   2025-10-30T20:19:52Z
created:                       2019-10-30T20:19:52Z
last-update:                   2025-11-27T05:02:46.208818Z
deleted:                       2025-11-27T05:02:46.208818Z
source:                        FRNIC
```