### PR TITLE
 Add 638966.xyz as public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -18,6 +18,12 @@ mil.ac
 net.ac
 org.ac
 
+// 638966.xyz - https://638966.xyz
+// Public suffix for free public subdomain distribution service
+// Submitted by: WinVistaTD <jswd_1003@qq.com>
+638966.xyz
+*.638966.xyz
+
 // ad : https://www.iana.org/domains/root/db/ad.html
 // Confirmed by Amadeu Abril i Abril (CORE) <amadeu.abril@corenic.org> 2024-11-17
 ad


### PR DESCRIPTION
### Description of organization:
We operate a free public subdomain hosting service at https://nic.638966.xyz, which is publicly accessible and allows third-party users to register custom subdomains under `*.638966.xyz` for personal, non-commercial, and legitimate commercial use. Our service provides stable DNS resolution support and complies with global internet security standards.

### Relevant website URL:
https://nic.638966.xyz

### Subdomain registration page:
https://nic.638966.xyz/login?act=reg

### Privacy policy URL:
https://nic.638966.xyz/tos/privacy.html

### Terms of service URL:
https://nic.638966.xyz/tos/tos.html

### Confirmation:
- [x] I have read and understood the [submission requirements](https://github.com/publicsuffix/list/wiki/Guidelines).
- [x] I confirm that my service is publicly accessible and allows third-party registrations.
- [x] I confirm that I will not use the public suffix list to circumvent security policies or for malicious purposes.
- [x] I will maintain valid contact information and respond promptly to any inquiries from the PSL maintainers.
- [x] My service has clear privacy policies and terms of service that govern subdomain usage.

Submitted by: WinVistaTD <jswd_1003@qq.com>
