### PR TITLE
Add app.rapitek.com (Rapitek CRM)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15315,6 +15315,10 @@ site.rb-hosting.io
 // Submitted by Phineas Walton <dns@railway.com>
 up.railway.app
 
+// Rapitek CRM : https://rapitek.com
+// Submitted by Kerim Yildirim <kerim.yildirim@rapitek.com>
+app.rapitek.com
+
 // Rancher Labs, Inc : https://rancher.com
 // Submitted by Vincent Fiduccia <domains@rancher.com>
 *.on-rancher.cloud


### PR DESCRIPTION
## Add app.rapitek.com to the Private section

Adding `app.rapitek.com` to the Private Domains section of the PSL.

### What
[Rapitek CRM](https://rapitek.com) is a multi-tenant SaaS CRM. Each customer organization is issued an independent subdomain under `app.rapitek.com` — e.g. `acme.app.rapitek.com`, `clinic.app.rapitek.com`. Tenants are operated independently and their data is fully isolated.

### Why
We need PSL inclusion so browsers scope cookies and credentials per tenant, the same way they do for `*.my.salesforce.com`, `*.github.io`, `*.netlify.app`, etc. Without it, Chrome treats `clinic.app.rapitek.com` and `acme.app.rapitek.com` as the same organization and cross-fills credentials between them.

### Live verification
- https://nexus.app.rapitek.com/
- https://clinic.app.rapitek.com/
- https://realestate.app.rapitek.com/

All three are independent tenants on distinct subdomains, each serving the same wildcard Let's Encrypt cert.

### Ownership verification
- Submitter: Kerim Yıldırım <kerim.yildirim@rapitek.com> (owner)
- Secondary contact: admin@rapitek.com
- WHOIS: `rapitek.com` is registered to Rapitek; registration stable since 2019.

Happy to add a `_psl.app.rapitek.com` TXT record pointing to this PR URL if the reviewers prefer that verification path.

### Diff
```diff
 up.railway.app
 
+// Rapitek CRM : https://rapitek.com
+// Submitted by Kerim Yildirim <kerim.yildirim@rapitek.com>
+app.rapitek.com
+
 // Rancher Labs, Inc : https://rancher.com
```