### PR TITLE
Add *.metaaiusercontent.com to Meta Platforms section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14621,6 +14621,7 @@ messerli.app
 // Submitted by Jacob Cordero <public-suffix@meta.com>
 atmeta.com
 apps.fbsbx.com
+*.metaaiusercontent.com
 
 // MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
 // Submitted by Zdeněk Šustr <zdenek.sustr@cesnet.cz> and Radim Janča <janca@cesnet.cz>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.facebook.com/help/reportlinks and https://www.meta.com/help/artificial-intelligence/1398109381236743/

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

Meta Platforms, Inc. builds technologies that help people connect, find communities, and grow businesses. Meta's family of apps and services includes Facebook, Instagram, WhatsApp, and Messenger, serving billions of users worldwide. Meta is also investing in AI, augmented reality, and virtual reality to build the next evolution of computing platforms.

The submitter is a Software Engineer at Meta working on infrastructure for hosting AI-generated content. This submission adds to Meta's existing PSL section (previously submitted by Jacob Cordero, `public-suffix@meta.com`, for `atmeta.com` and `apps.fbsbx.com` in [#1736](https://github.com/publicsuffix/list/pull/1736)).

**Organization Website:** https://about.meta.com/

## Reason for PSL Inclusion

Meta AI products allow users to generate interactive web applications and content. This user-generated content is served on unique subdomains under `metaaiusercontent.com`, following the pattern `{app-id}.{service}.metaaiusercontent.com` — for example, `abc123.artifact.metaaiusercontent.com`.

Each subdomain hosts content from a different, mutually untrusting user. Without a PSL entry, a malicious application at `evil.artifact.metaaiusercontent.com` could set cookies scoped to `.artifact.metaaiusercontent.com`, which would then be sent to every other application under that parent domain. This is a classic cookie-tossing attack that enables session fixation, cross-app data exfiltration, and other security issues between mutually untrusting origins.

Adding `*.metaaiusercontent.com` to the PSL ensures that each `{service}.metaaiusercontent.com` (e.g., `artifact.metaaiusercontent.com`) is treated as a public suffix by browsers. This means each `{app-id}.{service}.metaaiusercontent.com` becomes its own registrable domain with a fully isolated cookie jar, localStorage, and other origin-scoped storage.

The wildcard entry is necessary because Meta may operate multiple services under this domain, and new services may be added over time. A wildcard ensures proper isolation for all current and future services without requiring additional PSL submissions and the associated multi-month propagation delay through browser releases.

The domain `metaaiusercontent.com` is registered with more than two years remaining and will be maintained for as long as the service is operational.

**Number of THOUSANDS of distinct users this request is being made to serve:** Hundreds of millions. Meta AI products are used by hundreds of millions of users globally, and user-generated content served on subdomains of `metaaiusercontent.com` is expected to scale accordingly.

## DNS Verification

```
$ dig +short TXT _psl.metaaiusercontent.com
"https://github.com/publicsuffix/list/pull/2856"
```
