### PR TITLE
adding new domains for beefree.io products

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12455,7 +12455,7 @@ beagleboard.io
 bearblog.dev
 
 // Bee Content Design : https://beefree.io
-// Submitted by Mauro Giannandrea <mauro.giannandrea@beefree.io>
+// Submitted by Mauro Giannandrea <dev@beefree.io>
 beefreesdkmedia.net
 sdkhosting.net
 sdkmedia.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
N/A

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
dev@beefree.io

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.
URL where abuse contact and other information is: [beefree.io/abuse](https://beefree.io/abuse)
Diret email is: [abuse@beefree.io](mailto:abuse@beefree.io)

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization
**Bee Content Design** (operating as **Beefree**) provides advanced content creation tools, specifically drag-and-drop HTML editors for email and page design. We serve two primary segments:

- **Beefree App:** A B2C platform for end-users to design and export emails.
- **Beefree SDK:** A B2B solution allowing developers to embed our editor into their own SaaS applications via SDK and API integrations.

Our infrastructure serves over 12 PB of content monthly, supporting millions of end-users who host assets and digital content across our distributed network.

## Robust Reason for PSL Inclusion
We are requesting the addition of sdkhosting.net, sdkmedia.net, and beefreesdkmedia.net to the Private section to ensure proper security boundaries between our customers.
- **sdkhosting.net:** Used for hosting HTML and PDF documents generated by paying customers of the Beefree SDK.
- **sdkmedia.net:** Dedicated to image and asset storage for paying Beefree SDK customers.
- **beefreesdkmedia.net:** Used for asset hosting for our free-tier users.

Each of our thousands of customers is assigned a unique third-level subdomain (e.g., customer-id.sdkhosting.net). These subdomains host user-generated content. Without PSL inclusion:
- **Cookie Privacy:** One customer's subdomain could potentially set cookies reachable by another customer's subdomain.
- **Supercookies:** We need to prevent the setting of "wildcard" cookies at the second-level domain.
- **Browser Security:** Modern browsers rely on the PSL to determine the "registrable domain" for privacy features and storage partitioning.
- **Proper reputation:** Some Blacklists base on PSL the decision to block only the third level domains instead of the entire second level.

Given the volume of content and the multi-tenant nature of our platform, these domains function as public suffixes where the user-controlled portion begins at the third level.

Beefree SDK is primarily a B2B product, so it is difficult to calculate the number of end users who can use these domains.
However, we can calculate the number of our users, which is almost equal to the number of subdomains that will be created (one per user).
We have approximately 5,500 users and subdomains and a growth rate of about 2% per year.

<img width="1013" height="387" alt="Screenshot 2026-02-18 at 14 42 38" src="https://github.com/user-attachments/assets/1659c8f2-eae7-45b8-ac0f-6a05fc6f80bf" />

## DNS Verification

```
$ dig +short TXT _psl.sdkmedia.net          
"https://github.com/publicsuffix/list/pull/2783"
```
```
$ dig +short TXT _psl.beefreesdkmedia.net
"https://github.com/publicsuffix/list/pull/2783"
```
```
$ dig +short TXT _psl.sdkhosting.net     
"https://github.com/publicsuffix/list/pull/2783"
```


