### PR TITLE
Add claude.app and livepreview.claude.app (Anthropic)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12337,6 +12337,11 @@ eero-stage.online
 // Submitted by Sander Hoentjen <systeembeheer@antagonist.nl>
 antagonist.cloud
 
+// Anthropic : https://www.anthropic.com/
+// Submitted by Sid Bidasaria <sbidasaria@anthropic.com>
+claude.app
+livepreview.claude.app
+
 // Apigee : https://apigee.com/
 // Submitted by Apigee Security Team <security@apigee.com>
 apigee.io


### PR DESCRIPTION
Anthropic hosts independent, user-controlled sites under these suffixes:

- `claude.app`
- `livepreview.claude.app`

Each subdomain serves content controlled by a distinct third party. Listing these as public suffixes ensures correct cookie scoping and origin isolation between independently-controlled sites.

## Submission checklist

- [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Guidelines)
- [x] The domains are registered and under Anthropic's control
- [x] Sorted alphabetically in the PRIVATE section (between Antagonist and Apigee)
- [x] `_psl` TXT records will be published pointing to this PR once the PR number is assigned — see verification commands below
- [x] Submitter email (`sbidasaria@anthropic.com`) is monitored and reachable

## DNS verification

TXT records pointing to this PR:

```
_psl.claude.app.              TXT  "https://github.com/publicsuffix/list/pull/2814"
_psl.livepreview.claude.app.  TXT  "https://github.com/publicsuffix/list/pull/2814"
```

Verify with:

```sh
dig +short TXT _psl.claude.app
dig +short TXT _psl.livepreview.claude.app
```

We commit to maintaining these records permanently per the PSL acceptance criteria.
