### PR TITLE
rm: us.ci for missing "_psl" records and domain status on "clientHold" and "inactive"

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12965,7 +12965,6 @@ jozi.biz
 // Submitted by DNSHE Team <support@dnshe.com>
 ccwu.cc
 cc.cd
-us.ci
 de5.net
 
 // DNShome : https://www.dnshome.de/


### PR DESCRIPTION
#### Note: the main goal of this PR is to let @dnshe solve the issues related to `us.ci`, not removing the entry at the beginning.

Related: https://github.com/publicsuffix/list/pull/2677

A few days ago, i discovered that "us.ci" (and 2 other domains submitted by the same author) are flagged on virustotal for Malicious / Malware. A message was sent in PR #2677 and @dnshe [responded with an AI generated message](https://github.com/publicsuffix/list/pull/2677#issuecomment-4211431684).

<img width="1427" height="725" alt="{8DB514A1-CEE2-4D4A-9161-0260BFD5231D}" src="https://github.com/user-attachments/assets/ba1e5218-7cbf-4319-a7ec-c4d79e0a2afb" />

---

After receving a response, I then checked the `_psl` records for all entries submitted by @dnshe and discovered that `us.ci` is missing those records. A whois check on `us.ci` showed that it's currently in [clientHold](https://icann.org/epp#clientHold) and "[inactive](https://icann.org/epp#inactive)" status.

<img width="1171" height="213" alt="{54C1C0BB-AD08-416B-8B66-8BCE062F0A43}" src="https://github.com/user-attachments/assets/eb23ef1a-6e7b-4fc0-a84c-506792311377" />

```
Domain Name: us.ci
Registry Domain ID: 184287-cinic
Updated Date: 2026-04-06T19:01:44Z
Creation Date: 2025-11-12T16:10:22Z
Registry Expiry Date: 2028-11-12T16:10:22Z
Registrar Registration Expiration Date: 2028-11-12T16:10:22Z
Registrar: Netim
Registrar Street Address: 264 av arthur notebart
59160 Lille
FRANCE
Registrar City: FRANCE
Registrar State: FRANCE
Registrar Postal Code: 0033
Registrar Email: tld@netim.com
Domain Status: inactive https://icann.org/epp#inactive
Domain Status: clientHold https://icann.org/epp#clientHold
Registry Registrant ID: 184276-cinic
Registry Billing ID: 184284-cinic
Name Server: vip8.alidns.com
Name Server: vip7.alidns.com
DNSSEC: unsigned
>>> Last update of WHOIS database: 2026-04-08T14:49:32.599Z <<<

For more information on domain status codes, please visit https://icann.org/epp

TERMS OF USE: You are not authorized to access or query our WHOIS database through the use of electronic processes that are high-volume and automated.  THis WHOIS database is provided by as a service to the internet community.

The data is for information purposes only. We do not guarantee its accuracy. By submitting a WHOIS query, you agree to abide by the following terms of use: You agree that you may use this Data only for lawful purposes and that under no circumstances will you use this Data to: (1) allow, enable, or otherwise support the transmission of mass unsolicited, commercial advertising or solicitations via e-mail, telephone, or facsimile; or (2) enable high volume, automated, electronic processes. The compilation, repackaging, dissemination or other use of this Data is expressly prohibited.
```
---

FYI:

All 3 entries submitted in https://github.com/publicsuffix/list/pull/2677 are flagged by virustotal for being suspicious, malicious or containing malware.