### PR TITLE
Update contact information for `forgeblocks.com` & `id.forgerock.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13570,11 +13570,6 @@ fly.dev
 shw.io
 edgeapp.net
 
-// Ping Identity : https://www.pingidentity.com
-// Submitted by Ping Identity <security@pingidentity.com>
-forgeblocks.com
-id.forgerock.io
-
 // FoundryLabs, Inc : https://e2b.dev/
 // Submitted by Jiri Sveceny <security@e2b.dev>
 e2b.app
@@ -14995,6 +14990,11 @@ mypep.link
 // Perspecta : https://perspecta.com/
 // Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
 perspecta.cloud
+
+// Ping Identity : https://www.pingidentity.com
+// Submitted by Ping Identity <security@pingidentity.com>
+forgeblocks.com
+id.forgerock.io
 
 // Plain : https://www.plain.com/
 // Submitted by Jesús Hernández <security@plain.com>


### PR DESCRIPTION
Updating the contact information for the forgerock domains. We have since merged with [Ping](https://www.thomabravo.com/press-releases/thoma-bravo-completes-acquisition-of-forgerock-combines-forgerock-into-ping-identity) and would like to use our generic security domain as a contact. Thank you!