### PR TITLE
Add Northwest Nexus delegated locality domains in Washington State

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6298,6 +6298,31 @@ gen.mi.us
 mus.mi.us
 tec.mi.us
 washtenaw.mi.us
+// Northwest Nexus, Inc. maintains the registry for the following
+// delegated domains in Washington State:
+aberdeen.wa.us
+bainbridge-isl.wa.us
+bellevue.wa.us
+bremerton.wa.us
+centralia.wa.us
+chehalis.wa.us
+forks.wa.us
+gig-harbor.wa.us
+hoquiam.wa.us
+keyport.wa.us
+kingston.wa.us
+olympia.wa.us
+port-angeles.wa.us
+port-ludlow.wa.us
+port-orchard.wa.us
+port-townsend.wa.us
+poulsbo.wa.us
+redmond.wa.us
+renton.wa.us
+seattle.wa.us
+sequim.wa.us
+shelton.wa.us
+silverdale.wa.us
 
 // uy : http://www.nic.org.uy/
 uy


### PR DESCRIPTION
**Superseded by #2724**

Add 23 delegated locality domains in Washington State maintained by Northwest Nexus, Inc.

**Important: I have not yet received any endorsement from Northwest Nexus on this change. This PR should be considered a draft until I finish discussing contact emails and DNS validation.**

# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig

* [X] *(Not applicable)* ~~Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).~~

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - I, @pwbriggs, initially learned about the PSL while researching why Cloudflare would not allow me to set up a DNS zone for my personal domain, `briggs.seattle.wa.us`. However, I am now more concerned with improving cross-site isolation across these 23 locality domains than with getting a personal Cloudflare zone.
 - While researching the potential impact and willingness for `seattle.wa.us` to be added, at least one administrator mentioned to me (@pwbriggs) that they would be interested in this PSL entry to avoid any potential future issues with Let's Encrypt rate limits. Again, this is a benefit supporting my desire for these PSL entries, but it is not my primary objective in requesting them.

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [X] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

[TODO: DOES THIS APPLY? IF SO, NW NEXUS NEEDS TO DO THIS:]

 * [ ] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the `_psl` DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically both are solved or
neither.
-->

 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them (to the best of my knowledge).
 * [ ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

This submissions ***does not*** follow the sorting guidelines, nor does the entire `.us` domain section. This is because the sorting guidelines make the list more confusing, not less, in the context of 50 state prefixes. I have added the Northwest Nexus section next to the similar [Merit Network entry] for a similar case in Michigan.

[Merit Network entry]: https://github.com/publicsuffix/list/blob/a0814017572883671d2f48e789e2173bb2a1e57d/public_suffix_list.dat#L6296

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

[TODO: DOES THIS APPLY IN THIS CASE? NW NEXUS DOES NOT RUN ANY SITE AT E.G. `HTTPS://SEATTLE.WA.US/`&mdash;THIS IS NOT A "PRIVATE" SECTION PSL ENTRY]

* [ ] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- Provide the URL where an Internet user can access the abuse contact information -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Northwest Nexus, Inc., dba NuOz Corporation, is a technology services company in the greater Seattle area in Washington State. It is the [RFC 1480 &sect; 3.3](https://www.rfc-editor.org/rfc/rfc1480#section-3) delegated organization managing 23 locality domains under `.wa.us`.

I, @pwbriggs, am a resident of Seattle and operator of `briggs.seattle.wa.us`, which is affected by this change.

**Organization Website:** https://nwnexus.net/ or https://nuoz.com/
<!-- Provide the website address of the org as a full URL (i.e. https://example.com) -->

## Reason for PSL Inclusion
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare, etc.) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also reference any past issues or PRs 
specifically related to this submission or section.

Provide three or more sentences here that describe the purpose 
for which your PR should be included in the PSL. There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

Although the RFC 1480 specification for the `.us` domain is no longer in effect, some companies, including Northwest Nexus / NuOz, continue to distribute 4LD locality domains in accordance with the RFC to independent entities. This means the 3LD localities are eTLD's. Therefore, it is accurate for these suffixes to be added to the PSL.

I, @pwbriggs, am facilitating the addition of these entries to improve cross-site isolation for my own domain and for locality domains operated by others in Washington.

### Number of users this request is being made to serve:
<!-- Identify if this is current or an estimate. -->
In accordance with RFC 1480 &sect; 3.3.1., delegated `.us` domains deeper than 3rd-level are not included in the WHOIS database. I, @pwbriggs, have not requested Northwest Nexus to provide statistics about the number of registrations in each locality. However, I have done some research personally to gauge the impact of the `seattle.wa.us` entry specifically. Examples of users affected by this change include the administrators and viewers/clients of https://frederick.seattle.wa.us/, https://sleepless.seattle.wa.us, https://kevin.wallace.seattle.wa.us, https://social.seattle.wa.us/, and `briggs.seattle.wa.us`, in addition any services run on those domains, and within the other 22 locality domains delegated to NuOz. Notably, https://social.seattle.wa.us/ is a Mastodon instance with 100+ users (which in turn federates posts to the broader Mastodon network).

Since I have not enumerated all registrations in the Seattle locality, nor researched other localities that this PR affects, I am not comfortable claiming a specific number of users affected. If I had to guess, I'd say >30 web sites and >500 end-users affected.

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
DNS verification records are not yet in place.