### PR TITLE
Add Gambia SLDs (`gam.gm`, `blog.gm`, `sch.gm`,`ngo.gm`, `law.gm`, `name.gm`, +more)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13676,6 +13676,17 @@ futuremailing.at
 gadget.app
 gadget.host
 
+// GamDNS : https://gamdns.gm
+// Submitted by Bubacarr Sowe <support@gamdns.gm>
+blog.gm
+gam.gm
+law.gm
+nam.gm
+name.gm
+ngo.gm
+sch.gm
+
+
 // GCom Internet : https://www.gcom.net.au
 // Submitted by Leo Julius <support@gcom.net.au>
 aliases121.com
@@ -16225,12 +16236,3 @@ zabc.net
 
 // ===END PRIVATE DOMAINS===
 
-// GamDNS : https://gamdns.gm
-// Submitted by GamDNS Registry <support@gamdns.gm>
-blog.gm
-gam.gm
-law.gm
-nam.gm
-name.gm
-ngo.gm
-sch.gm


### PR DESCRIPTION
## Add Gambia SLDs to PRIVATE DOMAINS

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_ and the submission conforms to them.
* [x] A role-based email address has been used and is actively monitored.
* [x] Abuse contact information (email or web form) is available.
* [x] *Yes, I understand*. I could break my organization's website cookies and other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

**Organization Website:** https://gamdns.gm

GamDNS is a DNS and domain services provider in The Gambia. We operate authoritative DNS servers, manage domain registrations under the .gm TLD, and provide services such as subdomain delegation, backups, and TLS certificate issuance using Lets Encrypt.  

This submission is made by Bubacarr Sowe, the founder and operator of GamDNS, responsible for managing the domains in this request.

---

## Reason for PSL Inclusion

These domains (gam.gm, blog.gm, sch.gm, ngo.gm, law.gm, name.gm, nam.gm,) are publicly registrable second-level domains (SLDs) in The Gambia that require inclusion in the PSL so that browsers, certificate authorities (e.g., Let's Encrypt), and other software correctly handle cookie scoping and TLS issuance.  

The domains are actively maintained with multi-year registration, and `_psl` TXT records have been added for verification.  

Including these domains in the PRIVATE section ensures proper isolation for subdomains and prevents misinterpretation as top-level domains by software relying on the PSL.

**Number of users this request is being made to serve:** internal GamDNS clients; publicly registrable SLDs may be used by clients in The Gambia.

---

## DNS Verification and Abuse Contact

For each domain, `_psl` TXT records have been added for verification. You can confirm ownership via `dig`:

dig +short TXT _psl.gam.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

dig +short TXT _psl.blog.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

dig +short TXT _psl.sch.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

dig +short TXT _psl.ngo.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

dig +short TXT _psl.law.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

dig +short TXT _psl.name.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

dig +short TXT _psl.nam.gm
"github-psl-verify=https://github.com/bubacarrsowe/list/pull/new/add-gamdns-slds
"

**Abuse Contact:**

Email: abuse@gamdns.gm  

