### PR TITLE
FIXED #2619 / #2729 Hercules not appropriately scrutinized during merge-a-thon

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1298,12 +1298,6 @@ gov.gy
 net.gy
 org.gy
 
-// Hercules : https://hercules.app
-// Submitted by Brendan Falk <security@hercules.app>
-onhercules.app
-hercules-app.com
-hercules-dev.com
-
 // hk : https://www.hkirc.hk
 // Submitted by registry <hk.tech@hkirc.hk>
 hk
@@ -13956,6 +13950,12 @@ heliohost.us
 // Hepforge : https://www.hepforge.org
 // Submitted by David Grellscheid <admin@hepforge.org>
 hepforge.org
+
+// Hercules : https://hercules.app
+// Submitted by Brendan Falk <security@hercules.app>
+onhercules.app
+hercules-app.com
+hercules-dev.com
 
 // Heroku : https://www.heroku.com/
 // Submitted by Shumon Huque <public-dns@salesforce.com>


### PR DESCRIPTION
Removed and re-added Hercules entries in the public suffix list.

This deals with where #2619 was merged into the wrong section and addresses #2729
