### PR TITLE
Remove Storipress entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15651,10 +15651,6 @@ ipfs.w3s.link
 // Submitted by Tony Schirmer <tony@storebase.io>
 storebase.store
 
-// Storipress : https://storipress.com
-// Submitted by Benno Liu <benno@storipress.com>
-storipress.app
-
 // Storj Labs Inc. : https://storj.io/
 // Submitted by Philip Hutchins <hostmaster@storj.io>
 storj.farm


### PR DESCRIPTION
Removed entries for Storipress from the public suffix list.

- added by https://github.com/publicsuffix/list/pull/1583
- storipress.app expired at `2025-10-22T04:49:00.637Z`
- set as `pending delete` by the registry
- defunct organization Website: https://storipress.com
- email and GitHub mention sent 2025-12-10
  - **confirmed** https://github.com/publicsuffix/list/pull/1583#issuecomment-3635952180

```
Domain: STORIPRESS.APP
Created Date: 2021-10-22T04:49:00.637Z
Reregistration Date: 2024-09-22T04:05:55.702Z
Updated Date: 2025-12-01T04:02:52.401Z
Expired Date: 2025-10-22T04:49:00.637Z
Transfer Date: 2023-09-16T02:01:40.923Z
Status: pending delete,redemption period

Registrar Name:CloudFlare, Inc.
Name Server: etta.ns.cloudflare.com
Name Server: maciej.ns.cloudflare.com

>>> Last update of WHOIS database: 2025-12-10T08:21:25.851Z <<<
```