### PR TITLE
Add vibitely.com to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16012,7 +16012,7 @@ now.sh
 v-info.info
 
 // Vibitely, Inc. : https://vibitely.com
-// Submitted by Vytautas Liutvinas <abuse@vibitely.com>
+// Submitted by Vytautas Liutvinas <vibitely@gmail.com>
 vibitely.com
 
 // VistaBlog : https://vistablog.ir/


### PR DESCRIPTION
### Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

### Description of Organization

Vibitely.com is an AI-powered website builder platform (similar to Lovable) where users create websites through AI prompts and deploy them to subdomains (e.g., site.vibitely.com).

### Robust Reason for PSL Inclusion

We require inclusion in the Public Suffix List to:

1. **Cookie isolation** - users' sites can't access each other's cookies
2. **Security boundary** - browser treats each subdomain as a separate site
3. **Credential isolation** - password managers won't auto-fill across subdomains

### DNS verification via dig
```
dig +short TXT _psl.vibitely.com
"https://github.com/publicsuffix/list/pull/2751"
```

### Domain Registration

Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Confirmed.** Domain expires 2029-11-30 (Registry Expiry Date: 2029-11-30T19:45:09Z)

### Submitter affirms the following:

- [x] We are listing any third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)

None. We are not seeking to work around any third-party limits.

- [x] This request was not submitted with the objective of working around other third-party limits
- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
- [x] The Guidelines were carefully read and understood, and this request conforms to them
- [x] The submission follows the guidelines on formatting and sorting
- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days

### Abuse Contact

**Abuse Contact:** vibitely@gmail.com

- [x] Abuse contact information (email or web form) is available and easily accessible

**URL where abuse contact or abuse reporting form can be found:** https://vibitely.com/abuse

This link is shown in the footer of each page on vibitely.com.

### Number of users this request is being made to serve

Currently serving 500 users, with steady growth trajectory.

### Results of Syntax Checker (`make test`)
```
=== PSL Linter Self-Test ===
test_allowedchars: OK
test_dots: OK
test_duplicate: OK
test_exception: OK
test_NFKC: OK
test_punycode: OK
test_section1: OK
test_section2: OK
test_section3: OK
test_section4: OK
test_spaces: OK
test_wildcard: OK

=== PSL File Validation ===
No errors found - validation passed

=== Entry Added ===
// Vibitely : https://vibitely.com
// Submitted by Vibitely Team <vibitely@gmail.com>
vibitely.com
```

### Understanding of Impacts and Propagation

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the [affectation and propagation expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion), that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

- [x] **Yes, I understand. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. Proceed anyways.**
