### PR TITLE
Add `on.expo.app`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13439,9 +13439,11 @@ relay.evervault.app
 relay.evervault.dev
 
 // Expo : https://expo.dev/
-// Submitted by James Ide <psl@expo.dev>
+// Submitted by Phil Pluckthun <psl@expo.dev>
 expo.app
+on.expo.app
 staging.expo.app
+on.staging.expo.app
 
 // Fabrica Technologies, Inc. : https://www.fabrica.dev/
 // Submitted by Eric Jiang <eric@fabrica.dev>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  * URL where abuse contact or abuse reporting form can be found: https://expo.dev/support-options

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization

Expo provides a framework and services for software application development, and one such service is server hosting. Server hosting is being extended with a feature that allows development sandboxes to spin up temporarily on per-user reserved subdomains for testing and proxying to simulate live service. Each of these needs their own subdomain that is isolated from other developers' subdomains and the rest of the hosting subdomains. I am submitting this request as an engineer at Expo building this functionality, following on from #1975.

**Organization Website:**
https://expo.dev

## Reason for PSL Inclusion

The intent is for subdomains on `*.on.expo.app` of the development sandboxes on our hosting service to be isolated from each other, and isolated on a new subdomain separate from live services of our users at `*.expo.app`, as an extension of existing service.

This submission includes a staging subdomain (`*.on.staging.expo.app`) for parity between staging and production. The staging subdomain is to internally test and validate behavior before making changes to the production service.

The domain name is registered for more than two years and will not expire before 2032. `on.expo.app` was previously reserved and not made available to be reserved by users.

**Number of users this request is being made to serve:** estimated to serve several thousands of individual developers.

## DNS Verification

```
dig +short TXT _psl.on.staging.expo.app
"https://github.com/publicsuffix/list/pull/2790"
```

```
dig +short TXT _psl.on.expo.app
"https://github.com/publicsuffix/list/pull/2790"
```