### PR TITLE
Add exe.xyz

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13450,6 +13450,10 @@ us-4.evennode.com
 relay.evervault.app
 relay.evervault.dev
 
+// Exe : https://exe.dev
+// Submitted by Josh Bleecher Snyder <security@exe.dev>
+exe.xyz
+
 // Expo : https://expo.dev/
 // Submitted by Phil Pluckthun <psl@expo.dev>
 expo.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - None. This submission is not motivated by any third-party rate limits or restrictions.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://exe.dev/security

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

**Organization Website:** https://exe.dev

exe.dev is a cloud development platform that provides persistent Linux VMs. Each VM is assigned a unique subdomain under `exe.xyz` (e.g., `myvm.exe.xyz`), accessible over SSH and HTTPS. VMs are operated by independent, mutually-untrusting users who run their own applications on their subdomains.

I'm Josh Bleecher Snyder (josh@exe.dev), co-founder and CTO at exe. I co-manage the domain infrastructure for `exe.xyz`.

## Reason for PSL Inclusion

Each `*.exe.xyz` subdomain is operated by a different, independent user. PSL inclusion is requested for defense in depth for `.exe.xyz` cookies, and for browser-level isolation that our proxy cannot provide. This includes storage partitioning (localStorage, IndexedDB), `document.domain` restrictions, same-site cookie semantics, and certificate scoping.

`exe.xyz` is registered through 2030-12-12 (4+ years remaining). No prior issues or PRs related to this submission.

**Number of users this request is being made to serve:** > 10k (current)

## DNS Verification

```
dig +short TXT _psl.exe.xyz
"https://github.com/publicsuffix/list/pull/2810"
```

