### PR TITLE
Remove platterp.us

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15014,10 +15014,6 @@ us.platform.sh
 *.platformsh.site
 *.tst.site
 
-// PSL Sandbox : https://github.com/groundcat/PSL-Sandbox
-// Submitted by groundcat <psl-sandbox@alumni.upenn.edu>
-platter-app.dev
-
 // Pley AB : https://www.pley.com/
 // Submitted by Henning Pohl <infra@pley.com>
 pley.games
@@ -15064,6 +15060,10 @@ dev.project-study.com
 // Protonet GmbH : http://protonet.io
 // Submitted by Martin Meier <admin@protonet.io>
 protonet.io
+
+// PSL Sandbox : https://github.com/groundcat/PSL-Sandbox
+// Submitted by groundcat <psl-sandbox@alumni.upenn.edu>
+platter-app.dev
 
 // PT Ekossistim Indo Digital : https://e.id
 // Submitted by Eid Team <support@corp.e.id>


### PR DESCRIPTION
1. Removed `platterp.us`

- initially added on Apr 3, 2020 by #935
- expired 2025-08-14
- deleted from .us zone file 2025-09-10
- contacted requestor 2025-09-10 - no response
- re-registered by someone 2025-10-31 and http://platterp.us/ is now showing a domain parking page
- so, safe to remove

2. Updated comment lines for `platter-app.dev` for a PSL sandbox

- platter-app.dev was let expired, I re-registered it for $5 today to hopefully do some experiments/research with it. I'm curious to see how spam filters, security vendors, domain checkers, and community-sourced blocklists actually interact with domains that are in the PSL. It might not even be necessary to register the domain to test this, but figured it was worth the five bucks just in case.  Will remove it once I'm done with it.

```
dig @1.1.1.1 _psl.platter-app.dev. A
_psl.platter-app.dev.	1800	TXT	"https://github.com/publicsuffix/list/pull/2695"
```
