### PR TITLE
Add aiimp.jp

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14065,6 +14065,9 @@ iliadboxos.it
 imagine.diy
 imagine-proxy.work
 
+// imp Inc. : https://imp-ai.jp/
+aiimp.jp
+
 // Incsub, LLC : https://incsub.com/
 // Submitted by Aaron Edwards <sysadmins@incsub.com>
 smushcdn.com


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

* [x] We are listing *any* third-party limits that we seek to work around in our rationale... (We are NOT working around limits).
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section...
* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  * Web Site: https://imp-ai.co.jp/
  * E-mail: contact@imp-ai.jp

---

* [x] *Yes, I understand*. I could break my organization's website cookies... *Proceed anyways*.

---

## Description of Organization

**Organization Website:**
https://imp-ai.co.jp/

We are a technology service provider based in Japan. Our organization operates a multi-tenant SaaS platform that allows corporate clients to deploy and manage their own AI-driven applications. We provide unique subdomains (e.g., client-a.aiimp.jp) to each customer, hosting their distinct services while we manage the core infrastructure and security.

## Reason for PSL Inclusion

We provide subdomains to third-party organizations (our clients) to host their independent web applications. Currently, because "aiimp.jp" is not on the Public Suffix List, cookies set by one client's subdomain can be accessed or overwritten by another client's subdomain.

We are requesting inclusion in the PRIVATE section to enforce security boundaries (Same-Origin Policy) between these subdomains. This is essential to prevent cross-site scripting vulnerabilities and to ensure cookie isolation for our customers' users.

We confirm that the domain "aiimp.jp" is registered for more than two years, and we intend to maintain this service indefinitely.

**Number of users this request is being made to serve:**
We currently serve approximately 50 corporate clients.

## DNS Verification
dig +short TXT _psl.aiimp.jp
"https://github.com/publicsuffix/list/pull/XXXX"