### PR TITLE
added *.bwcloud-os-instance.de

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12559,6 +12559,10 @@ radio.fm
 cdn.bubble.io
 bubbleapps.io
 
+// bwCloud-OS : https://bwcloud-os.de/
+// Submitted by Klara Mall <dns@bwcloud-os.de>
+*.bwcloud-os-instance.de
+
 // Bytemark Hosting : https://www.bytemark.co.uk
 // Submitted by Paul Cammish <paul.cammish@bytemark.co.uk>
 uk0.bigv.io


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
dns@bwcloud-os.de
 * [x] Abuse contact information (email or web form) is available and easily accessible.
E-Mail: abuse@bwcloud-os.de

URL where abuse contact or abuse reporting form can be found: 
https://bwcloud-os.de/abuse
https://bwcloud-os.de/.well-known/security.txt

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

## Description of Organization
bwCloud-OS is an Infrastructure-as-a-Service (IaaS) platform developed and operated specifically to support research and teaching within Baden-Württemberg (federal state of Germany). Its operation is a joint initiative of four universities. Members of the currently 22 participating universities — including students, researchers, and administrative staff — are eligible to use bwCloud-OS to run their own virtual machines.

My name is Klara Mall, I am the head of the Network Department at the Scientific Computing Center (SCC) of Karlsruhe Institute of Technology (KIT) and serve as the technical contact for all DNS-related topics within the bwCloud-OS platform. Scientific Computing Center (SCC) is also the owner of the domain bwcloud-os-instance.de.

**Organization Website:**
https://bwcloud-os.de

## Reason for PSL Inclusion
Each virtual machine or other service deployed using the IaaS infrastructure is provided with a location-specific *.{ka,ul,ma,fr}.bwcloud-os-instance.de subdomain, e.g. project-xyz.ka.bwcloud-os-instance.de. Since these subdomains are controlled by different users, we need *.bwcloud-os-instance.de to be on the PSL to ensure that cookies are restricted to the individual subdomains and cannot be set for the main or location-specific domains.

Furthermore, inclusion on the PSL serves as an additional signal that these subdomains are run by different entities. For instance, in the case of fraud or abuse, it should ideally limit any corrective action (such as Google Safe Browsing flagging content as dangerous or denylisting by public resolver operators) to a specific subdomain (*.{ka,ul,ma,fr}.bwcloud-os-instance.de, e.g. project-xyz.ka.bwcloud-os-instance.de) instead of the entire location-specific domains, like ka.bwcloud-os-instance.de or ka.bwcloud-os-instance.de.

**Registration validity of 2y+**
Unfortunately, it is not possible to maintain 2 years of renaming validity for the domain bwcloud-os-instance.de as our registry DENIC eG does not allow to prolong de domains beyond the point they are already prolonged. The domain is set to automatically renew. We can affirm that we will keep this in place. Of course, we will keep `_psl` RRs in place. Please also note that expiration dates are not public for de domains.
There have been several cases with .de domains in the PSL; one reference MR is #2492.

**Number of users this request is being made to serve:**
The previous generation of the IaaS platform had more than 1,000 users. The new generation of the IaaS platform will be accessible for students, teachers, and researchers from all universities in Baden-Württemberg. It is estimated that the platform will grow quickly and reach more than 1,000 active users within the first year.

## DNS Verification
```
dig +short TXT _psl.bwcloud-os-instance.de
"https://github.com/publicsuffix/list/pull/2728"
```