### PR TITLE
Add kiloapps.ai, kiloapps.io to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14266,15 +14266,15 @@ kuleuven.cloud
 // Submitted by Martin Dannehl <postmaster@keymachine.de>
 keymachine.de
 
-// KingHost : https://king.host
-// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
-kinghost.net
-uni5.net
-
 // Kilo Code, Inc. : https://kilo.ai
 // Submitted by Remon Oldenbeuving <security@kilocode.ai>
 kiloapps.ai
 kiloapps.io
+
+// KingHost : https://king.host
+// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
+kinghost.net
+uni5.net
 
 // KnightPoint Systems, LLC : http://www.knightpoint.com/
 // Submitted by Roy Keene <rkeene@knightpoint.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

- [x] We are listing _any_ third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  - N/A – This request is for cookie isolation and security. We are not seeking to work around any third-party rate limits.

- [x] This request was _not_ submitted with the objective of working around other third-party limits.

- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the \_psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

- [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
- [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

- [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://kilo.ai/abuse

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

- [x] _Yes, I understand_. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. _Proceed anyways_.

---

## Description of Organization

Kilo Code is the all-in-one agentic engineering platform. Our platform consists of multiple products:

1. **Kilo Code** – An open-source VS Code extension that integrates AI coding assistants directly into developers' workflows, enabling AI-assisted code generation, debugging, and refactoring.

2. **Kilo Cloud** – A deployment platform where users can deploy web applications. Users connect their GitHub repositories, and Kilo deploys their projects to randomly-generated subdomains on `kiloapps.ai` and `kiloapps.io`. These deployments are used for prototyping, demos, and sharing work with colleagues.

I am Remon, Engineering Manager and Tech Lead at Kilo Code. I lead the Kilo Cloud team responsible for our deployment infrastructure, including the `kiloapps.ai` and `kiloapps.io` domains.

**Organization Website:**
https://kilo.ai

## Reason for PSL Inclusion

### Why PSL Inclusion Is Needed: Multi-Tenant Cookie Isolation

Kilo Cloud is a multi-tenant deployment platform. Each user's deployment receives a randomly-generated subdomain (e.g., `kiloman-bxpupc.d.kiloapps.io`). Multiple mutually-untrusting parties host web applications on subdomains of our domains. This creates a security concern that PSL inclusion directly addresses.

### The Security Problem

Without PSL listing, browsers treat all subdomains of `kiloapps.ai` and `kiloapps.io` as belonging to the same registrable domain. This allows the following attack:

1. **Attacker** deploys a malicious site to `evil-xyz.d.kiloapps.io`
2. **Attacker's site** sets a cookie with `Domain=.kiloapps.io`
3. **This cookie is now sent to ALL other deployments** on `kiloapps.io`
4. **Victim** visits their own deployment at `victim-abc.d.kiloapps.io`
5. **Attacker's cookie is included** in the request, enabling:
   - Session fixation attacks
   - Cross-site request forgery
   - Cookie poisoning
   - Unauthorized tracking across unrelated deployments

### How PSL Inclusion Resolves This

PSL inclusion instructs browsers to treat each subdomain of `kiloapps.ai` and `kiloapps.io` as a separate registrable domain. This enforces:

- **Cookie isolation**: A site at `evil.kiloapps.io` cannot set cookies that are readable by `victim.kiloapps.io`
- **Origin separation**: Each deployment is treated as a distinct origin
- **Storage isolation**: localStorage, IndexedDB, and other client-side storage are isolated per deployment

### Domain Registration Status

Both domains are registered with auto-renewal enabled and have registration terms exceeding 2 years:

| Domain        | Expiration Date | Time Remaining |
| ------------- | --------------- | -------------- |
| `kiloapps.ai` | 2029-10-28      | ~3.8 years     |
| `kiloapps.io` | 2028-12-10      | ~2.9 years     |

```
whois kiloapps.ai | grep -i "registry expiry"
Registry Expiry Date: 2029-10-28T12:18:31Z
```

```
whois kiloapps.io | grep -i "registry expiry"
Registry Expiry Date: 2028-12-10T11:31:25Z
```

We commit to maintaining registration and keeping the `_psl` TXT records in place indefinitely.

**Number of users this request is being made to serve:**
Currently serving hundreds of active deployments. We expect growth to thousands of deployments as Kilo Cloud expands.

## DNS Verification

```
dig +short TXT _psl.kiloapps.ai
"https://github.com/publicsuffix/list/pull/2701"
```

```
dig +short TXT _psl.kiloapps.io
"https://github.com/publicsuffix/list/pull/2701"
```

Both bare domains (`kiloapps.ai` and `kiloapps.io`) redirect to https://kilo.ai.

```
curl -sI https://kiloapps.ai | grep -i location
location: https://kilo.ai/
```

```
curl -sI https://kiloapps.io | grep -i location
location: https://kilo.ai/
```