### PR TITLE
Add siteazy.com to the Private Domain section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15625,6 +15625,10 @@ applinzi.com
 sinaapp.com
 vipsinaapp.com
 
+// Siteazy : https://www.siteazy.com/
+// Submitted by Yuma Ollivier <yuma@siteazy.com>
+*.siteazy.com
+
 // Siteleaf : https://www.siteleaf.com/
 // Submitted by Skylar Challand <support@siteleaf.com>
 siteleaf.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain
  at least two years remaining on registration, and we shall keep the
  `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] This request was _not_ submitted with the objective of working
  around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to
  maintain the domains within their section. This includes removing
  names which are no longer used, retaining the _psl DNS entry, and
  responding to e-mails to the supplied address. Failure to maintain
  entries may result in removal of individual entries or the entire
  section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines)
  were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the
  [guidelines](https://github.com/publicsuffix/list/wiki/Format)
  on formatting and sorting.

* [x] A role-based email address has been used and this inbox is
  actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available
  and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  https://siteazy.com/mentions-legales

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [x] *Yes, I understand*. I could break my organization's website
  cookies and cause other issues, and the rollback timing is
  acceptable. *Proceed anyways*.

---

## Description of Organization

**Organization Website:** https://siteazy.com

I am the founder and sole developer of Siteazy, a French no-code SaaS
platform that allows independent merchants — artisans, creators, and
small business owners — to create and publish their own complete online
stores without any technical knowledge.

The platform provides a visual store builder with pre-built sections
(hero, product catalog, about page, etc.) that merchants configure
through a dashboard. Once published, each merchant's store is
automatically served on a dedicated subdomain in the form
`<merchant-slug>.siteazy.com`. The main domain `siteazy.com` is
exclusively used for the platform's own marketing website, dashboard,
and documentation.

The target audience is non-technical independent sellers in France who
need an affordable and simple alternative to expensive agencies or
complex platforms. Merchants own their content entirely; Siteazy only
provides the infrastructure and tooling.

## Reason for PSL Inclusion

Each subdomain under `*.siteazy.com` is an independent storefront
belonging to a distinct third-party merchant with no editorial or
business affiliation to Siteazy beyond infrastructure hosting. The
content of each subdomain — products, descriptions, images, branding —
is entirely created, owned, and managed by the respective merchant.

Without PSL inclusion, browsers and search engines treat all
`*.siteazy.com` subdomains as part of the same origin as `siteazy.com`.
This causes two concrete problems: first, cookies set on one merchant's
subdomain can be read across other merchant subdomains, which is a
tenant isolation security concern. Second, Google associates merchant
storefronts with the Siteazy brand domain, causing unrelated merchant
pages to appear as sitelinks in branded search results for "Siteazy",
which misleads end users.

This submission follows the same established pattern as other
multi-tenant SaaS platforms already listed in the PSL, such as
`vercel.app`, `netlify.app`, and `github.io`, all of which assign
independent subdomains to distinct third-party users or organizations.

The domain `siteazy.com` is registered with more than two years
remaining and will be maintained well beyond that. The `_psl` TXT
record will be kept in place for as long as the entry remains in the
PSL.

This request is not made to work around any third-party rate limits
(Cloudflare, Let's Encrypt, Apple, etc.).

**Number of users this request is being made to serve:**
Approximately 50 active merchant stores currently, with ongoing
growth. Each merchant independently serves their own customer base
via their dedicated subdomain. (Current figure, not an estimate.)

## DNS Verification

Once this PR is open, the following TXT record will be added and
maintained at `_psl.siteazy.com`:

dig +short TXT _psl.siteazy.com
"https://github.com/publicsuffix/list/pull/2803"