### PR TITLE
add `algo.xyz` to PRIVATE

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15973,6 +15973,10 @@ tunnelmole.net
 // Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
 tuxfamily.org
 
+// TxnLab Inc. : https://txnlab.dev
+// Submitted by TxnLab admin <security@txnlab.dev>
+algo.xyz
+
 // Typedream : https://typedream.com
 // Submitted by Putri Karunia <putri@typedream.com>
 typedream.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [X] Description of Organization
* [X] Robust Reason for PSL Inclusion
* [X] DNS verification via dig

* [X] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [X] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [X] This request was _not_ submitted with the objective of working around other third-party limits.

 * [X] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [X] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [X] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [X] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [X] Abuse contact information (email or web form) is available and easily accessible.

Each NFD's profile page has a 'Report' option where issues can be reported.
ie: https://app.nf.domains/report/xxx.algo

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [X] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

TxnLab Inc. builds [NFDomains](https://app.nf.domains) (NFDs), a blockchain-based naming and identity system on the Algorand blockchain. Users mint names (e.g., `nfdomains.algo`) which serve as on-chain identities with associated metadata, including DNS records. TxnLab operates a DNS service — hosted alongside [Nodely](https://nodely.io), a key infrastructure provider for the Algorand ecosystem — that exposes DNS records configured by individual NFD owners via `*.algo.xyz`.

Each NFD owner independently controls their own DNS records (A, AAAA, CNAME, MX, TXT, SRV, CAA, etc.). TxnLab has no control over what individual NFD holders configure. `foo.algo.xyz` and `bar.algo.xyz` are independent, privately-controlled domains with separate owners. This is architecturally identical to other services in the PRIVATE section such as `herokuapp.com`, `vercel.app`, and `pages.dev`.

I am the founder of TxnLab Inc. and administrator of the algo.xyz zone.

**Organization Website:**
https://app.nf.domains
https://txnlab.dev

## Reason for PSL Inclusion

NFDomains functions as a domain registry — each NFD holder gets an independent subdomain under `algo.xyz` with full control over their DNS records. Without PSL inclusion, these subdomains are not recognized as independent registrable domains by services that consume the PSL. This causes three categories of problems:

**1. Hosting platform verification failures.** Services like Vercel require domain ownership verification. NFD holders are asked to prove ownership of `algo.xyz` itself, which they cannot and should not do — they own `theirname.algo.xyz`, not the apex. Vercel Support has directly recommended PSL inclusion as the appropriate solution for this architecture.

**2. Cookie isolation.** Without PSL inclusion, any NFD holder could set cookies scoped to `.algo.xyz`, readable by all other NFD holders' domains. PSL inclusion provides proper cookie boundaries so that `foo.algo.xyz` and `bar.algo.xyz` are fully isolated from each other, as they should be.

**3. Certificate scoping.** PSL inclusion enables proper per-subdomain TLS certificate handling by certificate authorities.

Regarding third-party limits: Vercel's domain verification behavior is what surfaced this gap, but Vercel Support explicitly directed us to submit this PR as the correct solution for our architecture. We are not attempting to circumvent any restriction — this is the mechanism Vercel (and the broader ecosystem) intends for services like ours.

Documentation on NFD DNS configuration: https://docs.nf.domains/platform/manage/native-dns-for-nfds

**Number of users this request is being made to serve:**
 over 69K potential (See current minted number: https://app.nf.domains/analytics)

## DNS Verification

```
dig +short TXT _psl.algo.xyz
"https://github.com/publicsuffix/list/pull/2782"
```