### PR TITLE
Remove `nom.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1521,7 +1521,6 @@ edu.io
 gov.io
 mil.io
 net.io
-nom.io
 org.io
 
 // iq : http://www.cmc.iq/english/iq/iqregister1.htm


### PR DESCRIPTION
**This is a change made to the ICANN section.**

Reasons for removal:
- Let expired by registry
- Re-registered by someone `2025-12-23T18:26:38Z` through commercial registrar `Name.com, Inc.`
- Unable to discover any websites using .nom.io as a suffix 
  - https://www.google.com/search?q=site%3Anom.io
  - https://subdomainfinder.c99.nl/scans/2026-01-12/nom.io
- Email sent to registry 2026-1-11 pending reply

Context:
- Added by #2236

WHOIS

```
Domain Name: nom.io
Registry Domain ID: REDACTED
Registrar WHOIS Server: whois.name.com
Registrar URL: http://www.name.com
Updated Date: 2025-12-28T18:27:08Z
Creation Date: 2025-12-23T18:26:38Z
Registry Expiry Date: 2026-12-23T18:26:38Z
Registrar: Name.com, Inc.
Registrar IANA ID: 625
Registrar Abuse Contact Email: abuse@name.com
Registrar Abuse Contact Phone: +1.7203101849
Domain Status: inactive https://icann.org/epp#inactive
Registry Registrant ID: REDACTED
Registrant Name: REDACTED
Registrant Organization: 
Registrant Street: REDACTED
Registrant City: REDACTED
Registrant State/Province: 
Registrant Postal Code: REDACTED
Registrant Country: US
Registrant Phone: REDACTED
Registrant Phone Ext: REDACTED
Registrant Fax: REDACTED
Registrant Fax Ext: REDACTED
Registrant Email: REDACTED
Registry Admin ID: REDACTED
Admin Name: REDACTED
Admin Organization: REDACTED
Admin Street: REDACTED
Admin City: REDACTED
Admin State/Province: REDACTED
Admin Postal Code: REDACTED
Admin Country: REDACTED
Admin Phone: REDACTED
Admin Phone Ext: REDACTED
Admin Fax: REDACTED
Admin Fax Ext: REDACTED
Admin Email: REDACTED
Registry Tech ID: REDACTED
Tech Name: REDACTED
Tech Organization: REDACTED
Tech Street: REDACTED
Tech City: REDACTED
Tech State/Province: REDACTED
Tech Postal Code: REDACTED
Tech Country: REDACTED
Tech Phone: REDACTED
Tech Phone Ext: REDACTED
Tech Fax: REDACTED
Tech Fax Ext: REDACTED
Tech Email: REDACTED
Name Server:
DNSSEC: unsigned
URL of the ICANN Whois Inaccuracy Complaint Form: https://icann.org/wicf/
>>> Last update of WHOIS database: 2026-01-12T02:57:43Z <<<
```

Currently listed in the PSL:

```
io
co.io
com.io
edu.io
gov.io
mil.io
net.io
nom.io
org.io
```

while it seems like only

```
io
gov.io
```

are actually used.