### PR TITLE
Added sryze.cc to the list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14058,10 +14058,6 @@ wpmucdn.com
 tempurl.host
 wpmudev.host
 
-// Stackryze : https://stackryze.com
-// Submitted by Sudheer Bhuvana <security@stackryze.com>
-indevs.in
-
 // Individual Network Berlin e.V. : https://www.in-berlin.de/
 // Submitted by Christian Seitz <chris@in-berlin.de>
 dyn-berlin.de
@@ -15668,6 +15664,10 @@ stackit.gg
 stackit.rocks
 stackit.run
 stackit.zone
+
+// Stackryze : https://stackryze.com
+// Submitted by Sudheer Bhuvana <security@stackryze.com>
+indevs.in
 
 // Staclar : https://staclar.com
 // Submitted by Q Misell <q@staclar.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15728,6 +15728,7 @@ stackit.zone
 // Stackryze : https://stackryze.com
 // Submitted by Sudheer Bhuvana <security@stackryze.com>
 indevs.in
+sryze.cc
 
 // Staclar : https://staclar.com
 // Submitted by Q Misell <q@staclar.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14058,8 +14058,8 @@ wpmucdn.com
 tempurl.host
 wpmudev.host
 
-// Indevs : https://indevs.in
-// Submitted by Sudheer Bhuvana <security@admin.indevs.in>
+// Stackryze : https://stackryze.com
+// Submitted by Sudheer Bhuvana <security@stackryze.com>
 indevs.in
 
 // Individual Network Berlin e.V. : https://www.in-berlin.de/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15727,8 +15727,8 @@ stackit.zone
 
 // Stackryze : https://stackryze.com
 // Submitted by Sudheer Bhuvana <security@stackryze.com>
-indevs.in
 sryze.cc
+indevs.in
 
 // Staclar : https://staclar.com
 // Submitted by Q Misell <q@staclar.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook — None.
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:  
  mailto:reportabuse@stackryze.com , https://domain.stackryze.com/abuse
  

---

(Link: https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion)

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

**Organization Website:** https://stackryze.com, https://domain.stackryze.com

Stackryze Domains is a community domain service that provides free subdomains under "sryze.cc" to developers, creators, and open-source projects. Stackryze already manages "indevs.in", which is listed in the Public Suffix List, and `sryze.cc` follows the same operating model.



---

## Reason for PSL Inclusion

`sryze.cc` hosts multiple unrelated users on separate delegated subdomains. Each subdomain is independently administered and represents a separate entity.
We require PSL status primarily for cookie separation, since each subdomain is owned and operated by a different party. This prevents security risks between unrelated users. Proper URL highlighting and browser origin handling is also beneficial for our users.

We already operate another PSL-listed namespace (indevs.in), which is actively maintained and moderated.

previously authored pr: https://github.com/publicsuffix/list/pull/2730

**Number of users this request is being made to serve:**  
  13738 users registered 30640 domains. 

---


## DNS Verification via dig

    dig +short TXT _psl.sryze.cc
    "https://github.com/publicsuffix/list/pull/2777"