### PR TITLE
removing no longer in use joyent subdomain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14283,7 +14283,6 @@ jouwweb.site
 
 // Joyent : https://www.joyent.com/
 // Submitted by Brian Bennett <brian.bennett@joyent.com>
-*.cns.joyent.com
 *.triton.zone
 
 // JS.ORG : http://dns.js.org


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

* [X] Description of Organization: Joyent no longer owns the Triton IP, sold it to MNX.io, and the cns.joyent.com subdomain is no longer in use
* [X] Robust Reason for PSL Inclusion: since the `cns.joyent.com` subdomain is no longer in use and not served by our DNS servers any longer, I am removing it from the list
* [X] DNS verification via dig 
    ```
    2026.01.27.09:47:13 ~/gits/joyent/list 🂁 dig +short @8.8.8.8 cns.joyent.com ANY
    2026.01.27.09:47:17 ~/gits/joyent/list 🂁
    ```
* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).  - NA
* [X ] This request was _not_ submitted with the objective of working around other third-party limits.
* [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.  - NOTE the user at the email address in the Joyent section is no longer employed at Joyent.  Additionally the names still in this section are part of a product that is no longer a Joyent project, and has been sold to MNX.io which I believe itself has been sold to Parler and reorganized under the edgecast entity.  It might be entirely more appropriate to drop this section entirely and then for someone from that org to PR in a new entry from their org.
 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting. - no change on sorting
 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. - the original PR was not done this way, the user inbox which was used no longer exists, and there is nobody at Joyent to contact about  `triton.zone` as that domain was transferred as part of the Triton product sale to MNX.
* [ ] Abuse contact information (email or web form) is available and easily accessible.
* [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
* [x] Description of Organization
Joyent is a part of the Samsung family of companies, and no longer owns or contributes to the Triton product for which this entry was originally made.

I Michael Hicks ( @numericillustration ) am a Joyent employee and seek only to remove now dead subdomains from this list that I came across in an old PR link from an old ticket.

**Organization Website:**
Joyent.com

## Reason for PSL Inclusion
The original PR was https://github.com/publicsuffix/list/pull/266
which listed "Add namespaces for Joyent's Triton Container Name Service." as the reason.

You may want to contact @danmcd  or @nshalman for a current custodian of the Triton CNS service which is still active

## DNS Verification

```
2026.01.05.16:27:46 ~ 🂁 dig +short triton.zone SOA
soa.tritondc.name. dns.mnx.io. 169 3600 600 604800 60
2026.01.06.09:31:57 ~ 🂁 dig +short triton.zone NS
ns1.tritondc.name.
ns2.tritondc.name.
```
