### PR TITLE
Remove Authentick UG entry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12395,10 +12395,6 @@ myasustor.com
 // Submitted by Sam Smyth <devloop@atlassian.com>
 cdn.prod.atlassian-dev.net
 
-// Authentick UG (haftungsbeschränkt) : https://authentick.net
-// Submitted by Lukas Reschke <lukas@authentick.net>
-translated.page
-
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.link


### PR DESCRIPTION
Removed Authentick UG entry from the public suffix list.

- added on Nov 23, 2021 by https://github.com/publicsuffix/list/pull/1478
- defunct organization Website: https://dilingual.com/
- translated.page expired 2025-11-13
- translated.page clientHold
- NXDOMAIN error since 2025-11-13
- confirmation email sent 2025-12-09 pending reply
