### PR TITLE
Add 638966.xyz as a public suffix for public subdomain distribution

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -9,6 +9,12 @@
 
 // ===BEGIN ICANN DOMAINS===
 
+// 638966.xyz - https://638966.xyz
+// Public suffix for free public subdomain distribution service
+// Submitted by: WinVistaTD <jswd_1003@qq.com>
+638966.xyz
+*.638966.xyz
+
 // ac : http://nic.ac/rules.htm
 ac
 com.ac
@@ -16290,10 +16296,5 @@ nett.to
 // ZoneABC : https://zoneabc.net
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
-// 638966.xyz - https://638966.xyz
-// Submitted by: Your Name <your-email@example.com>
-// Public suffix to provide free subdomain hosting for users.
-638966.xyz
-*.638966.xyz
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
### Description of organization:
We operate a free public subdomain hosting service at https://638966.xyz, which is publicly accessible and allows third-party users to register custom subdomains under `*.638966.xyz` for personal, non-commercial, and legitimate commercial use. Our service provides stable DNS resolution support and complies with global internet security standards.

### Purpose of this request:
To ensure that browsers, certificate authorities, and services like Cloudflare treat `*.638966.xyz` as independent "root domains". This enables core features for our users: direct NS record management, proper cookie isolation, and seamless integration with CDN/services that require root domain-level configuration.

### Relevant website URL:
https://638966.xyz

### Subdomain registration page:
https://638966.xyz/register

### Privacy policy URL:
https://638966.xyz/privacy

### Terms of service URL:
https://638966.xyz/tos

### Confirmation:
- [x] I have read and understood the [submission requirements](https://github.com/publicsuffix/list/wiki/Guidelines).
- [x] I confirm that my service is publicly accessible and allows third-party registrations.
- [x] I confirm that I will not use the public suffix list to circumvent security policies or for malicious purposes.
- [x] I will maintain valid contact information and respond promptly to any inquiries from the PSL maintainers.
- [x] My service has clear privacy policies and terms of service that govern subdomain usage.