### PR TITLE
Add ee3.org to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16215,6 +16215,10 @@ box.ca
 // Submitted by Kidd Hustle <kiddhustle@wiardweb.com>
 pages.wiardweb.com
 
+// WICLOUD.PL : https://dns.ee3.org/
+// Submitted by Jan Fedorowicz <dns.ee3.org@wicloud.pl>
+ee3.org
+
 // Wikimedia Foundation : https://wikitech.wikimedia.org
 // Submitted by Timo Tijhof <noc@wikimedia.org>
 toolforge.org


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://dns.ee3.org/#legal (Abuse contact email: abuse@wicloud.pl is provided in the ToS and the site footer).

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

Hi, I am the owner and system administrator of Wicloud.PL, an IT service provider based in Poland. We operate a dynamic DNS and third-level domain central registry under the `ee3.org` namespace. Our platform provides affordable and accessible subdomains (e.g., `username.ee3.org`) to hobbyists, small businesses, creators, and community projects.

**Organization Website:**
https://dns.ee3.org/

## Reason for PSL Inclusion

We are requesting the inclusion of `ee3.org` in the PRIVATE section of the PSL primarily to ensure proper security and isolation for our end-users. Currently, because `ee3.org` is not on the PSL, browsers treat all our users' subdomains as part of a single entity. This causes severe security implications, such as "supercookies" being shared across unrelated users' subdomains and issues with LocalStorage isolation. Inclusion in the PSL will strictly enforce boundaries between `userA.ee3.org` and `userB.ee3.org`.

Furthermore, our users require the ability to manage their own services independently. Without PSL inclusion, they are heavily rate-limited by Certificate Authorities like Let's Encrypt and are entirely blocked from adding their subdomains to third-party DNS/CDN providers like Cloudflare, which require a registrable domain boundary. Adding `ee3.org` to the PSL will grant our users the autonomy to secure and manage their projects properly. I confirm that the `ee3.org` domain has and will maintain a registration term of more than 2 years.

**Number of THOUSANDS of distinct users this request is being made to serve:**
0 (Project is currently launching). Estimated 2-5 within the first year. We are establishing this PSL baseline early to ensure strict security boundaries (cookie/LocalStorage isolation) are in place before scaling our user base.

## DNS Verification

```text
dig +short TXT _psl.ee3.org
"https://github.com/publicsuffix/list/pull/2864"