### PR TITLE
Add `corespeed.app`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12776,6 +12776,10 @@ gov.ru
 int.ru
 mil.ru
 
+// CoreSpeed, Inc. : https://corespeed.io
+// Submitted by CoreSpeed Team <ops@corespeed.io>
+corespeed.app
+
 // COSIMO GmbH : http://www.cosimo.de
 // Submitted by Rene Marticke <rmarticke@cosimo.de>
 dyn.cosidns.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://corespeed.app (the domain we are submitting)
  <!-- Provide the URL where an Internet user can access the abuse contact information -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

At CoreSpeed, Inc., we operate a Platform-as-a-Service (PaaS) that provides containerized infrastructure, similar to what other competitors do, but primarily targeting Developers/Enterprises building AI applications.

I am a senior software engineer working at CoreSpeed, Inc.

**Organization Website:**

https://corespeed.io

## Reason for PSL Inclusion

CoreSpeed provides customers with custom subdomains under the `corespeed.app` domain via our “service domains” feature. Each subdomain (e.g., `my-app.corespeed.app` and `my-app.my-username.corespeed.app`) is independently operated by different users (that are mutually-untrusting tenants) on our platform.

At the time of writing, over 500 of these domains are actively used right now as we are beta testing, and we expect to exceed 2000 after officially launch in the upcoming month.

Thus, our team has decided to implement measures to isolate each subdomain in order to proactively address any potential security concerns within those service domains before we officially launch. We want to ensure that these domains are respected as individual entities by both browsers and other applications, to prevent cross-site cookie/browser storage access, and to ensure ISPs/browsers don't block our entire zone if there is a singular misbehaving domain.

**Number of users this request is being made to serve:**

- Domains in use: currently over 500, expect to exceed 2000 in the upcoming month, and more in the future
- Users: currently over 200 (who joined the beta testing), expect to exceed 1000 in the upcoming month, and more in the future

## DNS Verification

```
dig +short TXT _psl.corespeed.app
"https://github.com/publicsuffix/list/pull/2743"
```
