### PR TITLE
Remove skygearapp.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14930,6 +14930,11 @@ tech.orange
 // https://nic.can.re
 can.re
 
+// Oursky Limited : https://authgear.com/
+// Submitted by Authgear Team <hello@authgear.com> & Skygear Developer <hello@skygear.io>
+authgear-staging.com
+authgearapps.com
+
 // OutSystems
 // Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
 outsystemscloud.com


### PR DESCRIPTION
Removed skygearapp.com

- added on on Dec 5, 2019 by #892 
- expired `Registry Expiry Date: 2025-08-12T04:06:15Z`
- deleted from .com zone file 2025-09-23
- re-registered on 2025-10-31T01:59:52Z
- email sent 2025-09-23 no response
- re-registered by someone 2025-10-31

```
   Domain Name: SKYGEARAPP.COM
   Registry Domain ID: 3034347710_DOMAIN_COM-VRSN
   Registrar WHOIS Server: whois.spaceship.com
   Registrar URL: http://www.spaceship.com
   Updated Date: 2025-10-31T01:59:53Z
   Creation Date: 2025-10-31T01:59:52Z
   Registry Expiry Date: 2026-10-31T01:59:52Z
```