### PR TITLE
Add iscoding.in to Public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15668,6 +15668,10 @@ stackit.zone
 // Submitted by Sudheer Bhuvana <security@stackryze.com>
 indevs.in
 
+// iscoding : https://iscoding.in
+// Submitted by Vignesh Rathod <security@admin.iscoding.in>
+iscoding.in
+
 // Staclar : https://staclar.com
 // Submitted by Q Misell <q@staclar.com>
 // Submitted by Matthias Merkel <matthias.merkel@staclar.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
* [ ] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
   ``mailto:security@admin.iscoding.in``

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

iscoding.in is a free public subdomain service that allows unrelated third-party users to register, host, and manage their own subdomains under the iscoding.in namespace. The service is designed to provide a platform for developers, students, and hobbyists to showcase coding projects and web applications.

**Organization Website: https://iscoding.in**

## Reason for PSL Inclusion
We primarily require PSL status to ensure proper cookie separation, which helps minimize security risks between subdomains, as each subdomain is owned and managed by a different party. PSL inclusion also enables correct URL highlighting and domain handling in supported browsers, improving safety and clarity for users.

**Number of users this request is being made to serve: 96 users**

## DNS Verification

```
dig +short TXT _psl.iscoding.in
"https://github.com/publicsuffix/list/pull/2737"
```


