### PR TITLE
Remove perso.sn (may not associated w respective registry)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5685,7 +5685,6 @@ com.sn
 edu.sn
 gouv.sn
 org.sn
-perso.sn
 univ.sn
 
 // so : http://sonic.so/policies/


### PR DESCRIPTION
Remove perso.sn from the ICANN section

Based on my recent research, the nameservers **a.name-servers.ch**, **b.name-servers.ch**, **c.name-servers.ch**, and **d.name-servers.ch** frequently appear among newly registered domains that masquerade as official suffixes. 

Examples include **mil.gg, ac.mr, mil.je, or.uy, or.pa, ac.nf**, etc. 

* **mil.gg**  imitates a military-related suffix (“mil”) to appear authoritative
* **ac.mr**  imitates an academic or educational suffix (“ac”)
* **mil.je**  again leverages the “mil” designation to suggest military legitimacy
* **or.uy**  imitates an organizational suffix (“or” / “org”)
* **or.pa**  imitates an organizational suffix (“or” / “org”)

These "fake suffixes" are often classified (https://radar.cloudflare.com/domains/domain/mil.gg) by Cloudflare Radar or VitusTotal under multiple abuse categories, including **CIPA Filter**, **Command and Control**, **Botnet**, **Malware**, and **Phishing**.

The suffix **perso.sn** in this PR follows the same abuse pattern, using the **c.name-servers.ch** and **d.name-servers.ch** nameservers. It is listed in a 2008 registry document ([https://nicsenegal.sn/wp-content/uploads/2023/12/charte_nommage.pdf](https://nicsenegal.sn/wp-content/uploads/2023/12/charte_nommage.pdf)), but the registry appears to have let it expire, after which it was picked up by abusers. This case may warrant higher priority, as some security vendors and firewalls (https://github.com/publicsuffix/publicsuffix.org/pull/58) rely on the PSL, and I see no harm in removing it. 

I have reached out to the registry but have not received any response.

---

Reasons for removal:

- **Not registry-controlled**: Registered by individual registrant (Chris BUTDORF, US-based) through commercial registrar NETIM, not by .sn registry
- **Evidence of abuse**: Google search (`site:perso.sn`) reveals numerous spammy websites with random string prefixes
- **Suspected SEO spam**: High volume of suspicious subdomains appearing to exploit PSL inclusion for search engine manipulation
- **No SSL/security**: None of the surveyed subdomains implement HTTPS
- **Nameserver inconsistency**: Uses `ns1-nonameservers.netim.net` and `ns2-nonameservers.netim.net`, inconsistent with other .sn ICANN section entries; recently changed to `c.name-servers.ch` and `d.name-servers.ch`
- **Registration**: Domain created 2025-02-03, expires 2026-02-03

Status:

- Email sent to .sn registry to confirm this domain should not be in PSL, pending reply

Comparable case studies of PSL exploitation:

- #2198
- #2203
- #2200
- #2311


## WHOIS data

```
============================================================================
Whois du Registre .SN
Les informations fournies par ce service ne sont qu'à titre informatif.

Les données collectées via le formulaire d'enregistrement sont traitées exclusivement à des fins liées au traitement des domaines conformément à la RFC 3912 par le NIC Sénégal.

En application des dispositions de la loi n°2008-12 du 25 janvier 2008 portant sur la protection des données à caractère personnel, vous pouvez exercer vos droits d'accès, d'opposition, de rectification et de suppression auprès du NIC Sénégal - abuse(at)nic.sn.
============================================================================

Domain ID:                     DOM5501614-SN
Nom de domaine:                perso.sn
Date de création:              2025-02-03T00:49:22.942025Z
Dernière modification:         2025-08-31T14:02:56.681745Z
Date d'expiration:             2026-02-03T00:49:22.87333Z
Registrar:                     NETIM
Statut:                        actif

[HOLDER]
ID Contact:                    CTC5247
Type:                          Organisation
Nom:                           Chris BUTDORF
Adresse:                       32790 Titus Hill Ln
Code postal:                   44012
Ville:                         AVON LAKE
Pays:                          US
Téléphone:                     +1.8889252638
Courriel:                      cjb@cjbmanagement.com

[ADMIN_C]
ID Contact:                    CTC5248
Type:                          Organisation
Nom:                           Chris BUTDORF
Adresse:                       32790 Titus Hill Ln
Code postal:                   44012
Ville:                         AVON LAKE
Pays:                          US
Téléphone:                     +1.8889252638
Courriel:                      cjb@cjbmanagement.com

[TECH_C]
ID Contact:                    CTC5248
Type:                          Organisation
Nom:                           Chris BUTDORF
Adresse:                       32790 Titus Hill Ln
Code postal:                   44012
Ville:                         AVON LAKE
Pays:                          US
Téléphone:                     +1.8889252638
Courriel:                      cjb@cjbmanagement.com

[BILLING_C]
ID Contact:                    CTC5248
Type:                          Organisation
Nom:                           Chris BUTDORF
Adresse:                       32790 Titus Hill Ln
Code postal:                   44012
Ville:                         AVON LAKE
Pays:                          US
Téléphone:                     +1.8889252638
Courriel:                      cjb@cjbmanagement.com

Serveur de noms:               ns1-nonameservers.netim.net
Serveur de noms:               ns2-nonameservers.netim.net

DNSSEC:                        unsigned

>>> Last update of WHOIS database: 2025-12-10T04:01:23.252535Z <<<
```


## Spam websites with random string prefixes

<img width="1080" height="1067" alt="google search" src="https://github.com/user-attachments/assets/b96dd4d0-8ff6-49ea-84ca-c94c5a82dbe0" />
