### PR TITLE
Add 9e.nz to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16217,6 +16217,10 @@ weeklylottery.org.uk
 wpenginepowered.com
 js.wpenginepowered.com
 
+// wu tong : https://yu.9e.nz
+// Submitted by wu tong <qfyyz3369@gmail.com>
+9e.nz
+
 // XenonCloud GbR : https://xenoncloud.net
 // Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>
 *.xenonconnect.de


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

* [ ] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the guidelines on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://yu.9e.nz/ and https://9e.nz/

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

I am an individual developer and the sole owner and operator of 9e.nz. My project provides a free subdomain distribution service to the public. As the maintainer, I manage the infrastructure, ensure the service remains reliable, and handle any abuse reports. Because I operate independently rather than as a corporation, I am using my primary administrative email address to monitor and respond to all PSL and security-related communications.

**Organization Website:**
https://yu.9e.nz/

## Reason for PSL Inclusion

The primary reason for requesting inclusion in the PSL is to ensure proper cookie isolation and strict security boundaries for my users. Since I provide subdomains (e.g., userA.9e.nz and userB.9e.nz) to mutually untrusted third parties, it is critical that browsers treat these subdomains as separate entities to prevent cross-site scripting (XSS), cross-domain cookie leakage, and other security vulnerabilities.

The domain 9e.nz has been registered for a long term and will maintain at least 2 years of registration remaining, as required, and I commit to keeping it in good standing. This request is strictly for user security and cookie isolation; it is not submitted to bypass any third-party rate limits.

**Number of users this request is being made to serve:**
Currently serving approximately 100+ users (growing estimate).

## DNS Verification

```text
dig +short TXT _psl.9e.nz
"https://github.com/publicsuffix/list/pull/2795"