### PR TITLE
Remove PageXL entry from public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15069,10 +15069,6 @@ oy.lc
 // Submitted by Derek Myers <derek@pagefog.com>
 pgfog.com
 
-// PageXL : https://pagexl.com
-// Submitted by Yann Guichard <yann@pagexl.com>
-pagexl.com
-
 // Pantheon Systems, Inc. : https://pantheon.io/
 // Submitted by Gary Dylina <gary@pantheon.io>
 gotpantheon.com


### PR DESCRIPTION
## Removal request for pagexl.com

I am Yann Guichard, the original submitter of pagexl.com to the PSL (added in 2018) and the owner/registrant of the domain.

pagexl.com is a SaaS website builder that hosts user sites on subdomains (user.pagexl.com). The PSL listing was originally added for cookie isolation between user subdomains.

I am requesting removal because:

1. User sites hosted on pagexl.com subdomains are static HTML pages that do not set or use cookies
2. Modern browser cookie handling (SameSite=Lax default since 2020, partitioned cookies) provides sufficient isolation without PSL listing
3. The main pagexl.com application sets cookies scoped to the root domain only, which are not accessible by subdomains by default
4. The PSL listing prevents us from using standard DNS management services (Cloudflare treats pagexl.com as a TLD and refuses to manage it)

The entry to remove from the PRIVATE section:

```
// PageXL : https://pagexl.com
// Submitted by Yann Guichard <yann@pagexl.com>
pagexl.com
```

I understand the implications of removal and confirm this is intentional.