### PR TITLE
Rename 'aquila.it' to 'laquila.it'

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1692,6 +1692,7 @@ aosta.it
 aoste.it
 ap.it
 aq.it
+aquila.it
 laquila.it
 ar.it
 arezzo.it


### PR DESCRIPTION
This PR requests the removal of aquila.it from the Public Suffix List, as it does not represent a valid public suffix for administrative subdomains in Italy and replace it with laquila.it.

- The Province and Municipality of L’Aquila use laquila.it as their authoritative domain. This is publicly verifiable from the official municipal website:

https://www.comune.laquila.it/

The domain aquila.it is not the administrative suffix under which municipal or provincial subdomains are delegated. Its inclusion in the PSL therefore misrepresents the real domain hierarchy.

- WHOIS evidence

A WHOIS lookup further confirms the mismatch between administrative use and domain ownership:

$ whois laquila.it
Domain:     laquila.it
Status:     UNASSIGNABLE


This indicates that laquila.it is reserved and not registrable, consistent with its role as an institutional domain.

$ whois aquila.it
Domain:     aquila.it
Status:     ok
Created:    2012-11-30

Registrant:
  Organization: Puglia.com Srls

Admin / Technical Contact:
  Domain Profit Srl

Registrar:
  Algorithmedia S.r.l.


This shows that aquila.it is a privately registered domain, owned and operated by commercial entities, and not delegated by any public authority.

- Observed impact

While investigating certificate issuance patterns, we observed thousands of TLS certificates issued for arbitrary subdomains of aquila.it, many of which resemble phishing or impersonation attempts (for example comune.aquila.it):

https://crt.sh/?q=comune.aquila.it

At the time of writing, aquila.it resolves using a wildcard configuration, responding to essentially any subdomain with the same IP address.