### PR TITLE
Adding Deuxfleurs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12864,6 +12864,11 @@ dedyn.io
 deta.app
 deta.dev
 
+// Deuxfleurs : https://deuxfleurs.fr
+// Submitted by Aeddis Desauw <ca@deuxfleurs.fr>
+deuxfleurs.eu
+deuxfleurs.page
+
 // Developed Methods LLC : https://methods.dev
 // Submitted by Patrick Lorio <security@playit.gg>
 *.at.ply.gg


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [X] This request was _not_ submitted with the objective of working around other third-party limits.

 * [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [X] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [X] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: Yes

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---


## Description of Organization

Deuxfleurs is a French Association, members of CHATONS, that host services for the public. The infrastructure is based on lightweight S3 backend Garage. Among the service is web hosting under subdomain. 

I am a member of the Administrative Council of this association. 

**Organization Website:** https://deuxfleurs.fr 

## Reason for PSL Inclusion

We want to provide each of our user with a subdomain of `deuxfleurs.page`or `deuxfleurs.eu`. 
We want to clearly define what is hosted by us and what is hosted by our users. 
Those domains  


**Number of users this request is being made to serve:** currently around 600

## DNS Verification

```
dig +short TXT _psl.deuxfleurs.page
"https://github.com/publicsuffix/list/pull/2727"
```

```
dig +short TXT _psl.deuxfleurs.eu
"https://github.com/publicsuffix/list/pull/2727"
```

## Results of Syntax Checker (make test)

All tests passed