### PR TITLE
Add dplooy.com to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12964,6 +12964,10 @@ de5.net
 // Submitted by Norbert Auler <mail@dnshome.de>
 dnshome.de
 
+// Dplooy : https://www.dplooy.com/
+// Submitted by Parash Dev <abuse@dplooy.com>
+dplooy.com
+
 // DotArai : https://www.dotarai.com/
 // Submitted by Atsadawat Netcharadsang <atsadawat@dotarai.co.th>
 online.th


### PR DESCRIPTION
### Checklist of required steps

* [ ] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - None. This submission is not intended to work around any third-party rate limits or restrictions.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.dplooy.com/abuse



 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.


## Description of Organization

**Organization Website:** https://www.dplooy.com

Dplooy is a web hosting platform that allows independent users to deploy static websites, landing pages, and portfolio sites. Each user's project is served on its own unique subdomain under dplooy.com (e.g., my-portfolio.dplooy.com). Users upload HTML, CSS, JavaScript, and image assets through the platform, and their sites become publicly accessible at their assigned subdomain.

I am Parash Panta, the founder and developer of Dplooy. I am submitting this request on behalf of the platform. My role covers all engineering, infrastructure, and domain administration.

Dplooy's subdomains serve content from independent, mutually-untrusting users. One user has no control or visibility over another user's subdomain or content. Users do not share authentication, sessions, cookies, or any data between subdomains.

## Reason for PSL Inclusion

**Number of users this request is being made to serve:** 500+ deployed projects and growing (current, not an estimate).

Dplooy assigns subdomains of dplooy.com to independent users who deploy their own static websites. These users are mutually untrusting — they have no relationship to each other and no access to each other's content or subdomains.

The primary reason for this submission is **Google Safe Browsing domain reputation isolation**. Without PSL inclusion, Google Safe Browsing treats all of *.dplooy.com as a single eTLD+1. When one user uploads abusive content and their subdomain gets flagged, Google escalates the flag to the entire dplooy.com domain. This causes every legitimate customer site to display a "Dangerous Site" red-screen warning in Chrome, Firefox, Safari, and Edge. We have already experienced this issue in production, resulting in all customer sites being blocked simultaneously.

A secondary benefit is **cookie isolation**. Without PSL inclusion, a malicious user at attacker.dplooy.com could set cookies scoped to .dplooy.com, which would be sent to every other user's subdomain. PSL inclusion prevents this by treating each subdomain as its own cookie boundary.

This submission is not intended to work around any third-party rate limits. We are not seeking to bypass Let's Encrypt, Cloudflare, or any other vendor's restrictions. The sole purpose is security isolation between mutually-untrusting users sharing a common domain suffix.

**Abuse prevention measures in place:**
- Automated content scanning at upload time blocks phishing pages, malware, credential harvesting forms, and brand impersonation before content goes live.
- All free-tier hosted sites display a platform badge with a "Report Abuse" button linking directly to our abuse reporting page.
- Dedicated abuse reporting page at https://www.dplooy.com/abuse with `abuse@dplooy.com` actively monitored (24-hour acknowledgment SLA).
- The contact form at https://www.dplooy.com/contact includes a "Report Abuse" subject category.

The domain dplooy.com is registered through Vercel and expires **May 30, 2029**, providing over 3 years of remaining registration.

## DNS Verification

The `_psl` TXT record will be added to `_psl.dplooy.com` once this PR number is assigned. This section will be updated with dig output after the record is in place.

```
dig +short TXT _psl.dplooy.com
"https://github.com/publicsuffix/list/pull/2798"
```
