### PR TITLE
Add int.apple and cloud infrastructure subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12344,6 +12344,24 @@ panel.dev
 // Submitted by Alexander Selivanov <alex@apphud.com>
 siiites.com
 
+// Apple : https://www.apple.com
+// Submitted by Apple DNS <dnscontact@apple.com>
+int.apple
+*.cloud.int.apple
+*.r.cloud.int.apple
+*.ap-north-1.r.cloud.int.apple
+*.ap-south-1.r.cloud.int.apple
+*.ap-south-2.r.cloud.int.apple
+*.eu-central-1.r.cloud.int.apple
+*.eu-north-1.r.cloud.int.apple
+*.us-central-1.r.cloud.int.apple
+*.us-central-2.r.cloud.int.apple
+*.us-east-1.r.cloud.int.apple
+*.us-east-2.r.cloud.int.apple
+*.us-west-1.r.cloud.int.apple
+*.us-west-2.r.cloud.int.apple
+*.us-west-3.r.cloud.int.apple
+
 // Appspace : https://www.appspace.com
 // Submitted by Appspace Security Team <security@appspace.com>
 appspacehosted.com


### PR DESCRIPTION
Adds Apple's int.apple domain and associated cloud infrastructure subdomains for regional services.

We need segmentation between portions of the .apple TLD that supply user-controlled data from different users. The regional structure is necessary for operational reliability. Our team evaluated the options and trade-offs and chose this structure for services at our scale.

The wildcards (`*.`) in these names cover significant infrastructure.

This request addresses browser origin and cookie handling, not third-party limits.

### Organizational Authentication

This PR follows the organizational authentication model established by AWS in #1605:

* The PR comes from a repository in the github.com/apple organization
* The PR author is a public member of the @apple organization
* Permission to modify this repository represents Apple's approval

Under this model, we provide DNS verification at `_psl.int.apple` only, not for each individual entry. This matches our organizational decision tree for these suffixes and gives us confidence we can maintain it correctly long-term. As discussed in #2604, we hope this approach will be sufficient.

Submitted by Apple DNS <dnscontact@apple.com>

---

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
`dnscontact@apple.com` and https://support.apple.com/en-us/102549

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

Apple Inc. is a technology company headquartered in Cupertino, California. It designs and sells consumer electronics, software, and services.

I manage the engineering team responsible for Apple's DNS infrastructure and data.

**Organization Website:**

https://www.apple.com/
https://www.systemstatus.apple/ (example of a related `.apple` domain that this infrastructure supports)

## Reason for PSL Inclusion

Browser security parameters.

We operate this domain under our `.apple` brand TLD and will maintain registration indefinitely.

**Number of users this request serves:** We are a large company with many users.
