### PR TITLE
Add pplx.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15088,7 +15088,7 @@ mypep.link
 
 // Perplexity AI : https://www.perplexity.ai/
 // Submitted by Alec Xiang <security@perplexity.ai>
-*.pplx.app
+pplx.app
 
 // Perspecta : https://perspecta.com/
 // Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - We are not seeking to work around any third-party limits.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: security@perplexity.ai

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

Note: `pplx.app` is a separate domain from our primary organization domain (`perplexity.ai`), so there is no risk to our organization's website cookies.

---

## Description of Organization

Perplexity AI is an AI company based in San Francisco that builds AI-powered search and answer products. I am a software engineer at Perplexity working on our platform infrastructure and agent products. Perplexity will operate a platform where users can build and deploy web applications, each served on isolated subdomains under `pplx.app`. These subdomains will host user-controlled content that is independent and mutually untrusting.

**Organization Website:** https://www.perplexity.ai/

## Reason for PSL Inclusion

We are requesting `pplx.app` be added to the PRIVATE section of the PSL for cookie and origin isolation between user-deployed applications.

Each user-deployed app is served on its own subdomain (e.g., `myapp.pplx.app`, `otherapp.pplx.app`). Without PSL inclusion, a cookie set on `.pplx.app` by one user's application would be readable by all other user applications under `pplx.app`. This is a security concern because these subdomains host content controlled by different, mutually untrusting parties.

Adding `pplx.app` to the PSL ensures that browsers treat each subdomain as a separate registrable domain, preventing cross-subdomain cookie attacks and enforcing proper origin isolation. This is the same use case as other platform providers already listed in the PSL, such as Vercel (`vercel.app`, see #2121), Heroku (`herokuapp.com`), and Cloudflare Pages (`pages.dev`).

The domain `pplx.app` is registered through August 14, 2029, and we commit to maintaining the registration in good standing with more than one year remaining at all times.

**Number of users this request is being made to serve:** Thousands.

## DNS Verification

```
dig +short TXT _psl.pplx.app
"https://github.com/publicsuffix/list/pull/2821"
```

The `_psl` TXT record is in place and will be maintained permanently.







