### PR TITLE
Add deployagent.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12879,16 +12879,16 @@ debian.net
 definima.io
 definima.net
 
-// DeployAgent : https://deployagent.com
-// Submitted by Danny <security@deployagent.com>
-deployagent.com
-
 // Deno Land Inc : https://deno.com/
 // Submitted by Luca Casonato <hostmaster@deno.com>
 deno.dev
 deno-staging.dev
 deno.net
 sandbox.deno.net
+
+// DeployAgent : https://deployagent.com
+// Submitted by Danny <security@deployagent.com>
+deployagent.com
 
 // deSEC : https://desec.io/
 // Submitted by Peter Thomassen <peter@desec.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12879,6 +12879,10 @@ debian.net
 definima.io
 definima.net
 
+// DeployAgent : https://deployagent.com
+// Submitted by Danny <security@deployagent.com>
+deployagent.com
+
 // Deno Land Inc : https://deno.com/
 // Submitted by Luca Casonato <hostmaster@deno.com>
 deno.dev


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

- [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  - None. This is not a workaround for any third-party limits.
- [x] This request was *not* submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
- [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully *read* and *understood*, and this request conforms to them.
- [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

- [x] Abuse contact information (email or web form) is available and easily accessible.

    Abuse contact: security@deployagent.com

---

- [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

DeployAgent (https://deployagent.com) is a web app deployment platform. Users upload a ZIP with their source code, we detect the framework, build it, and deploy it to `<project-id>.deployagent.com`. 

## Reason for PSL Inclusion

In March 2026, someone deployed phishing sites (fake Indonesian bank login pages) on a few of our subdomains. Google Safe Browsing then flagged the entire `deployagent.com` domain, which took down every legitimate user's app along with it. We need subdomains to be treated as separate sites so one bad tenant doesn't nuke everyone else.
Some live user apps for reference:
- https://w23p0qgou0o70fesobe85mff.deployagent.com
- https://c8z54oj7ck424q0d1kwnli8o.deployagent.com
- https://cml5z6p2l005ix4uowj5rio1f.deployagent.com

We use a wildcard cert (`*.deployagent.com`), so crt.sh won't show individual subdomain certs.

`deployagent.com` is registered through 2029-04-13 (3+ years remaining). We will maintain registration with >1 year remaining at all times.

**Number of users this request is being made to serve:** ~2,500 registered users with ~1,800 deployed applications, and growing.

## DNS Verification

```
dig +short TXT _psl.deployagent.com
"https://github.com/publicsuffix/list/pull/2830"
```