### PR TITLE
Add clevermind.com.br

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12645,6 +12645,10 @@ cleverapps.cc
 cleverapps.io
 cleverapps.tech
 
+// CleverMind : https://clevermind.com.br/
+// Submitted by Rodrigo <andradesempresarial@gmail.com>
+clevermind.com.br
+
 // ClickRising : https://clickrising.com/
 // Submitted by Umut Gumeli <infrastructure-publicsuffixlist@clickrising.com>
 clickrising.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

### Submitter affirms the following:

- [x] This request was *not* submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
- [x] The Guidelines were carefully *read* and *understood*, and this request conforms to them.
- [x] The submission follows the Guidelines on formatting and sorting.
- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

- [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found: https://www.clevermind.com.br/ (contact via the website footer / email `andradesempresarial@gmail.com`)

---

For PRIVATE section requests that are submitting entries for domains that match their organization's website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

- [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

We have audited the platform and confirmed that authentication uses JWT tokens stored in localStorage with the `Authorization` header (no cross-subdomain cookies are used). Static client sites under `*.clevermind.com.br` are served from Cloudflare R2 and do not share session state with the main application. PSL inclusion will therefore not break our existing services.

---

# Description of Organization

**Organization Website:** https://www.clevermind.com.br/

CleverMind is a Brazilian SaaS platform that provides two integrated products to small and medium businesses:

1. **Multichannel customer service automation** with AI agents over WhatsApp, Instagram, Messenger and Telegram (the public-facing product shown on our website).
2. **A website builder** that provisions a fully isolated static site for each customer under `*.clevermind.com.br` (or under their own custom domain when they choose to connect one). Each customer-published site is independent, with its own content, theme, tracking codes (Google Analytics, Meta Pixel, Google AdSense, etc.) and SEO identity.

We are submitting `clevermind.com.br` so that each customer subdomain (`customer.clevermind.com.br`) is treated as an independent site by browsers, search engines and ad networks — exactly as `*.blogspot.com`, `*.wordpress.com`, `*.vercel.app` and `*.pages.dev` are today.

# Reason for PSL Inclusion

There are three concrete, technical reasons we need PSL inclusion. None of them are workarounds for third-party limits — they are the standard reasons SaaS site-hosting platforms are added to the PSL.

### 1. Cookie isolation between customer sites (security)

Multiple unrelated customers publish their own sites under `customer.clevermind.com.br`. Without PSL inclusion, browsers treat all of them as the same registrable domain, which means a cookie set with `domain=.clevermind.com.br` would be readable across all customer sites. This is a security concern for our customers and an industry-standard reason for PSL listing.

### 2. Independent identity in search engines and webmaster tools

Today, Google Search Console and other webmaster tools treat each customer subdomain as part of the same parent property, which prevents customers from owning their own SEO identity, sitemap submission and search performance data. PSL inclusion makes each customer subdomain a separate site for verification.

### 3. Independent ad network and analytics accounts (Google AdSense)

The most concrete trigger for this submission: Google AdSense no longer accepts subdomain-only site registrations. Customers who try to add their own AdSense account on `customer.clevermind.com.br` are rejected by AdSense with the message *"URL must specify a valid top level domain"*, because AdSense treats the subdomain as belonging to the parent `clevermind.com.br` (which we — the platform operator — own and which is reserved for the SaaS product itself, not the published customer sites). The same problem affects other ad networks and pixel-based platforms that consume the PSL.

This is documented Google behaviour: see https://support.google.com/adsense/answer/12170421 — sites that are not on the PSL cannot register subdomains as independent sites in AdSense; sites that are on the PSL (like `*.blogspot.com`) can.

Without PSL inclusion, customers using a CleverMind subdomain are effectively locked out of monetizing or measuring their own sites with the largest ad and analytics platforms. This is the same problem that drove `vercel.app`, `netlify.app`, `pages.dev`, `myshopify.com`, `wordpress.com`, `blogspot.com` and others into the PSL.

### Number of THOUSANDS of distinct users this request is being made to serve:

We are not yet serving thousands of users — at the time of submission we have approximately 5 active business customers using the website-builder product, each operating their own published site under a CleverMind subdomain. Our goal with PSL inclusion is **not** scale-driven; it is structural correctness, security isolation, and the ability to offer customers the same parity of features that competing site-builder platforms already enjoy through their own PSL entries.

We commit to maintaining the `_psl` TXT record permanently, to keeping the domain registration current with more than one year remaining at all times, and to actively responding to PSL maintainer correspondence at the submitter email below.

## DNS Verification

    dig +short TXT _psl.clevermind.com.br
    "https://github.com/publicsuffix/list/pull/2847"

Verified resolving via `1.1.1.1` (Cloudflare public resolver) at the time of submission.

The domain `clevermind.com.br` is registered through Registro.br with expiration on **2029-05-14** (more than 3 years remaining at the time of this PR).
