### PR TITLE
Add shiptoday to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14341,7 +14341,6 @@ shiptoday.build
 laravel.cloud
 on-forge.com
 on-vapor.com
-ship.today
 
 // LCube - Professional hosting e.K. : https://www.lcube-webhosting.de
 // Submitted by Lars Laehn <info@lcube.de>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:** security@laravel.com & abuse@ship.today, abuse@shiptoday.app, and abuse@shiptoday.build
* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: [https://ship.today/abuse](https://ship.today/abuse)

This link is shown in the footer of each page. shiptoday.app and shiptoday.build redirect to ship.today so there's one central location to report abuse.

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization
Laravel the company authors one of the most popular web application frameworks in the world. We are adding these new domains to allow users to host their websites on subdomain at the chosen domains, where currently only *.on-forge.com is available.

I'm an Engineering Team Lead at Laravel and am building this functionality.

See [forge.laravel.com](https://forge.laravel.com/).

**Organization Website:**
[https://laravel.com](https://laravel.com)

## Reason for PSL Inclusion
Laravel provides managed hosting for web applications under subdomains.

- Cookie security: Without inclusion in the PSL, browsers may treat domains as a single-origin domain, potentially allowing cookies to be shared between different user subdomains. This presents a security risk, as one user’s site could access another user’s cookies. Inclusion in the PSL ensures that each subdomain is treated as a separate site, preventing cross-user cookie access.
- Browser and Platform Compatibility: Many platforms and services (e.g., Chrome, Firefox, Let’s Encrypt, Cloudflare) use the PSL to define domain boundaries. Listing our domains in the PSL ensures compatibility with modern security policies.

Previous PRs: #2381  #2523 

**Number of users this request is being made to serve:**
- Laravel Forge - 10, 000+ across the various domains

## DNS Verification

```shell
❯ dig +short TXT _psl.shiptoday.app
"https://github.com/publicsuffix/list/pull/2753"

❯ dig +short TXT _psl.shiptoday.build
"https://github.com/publicsuffix/list/pull/2753"
```

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.shiptoday.app
"https://github.com/publicsuffix/list/pull/2753"
```

```
dig +short TXT _psl.shiptoday.build
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
