### PR TITLE
Add QD.JE

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12948,6 +12948,7 @@ ondigitalocean.app
 // DigitalPlat : https://www.digitalplat.org/
 // Submitted by Edward Hsing <contact@digitalplat.org>
 qzz.io
+qd.je
 us.kg
 xx.kg
 dpdns.org


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address.

* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

---

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found:  
https://domain.digitalplat.org/abuse/

Email: abusereport@digitalplat.org

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

DigitalPlat Domains is a subdomain registration service providing public suffixes for developers, individuals, and open-source projects.

The platform operates a multi-tenant domain infrastructure where users can register and manage subdomains through a unified dashboard. It currently serves over 400,000 users globally and is actively used for personal websites, development environments, and community projects.

The platform has significant adoption within the developer community, with over 157,000 GitHub stars:
https://github.com/DigitalPlatDev/FreeDomain

**Organization Website:**  
https://digitalplat.org

---

## Reason for PSL Inclusion

This submission adds **qd.je** as a new public suffix operated by DigitalPlat.

The domain has been recently launched and is already in active use, with 1,681 registered subdomains and continuous growth. It is fully integrated into the DigitalPlat dashboard and follows the same multi-tenant model as existing suffixes.

DigitalPlat has previously had multiple domains accepted into the PSL:

- us.kg — https://github.com/publicsuffix/list/pull/1755  
- dpdns.org — https://github.com/publicsuffix/list/pull/2414  
- xx.kg / qzz.io — https://github.com/publicsuffix/list/pull/2462  

The addition of qd.je ensures proper cookie isolation between unrelated users, prevents cross-origin data leakage, and aligns browser behavior with the intended multi-tenant usage of the domain.

**Number of THOUSANDS of distinct users this request is being made to serve:**  
400+ (~400,000 active users, current estimate)

---

## DNS Verification

```
dig +short TXT _psl.qd.je
"https://github.com/publicsuffix/list/pull/2854"
```


We commit to maintaining this record indefinitely.