### PR TITLE
Remove cloudapps.digital

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13920,11 +13920,6 @@ goupile.fr
 // Submitted by Richard Baker <richard.baker@digital.cabinet-office.gov.uk>
 pymnt.uk
 
-// GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
-// Submitted by Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>
-cloudapps.digital
-london.cloudapps.digital
-
 // Government of the Netherlands : https://www.government.nl
 // Submitted by <domeinnaam@minaz.nl>
 gov.nl


### PR DESCRIPTION
Removed entries related to GOV.UK Platform as a Service.

Domain expired for ~ 2 months, clientHold status.

> RDAP Server
> https://rdap.gandi.net
> Creation Date
> 2016-02-24 08:49:47
> Expiration Date
> 2026-02-24 08:49:47

GOV.UK Platform as a Service (PaaS), which operated under the domains cloud.service.gov.uk and cloudapps.digital, was officially decommissioned by the end of December 2023.

The Government Digital Service (GDS) announced the decision to retire the platform on July 11, 2022. GDS noted that the platform had not experienced the rapid and continued growth seen in their other platform products. Rather than investing heavily in significant technical architecture changes that the platform required, GDS made the decision to sunset the service.

Following the announcement, an 18-month transition period was established to allow government organizations to find alternative hosting solutions. At the time of the announcement, GOV.UK PaaS was supporting 172 digital services across 60 different government departments. Throughout 2023, these services—including those from the Crown Commercial Service and the Energy Performance of Buildings Register—migrated to other commercial cloud providers such as AWS.

Reference:

https://mhclgdigital.blog.gov.uk/2023/11/16/migrating-our-data-from-gov-uk-platform-as-a-service-paas-to-amazon-web-services-aws/

https://www.hitachi-solutions.co.uk/blog/2022/10/gov-paas-migrate/

