### PR TITLE
REMOVE 12chars from private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11270,12 +11270,6 @@ poznan.pl
 wroc.pl
 zakopane.pl
 
-// 12CHARS : https://12chars.com
-// Submitted by Kenny Niehage <psl@12chars.com>
-12chars.dev
-12chars.it
-12chars.pro
-
 // 1GB LLC : https://www.1gb.ua/
 // Submitted by 1GB LLC <noc@1gb.com.ua>
 cc.ua


### PR DESCRIPTION
**Original PR**

* https://github.com/publicsuffix/list/pull/1915

**Affected domains**

* `12chars.dev`
* `12chars.it`
* `12chars.pro`

**Details**

* We are rebranding and switching to `__Host-` prefixes for cookie security.
* The `_psl` TXT records have already been removed.
* Therefore the domains can be removed from the PSL.


Thanks a lot for your hard work. 🙏