### PR TITLE
Add *.paas.sandbox.gov.sg

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13920,6 +13920,10 @@ london.cloudapps.digital
 // Submitted by <domeinnaam@minaz.nl>
 gov.nl
 
+// Government Technology Agency of Singapore : https://www.tech.gov.sg/
+// Submitted by TOH Yong Cheng <toh_yong_cheng@tech.gov.sg>
+*.paas.sandbox.gov.sg
+
 // Grafana Labs : https://grafana.com/
 // Submitted by Platform Engineering <info@grafana.com>
 grafana-dev.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.tech.gov.sg/contact-us/

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

The Government Technology Agency (GovTech) is a statutory board under the Singapore Government responsible for building and operating the country's public sector digital infrastructure. GovTech develops and runs shared platforms used across government agencies for hosting, identity, payments, and other common services.

GovPaaS is a multi-tenant application hosting platform operated by GovTech, built on Northflank. It provides Singapore government agencies with managed infrastructure to deploy and run web applications and services. Each tenant workload receives a generated subdomain under `paas.sandbox.gov.sg` following the pattern `<service>.<cluster>.paas.sandbox.gov.sg`.

The submitter is a principal software engineer at GovTech working on the GovPaaS platform team. This submission is made on behalf of GovTech to support the platform's TLS certificate strategy and tenant isolation requirements.

**Organization Website:** https://www.tech.gov.sg/

## Reason for PSL Inclusion

This request addresses two problems that arise from operating a multi-tenant hosting platform where unrelated government agencies share subdomains under the same domain structure.

We are requesting `*.paas.sandbox.gov.sg` be added to the PRIVATE section of the PSL for cookie and origin isolation between tenant workloads.

GovPaaS is a multi-tenant platform. Each tenant workload (service, addon, database) across each environment (development, staging, production) is served on its own subdomain, for example `app--studio--vp8xdk8txjkp.fs5pmkc8jx.paas.sandbox.gov.sg`. Different government agencies are mutually untrusting parties: agency A must not be able to read, set, or influence cookies belonging to agency B.

Without PSL inclusion, browsers treat all subdomains under a cluster (e.g. `*.fs5pmkc8jx.paas.sandbox.gov.sg`) as the same site. A cookie set with `Domain=fs5pmkc8jx.paas.sandbox.gov.sg` by one tenant's workload would be sent to every other tenant's workload under that cluster. This enables cross-tenant cookie overwrites, session confusion, and supercookie tracking between unrelated government applications.

With PSL inclusion, browsers treat each cluster as a public suffix, making each workload's full hostname the registrable domain. This correctly isolates cookies, storage, and same-site context between tenants. This is the same use case as other multi-tenant platforms already listed in the PSL, such as Vercel (`vercel.app`), Heroku (`herokuapp.com`), and GitHub Pages (`github.io`).

Application-level mitigations like `__Host-` cookie prefixes exist but cannot be enforced across all tenant code and third-party libraries on a shared platform. PSL provides a browser-enforced guarantee.

As a secondary benefit, PSL inclusion corrects the domain boundary for Let's Encrypt rate limits, which are scoped per registered domain. This is not the motivation for this submission.

**Domain registration.** The domain `paas.sandbox.gov.sg` is a subdomain of `gov.sg`, which is a government reserved second-level domain under Singapore's `.sg` ccTLD. Whois records show `gov.sg` has a registry expiry date of `3000-01-01` with `serverDeleteProhibited`, `serverRenewProhibited`, and `serverTransferProhibited` status flags. The domain has well over 2 years of registration remaining at the time of this submission. GovTech commits to maintaining registration of `paas.sandbox.gov.sg` in good standing with more than 1 year of term remaining for as long as it is listed in the PSL.

There are no past issues or PRs related to this submission.

**Number of users this request is being made to serve:** Thousands of workloads across Singapore government agencies.

## DNS Verification

```
dig +short TXT _psl.paas.sandbox.gov.sg
"https://github.com/publicsuffix/list/pull/2820"
```
