### PR TITLE
removing mazeplay.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14561,10 +14561,6 @@ polyspace.com
 mayfirst.info
 mayfirst.org
 
-// Maze Play : https://www.mazeplay.com
-// Submitted by Adam Humpherys <adam@mws.dev>
-mazeplay.com
-
 // McHost : https://mchost.ru
 // Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
 mcdir.me


### PR DESCRIPTION
**Original PR**

* [Adding mazeplay.com #1253](https://github.com/publicsuffix/list/pull/1253)

**Affected Domains**

* `mazeplay.com`

**Details**

The platform that was utilizing the domains has been shuttered so the cookie security between subdomains no longer applies.

The `_psl` TXT record has already been removed.