### PR TITLE
Add indevs.in to Public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14027,7 +14027,7 @@ tempurl.host
 wpmudev.host
 
 // Indevs : https://indevs.in
-// Submitted by Sudheer Bhuvana <sudheer@admin.indevs.in>
+// Submitted by Sudheer Bhuvana <security@admin.indevs.in>
 indevs.in
 
 // Individual Network Berlin e.V. : https://www.in-berlin.de/


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__
* [x] We are listing *any* third-party limits that we seek to work around in our rationale - None. This request is not intended to work around any third-party limits.
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [formatting and sorting guidelines](https://github.com/publicsuffix/list/wiki/Format).
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

---

## Abuse Contact
* [ ] Abuse contact information (email or web form) is available and easily accessible.

**Abuse contact URL:** https://indevs.in/abuse (or `mailto:security@admin.indevs.in`)

---

## Description of Organization

An open-source project/service that provides free subdomains to developers, creators, and open-source enthusiasts who want their own "indevs.in" domain.

**Organization Website:** https://indevs.in
Registry Expiration: 2028-12-11 20:33:11 UTC
---

## Reason for PSL Inclusion

Like is-a.dev, js.org, vercel.app, and other domain name services listed on the PSL, indevs.in is a free subdomain name service where developers can register `yourname.indevs.in`.

We primarily require PSL status for cookie separation, which will help minimize security risks among subdomains as each subdomain is owned by a different party. URL highlighting in supported browsers is also beneficial for our users.

**Number of users this request is being made to serve:**  
157+ current subdomains, actively used by independent users.

---

## DNS Verification via dig
```
bhuvana-sudheer@sudhi:~$ dig +short TXT _psl.indevs.in
"https://github.com/publicsuffix/list/pull/2709"
```