### PR TITLE
Add atlassian-3p.com and variants

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12420,7 +12420,10 @@ sweetpepper.org
 myasustor.com
 
 // Atlassian : https://atlassian.com
-// Submitted by Sam Smyth <devloop@atlassian.com>
+// Submitted by Benjamin McAlary <edge-services@atlassian.com>
+*.atlassian-3p.com
+*.atlassian-3p-us-gov-mod.com
+*.atlassian-isolated-3p.com
 cdn.prod.atlassian-dev.net
 
 // AVM : https://avm.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - No third-party rate limits are being worked around by this submission.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  You can contact the Atlassian Security team at: [abuse@atlassian.com](mailto:abuse@atlassian.com)

  These are new domains with no existing HTTP services — they exist solely for subdomain isolation.

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

**Organization Website:** https://www.atlassian.com

Atlassian builds collaboration and developer tools (Jira, Confluence, Bitbucket, Trello) used by over 300,000 customer organizations. I am Benjamin McAlary, a Principal Engineer on Atlassian's Edge infrastructure team. Atlassian already has an existing PSL entry (`cdn.prod.atlassian-dev.net`) submitted by a colleague.

This submission adds three new purpose-built domains for isolating third-party, malleable and sandboxed content served through Atlassian Cloud. The submitter (Atlassian) is the domain registrant and DNS operator for all three domains.

## Reason for PSL Inclusion

Atlassian Cloud serves third-party, malleable and sandboxed content content from multiple sources on per-tenant subdomains. Without PSL inclusion, a cookie set on `atlassian-3p.com` would be readable by all tenant subdomains, allowing cross-tenant session fixation or auth confusion between mutually untrusting parties.

### What content is served

1. **Forge apps** — Third-party marketplace applications (built by external developers) that serve custom UI (HTML/JS/CSS) via iframes. Each app installation gets a unique FQDN:
   `{installationId}--{appId}.forge.atlassian-3p.com`

2. **XEN web triggers** — HTTP endpoints that invoke Forge functions from external systems. Each trigger gets a unique subdomain serving untrusted request/response payloads.

3. **Malleable Content** — User-generated content transformations in Confluence rendered as dynamic HTML in sandboxed iframes on per-content subdomains.

4. **DevAI Sandboxes** — Sandboxed cloud development environments for AI-assisted coding, each running on an isolated subdomain.

### Why PSL inclusion is necessary (vs. alternatives)

- **`__Host-` cookie prefix**: We do use `__Host-` cookies where possible on our first-party domains. However, the content on these isolation domains is served by **third-party code** (Forge app developers, external integrations) that we do not control. We cannot enforce cookie-naming conventions on third-party JavaScript.

- **Separate domains per app**: Not feasible — there are thousands of Forge apps, each with many installations across many customers.

### FQDN structure

```
{id}.{appName}.atlassian-3p.com
```

- `{id}` — Application-specific identifier (e.g., installation UUID)
- `{appName}` — Serving application (`forge`, `sbox`, `malleable`, etc.)

### Three domains for three cloud perimeters

Atlassian operates three cloud environments with separate infrastructure. Each needs its own isolation domain:

| Domain | Environment | 
|--------|------------|
| `atlassian-3p.com` | Commercial cloud | 
| `atlassian-isolated-3p.com` | Isolated Cloud (single-tenant) | 
| `atlassian-3p-us-gov-mod.com` | FedRAMP Moderate (US Gov) | 

All three domains were registered via Markmonitor in March 2026 with 2+ year registration. DNS zones are hosted in AWS Route53. These domains have no MX records and are not used for email.

**Number of THOUSANDS of distinct users this request is being made to serve:**

Per-domain current counts of distinct subdomain operators (Forge app developers + internal teams serving sandboxed content):

- `atlassian-3p.com`: ~5,000+ distinct Forge apps across 300,000+ customer orgs. Thousands of distinct subdomain operators (app developers).
- `atlassian-isolated-3p.com`: Hundreds of isolated cloud customers, each with Forge app installations.
- `atlassian-3p-us-gov-mod.com`: Dozens of FedRAMP customers currently, growing.

These are current actual counts based on existing Forge marketplace installations that will migrate to these domains.

## DNS Verification

```
$ dig +short SOA atlassian-3p.com
ns-279.awsdns-34.com. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400

$ dig +short SOA atlassian-isolated-3p.com
ns-27.awsdns-03.com. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400

$ dig +short SOA atlassian-3p-us-gov-mod.com
ns-751.awsdns-29.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400
```

```
$ dig +short TXT _psl.atlassian-3p.com
"https://github.com/publicsuffix/list/pull/2852"

$ dig +short TXT _psl.atlassian-isolated-3p.com
"https://github.com/publicsuffix/list/pull/2852"

$ dig +short TXT _psl.atlassian-3p-us-gov-mod.com
"https://github.com/publicsuffix/list/pull/2852"
```