### PR TITLE
Add hostlocal.app, tunnelmy.app, tunneled.to, visitmy.app for Pangolin

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16297,4 +16297,11 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// Pangolin : https://pangolin.net
+// Submitted by Pangolin Team <security@pangolin.net>
+hostlocal.app
+tunnelmy.app
+visitmy.app
+tunneled.to
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

   The following third-party systems are relevant to our domains. Our **primary motivation is multi-tenant subdomain isolation and cookie security**, not circumvention of rate limits. We disclose these third-party interactions for full transparency:

   - **[Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)**: Pangolin Cloud automatically provisions TLS certificates for customer subdomains (e.g. `tenant.hostlocal.app`). PSL inclusion will allow Let's Encrypt to treat each customer subdomain as a distinct registrable domain for rate-limiting purposes. While this is a beneficial side-effect, it is not the primary motivation for this request; the primary motivation is browser-level cookie and storage isolation between mutually untrusting tenants. We have not contacted Let's Encrypt about rate-limit increases because our architecture currently relies on wildcard certificates at the base domain level, and we expect per-subdomain issuance to be a future need as our user base grows.

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!--
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  https://trust.pangolin.net/

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

   Note: None of the four domains listed (`hostlocal.app`, `tunnelmy.app`, `tunneled.to`, `visitmy.app`) are used as the primary website or application domain for Fossorial or Pangolin. Our primary web presence is `pangolin.net` and `fossorial.io`, neither of which is included in this submission. The four domains listed are used exclusively as subdomain namespaces for Pangolin Cloud customer resources, so the cookie/certificate behavioral change is the desired outcome.

---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization

**Organization Website:** https://pangolin.net

Fossorial is the company behind Pangolin, an open-source, identity-based remote access platform built on WireGuard. Pangolin combines reverse-proxy and VPN capabilities into a single platform, enabling zero-trust, granular access control for web applications and private network resources such as databases and SSH servers. The project is hosted at https://github.com/fosrl/pangolin and has accumulated over 19,000 GitHub stars, with more than one million deployments worldwide across self-hosted and cloud configurations.

Pangolin operates in two deployment modes. In the self-hosted mode, users run the entire Pangolin stack on their own infrastructure and supply their own domain names. In the Pangolin Cloud mode, Fossorial operates a hosted control plane and provides users with pre-configured subdomain namespaces under our owned domains so that customers can expose resources without needing to register or configure their own DNS. The domains listed in this PR (`hostlocal.app`, `tunnelmy.app`, `tunneled.to`, `visitmy.app`) are the base domains used for this second, cloud-hosted mode.

This PR is submitted by the Pangolin engineering team at Fossorial. We are the registrants and sole operators of all four domains. No third party submitted or suggested this request; we identified the need for PSL inclusion ourselves while building out the Pangolin Cloud multi-tenant architecture.

## Reason for PSL Inclusion

Pangolin Cloud is a multi-tenant service. When a user or organization signs up for Pangolin Cloud and does not supply their own custom domain, the platform automatically allocates a subdomain under one of our base domains — for example, `myorg.hostlocal.app` or `myorg.tunneled.to`. Each such subdomain is scoped to a single customer organization and is used to serve that customer's proxied web resources (internal dashboards, self-hosted apps, dev environments, etc.). Different customer organizations are mutually untrusting parties: organization A must not be able to read, set, or influence cookies or local storage belonging to organization B.

Without PSL inclusion, browsers treat all subdomains of `hostlocal.app` (for example) as sharing an effective top-level domain of `app`, meaning the registrable domain is `hostlocal.app`. This causes two concrete security problems:

1. **Cookie isolation failure**: A cookie set with `Domain=hostlocal.app` by a resource at `tenant-a.hostlocal.app` would be sent to `tenant-b.hostlocal.app` by the browser. Because Pangolin Cloud serves resources on behalf of many independent customer organizations, this cross-tenant cookie leakage is unacceptable.

2. **Same-site context conflation**: Browser same-site cookie policies treat all subdomains of a non-PSL domain as the same site. PSL inclusion ensures that `tenant-a.hostlocal.app` and `tenant-b.hostlocal.app` are treated as distinct sites.

With PSL inclusion, browsers will treat each of `hostlocal.app`, `tunnelmy.app`, `tunneled.to`, and `visitmy.app` as effective TLDs, making each customer's subdomain (e.g. `myorg.hostlocal.app`) the registrable domain from the browser's perspective. This correctly isolates cookies, storage, and same-site context between tenants.

All four domains are registered with more than two years remaining on their terms as of the date of this PR, and we commit to maintaining their registration with more than one year remaining for as long as they appear in the PSL. We will keep the `_psl` TXT validation records in place in each zone indefinitely.

There are no prior PSL issues or pull requests related to these domains or to Fossorial/Pangolin.

**Number of users this request is being made to serve:** Pangolin Cloud currently serves 517 sites on subdomains of the submitted domains. This figure reflects current cloud users only; it does not count the much larger self-hosted user base, which supplies its own domains and is unaffected by this submission.

## DNS Verification

Once this pull request is opened, `_psl` TXT records pointing to the PR URL will be added to each zone. The expected output is shown below.

```
dig +short TXT _psl.hostlocal.app
"https://github.com/publicsuffix/list/pull/2819"
```

```
dig +short TXT _psl.tunnelmy.app
"https://github.com/publicsuffix/list/pull/2819"
```

```
dig +short TXT _psl.visitmy.app
"https://github.com/publicsuffix/list/pull/2819"
```

```
dig +short TXT _psl.tunneled.to
"https://github.com/publicsuffix/list/pull/2819"
```

These records will remain in place for the lifetime of the PSL entries, as required.