### PR TITLE
Add misabilirridlo.sch.id to Private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16258,17 +16258,19 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
-// MIS Sabilirridlo : https://misabilirridlo.sch.id
-// Submitted by Ilham (MIS SABILIRRIDLO) <admin@misabilirridlo.sch.id>
-alumni.misabilirridlo.sch.id
-canva.misabilirridlo.sch.id
-domain.misabilirridlo.sch.id
-guru.misabilirridlo.sch.id
-id.misabilirridlo.sch.id
-info.misabilirridlo.sch.id
-murid.misabilirridlo.sch.id
-my.misabilirridlo.sch.id
-org.misabilirridlo.sch.id
-project.misabilirridlo.sch.id
+// MISR : https://misr.my.id
+// Submitted by Ilham <admin@misabilirridlo.sch.id>
+misr.my.id
+alumni.misr.my.id
+blog.misr.my.id
+canva.misr.my.id
+dev.misr.my.id
+domain.misr.my.id
+guru.misr.my.id
+id.misr.my.id
+info.misr.my.id
+mrd.misr.my.id
+org.misr.my.id
+project.misr.my.id
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The Guidelines were carefully read and understood, and this request conforms to them.
* [x] The submission follows the guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored.

**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL: https://misabilirridlo.sch.id/

---

* [x] Yes, I understand. I could break my organization's website cookies and cause other issues. Proceed anyways.

---

## Description of Organization
MIS Sabilirridlo is an Islamic Elementary School (Madrasah Ibtidaiyah) located in Jombang, East Java, Indonesia. I am Ilham, acting as the system administrator for the school's digital infrastructure. We are developing several internal platforms for our students and staff.

**Organization Website:**
https://misabilirridlo.sch.id

## Reason for PSL Inclusion
We are requesting to add `misabilirridlo.sch.id` to the Private Section to ensure proper cookie isolation and security boundaries between our subdomains (e.g., for our PPDB and LMS services). This is crucial to prevent session leakage between different educational tools we host. We confirm that the domain registration is secured for more than 2 years.

**Number of users this request is being made to serve:**
Approximately 600 users (Students, Teachers, and Staff).

## DNS Verification
dig +short TXT _psl.misabilirridlo.sch.id "[https://github.com/publicsuffix/list/pull/2767](https://www.google.com/search?q=https://github.com/publicsuffix/list/pull/2767)"