### PR TITLE
Add 638966.xyz as a public suffix

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -22,6 +22,10 @@ org.ac
 // Confirmed by Amadeu Abril i Abril (CORE) <amadeu.abril@corenic.org> 2024-11-17
 ad
 
+// 638966.xyz - Free public subdomain hosting service (https://nic.638966.xyz/) - WinVistaTD
+// Open subdomain registration for developers, with published Terms of Service and Privacy Policy
+638966.xyz
+
 // ae : https://www.iana.org/domains/root/db/ae.html
 ae
 ac.ae


### PR DESCRIPTION
Add 638966.xyz - open public subdomain registration for developers at https://nic.638966.xyz/
Complies with PSL format and sorting guidelines

---

### Description of Organization
I am WinVistaTD, the individual operator of nic.638966.xyz, a non-profit free public subdomain hosting service. The service provides open registration for `*.638966.xyz` subdomains to developers, students, and technical enthusiasts, with published Terms of Service (https://nic.638966.xyz/tos/tos.html) and Privacy Policy (https://nic.638966.xyz/tos/privacy.html).

### Reason for PSL Inclusion
638966.xyz is a suffix under which Internet users can directly register names, as defined by the PSL. Adding it to the PSL will prevent cross-site supercookie leakage for users of these subdomains, protecting browser privacy and security, which aligns with the core mission of the PSL project.

### Checklist of required steps
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PR has at least two years of remaining registration
* [x] I affirm this request is not submitted to work around third-party limits (e.g., Cloudflare, Adsense)
* [x] I have read and understood the PSL guidelines (https://github.com/publicsuffix/list/wiki/Guidelines)
* [x] This submission conforms to the PSL format and sorting rules
* [x] I will maintain the domain entry and respond to PSL communications via jswd_1003@qq.com
* [x] Abuse contact information is available at https://nic.638966.xyz/ (abuse reports can be sent to jswd_1003@qq.com)
