### PR TITLE
Add tycoon.cool

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16055,6 +16055,10 @@ typedream.app
 // Submitted by Typeform <ops@typeform.com>
 pro.typeform.com
 
+// Tycoon : https://tycoon.cool
+// Submitted by Xiaoyin Qu <xq002011@gmail.com>
+tycoon.cool
+
 // Uberspace : https://uberspace.de
 // Submitted by Moritz Werner <mwerner@jonaspasche.com>
 uber.space


### PR DESCRIPTION
## Summary

Tycoon (<https://tycoon.cool>) is a multi-tenant web platform where each user receives their own subdomain under `tycoon.cool` (e.g. `alice.tycoon.cool`, `bob.tycoon.cool`). These sites belong to different owners and must not share cookies, localStorage, or other origin-scoped state.

Without a PSL entry, browsers treat `tycoon.cool` as a registrable domain. A malicious tenant could `Set-Cookie: sid=...; Domain=.tycoon.cool` and a sibling tenant would read it — cross-tenant session leak.

Adding `tycoon.cool` to PRIVATE DOMAINS asks browsers to treat it as a boundary. Our edge already sanitizes `Set-Cookie` as defense-in-depth; this adds the browser-level guarantee.

## Ownership

Tycoon operates `tycoon.cool`. I can add any DNS TXT record you'd like for ownership verification — just let me know the token.

## Format

- Added under the existing alphabetical neighborhood (between Typeform and Uberspace).
- Follows the standard comment format `// Name : URL` + `// Submitted by ...`.