### PR TITLE
Add files via upload

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16297,4 +16297,10 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// Mi ikun : https://9936799.xyz
+// Submitted by Mi ikun <dksnsnbsjsnsn@outlook.com>
+9936799.xyz
+*.9936799.xyz
+
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
### Description
Add `9936799.xyz` to the private domains section for subdomain isolation.

This domain is used to provide isolated subdomains to end-users, ensuring that cookies and storage are not shared between different user subdomains.

### Verification
DNS TXT verification will be added at `_psl.9936799.xyz` after PR is created.

### Contact
Owner: Mi ikun
Email: dksnsnbsjsnsn@outlook.com
