### PR TITLE
Add serveousercontent.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15504,6 +15504,10 @@ senseering.net
 // Submitted by Daniel Kjeserud <cloudops@servebolt.com>
 servebolt.cloud
 
+// Serveo : https://serveo.net
+// Submitted by Trevor Dixon <trevor@serveo.net>
+serveousercontent.com
+
 // Service Online LLC : http://drs.ua/
 // Submitted by Serhii Bulakh <support@drs.ua>
 biz.ua


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).
__Submitter affirms the following:__ 
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
   - None
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
**Abuse Contact:** abuse@serveo.net
 * [x] Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: https://serveo.net/abuse
---
 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---
## Description of Organization

Serveo is a developer tool that provides secure tunneling services to expose local development servers to the internet. We offer both SSH-based and WireGuard-based tunneling, allowing developers to share their localhost web applications with clients, webhooks, or remote teams without deploying to a public server.

I am the founder and developer of Serveo, responsible for the platform's architecture and operations.
When users connect to Serveo, they are automatically assigned a subdomain on serveousercontent.com (e.g., `abc123def456.serveousercontent.com`) that proxies traffic to their local server. Users can also register and reserve custom subdomains on serveousercontent.com for their projects when they create an account.

**Organization Website:**
https://serveo.net

## Reason for PSL Inclusion

Serveo assigns each user a unique subdomain under serveousercontent.com for their tunnel endpoints. For example, when a developer runs `ssh -R 80:localhost:3000 serveo.net`, they receive a URL like `https://randomsubdomain.serveousercontent.com` that routes traffic to their local development server.

Cookie Isolation is Critical: Without PSL inclusion, a malicious user could set a cookie on `.serveousercontent.com` that would be sent to all other users' subdomains. This creates a significant security and privacy risk, as user A's application could receive cookies set by user B's application, potentially leading to myriad security and privacy problems.

TLS Certificate Security: PSL inclusion also ensures proper handling of wildcard TLS certificates and prevents potential certificate-based attacks between subdomains. This protects our users from certificate-related security issues.

Similar Services: This is a common pattern for services that provide subdomains to users, such as GitHub Pages (github.io), Netlify (netlify.app), and Vercel (vercel.app), all of which are in the PSL for the same security reasons.
We confirm that serveousercontent.com has more than 2 years remaining on registration and we commit to maintaining more than 1 year term to remain listed. The `_psl` TXT record will remain in place indefinitely.

**Previous PRs**:
None - this is our first PSL submission.

**Number of users this request is being made to serve:**
Current estimate: Several thousand active users daily.

## DNS Verification
```
$ dig +short TXT _psl.serveousercontent.com
"https://github.com/publicsuffix/list/pull/2717"
```