### PR TITLE
Add org.sk

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5670,7 +5670,9 @@ si
 sj
 
 // sk : https://www.iana.org/domains/root/db/sk.html
+// https://sk-nic.sk/
 sk
+org.sk
 
 // sl : http://www.nic.sl
 // Submitted by registry <adam@neoip.com>


### PR DESCRIPTION
- Documented at the registry website at https://sk-nic.sk/en/home/ "SK-NIC, a. s. (a member of CentralNic GROUP PLC), is the manager of the top-level domain .sk and the second-level domain org.sk."
- Confirmed by registry through email (from `Hostmaster SK-NIC <hostmaster@sk-nic.sk>`, subject: "Re: [Ticket#2025121900000539] Public Suffix List Submission Request for org.sk and gov.sk - Verification Needed") forwarded to @simon-friedberger : "Yes, we can confirm that form our side its fine. Also, the third level domain is indeed separate domain for org.sk.- org.sk is reserved for non-for-profit organizations and managed by us"
- To close #2712