### PR TITLE
Add public suffix entries for Lunaweb and related domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16366,4 +16366,21 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// Lunaweb : https://Lunaweb.ru
+// Submitted by Lunaweb Team <support@lunaweb.ru>
+c6t.ru
+cocal.ru
+furry-club.ru
+horsefucker.ru
+p7z.ru
+pidor.sbs
+q9p.ru
+*.c6t.ru
+*.cocal.ru
+*.furry-club.ru
+*.horsefucker.ru
+*.p7z.ru
+*.pidor.sbs
+*.q9p.ru
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] We are listing *any* third-party limits that we seek to work around in our rationale.
* [x] This request was *not* submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully *read* and *understood*, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
* [x] Abuse contact information (email or web form) is available and easily accessible.
* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

**Organization Website:** https://lunaweb.ru

Lunaweb (lunaweb.ru) is a subdomain registrar service that allows users to register arbitrary subdomains of any level under our domains. Users can self-host websites, applications, or other services without buying their own domain. The submitter is authorized representative of Lunaweb Team (support@lunaweb.ru).

## Reason for PSL Inclusion

Without PSL inclusion, cookies with `Domain=.p7z.ru` would work across all user subdomains. This creates a security vulnerability where one malicious user could set a cookie affecting another user's subdomain, leading to session hijacking or cross-subdomain attacks.

We need each subdomain to be treated as a separate site by browsers. This ensures: cookies are isolated between different users, each subdomain has its own security boundary, users cannot interfere with each other's sessions, and browser features like localStorage are properly isolated.

**Number of distinct users this request serves:** 860 active users (current actual count).

## DNS Verification

```

dig +short TXT _psl.c6t.ru
"https://github.com/publicsuffix/list/pull/2871"

dig +short TXT _psl.cocal.ru
"https://github.com/publicsuffix/list/pull/2871"

dig +short TXT _psl.furry-club.ru
"https://github.com/publicsuffix/list/pull/2871"

dig +short TXT _psl.horsefucker.ru
"https://github.com/publicsuffix/list/pull/2871"

dig +short TXT _psl.p7z.ru
"https://github.com/publicsuffix/list/pull/2871"

dig +short TXT _psl.pidor.sbs
"https://github.com/publicsuffix/list/pull/2871"

dig +short TXT _psl.q9p.ru
"https://github.com/publicsuffix/list/pull/2871"

```

## Abuse Contact

Abuse reports: **abuse@lunaweb.ru** (24-48 hour response). Contact clearly listed at https://lunaweb.ru.

## Registration Term Confirmation

All domains have at least 2 years remaining registration. I confirm that I will maintain these domains and keep the `_psl` DNS records for as long as they remain in the PSL.

## Domains to add (PRIVATE section)

```

// Lunaweb (lunaweb.ru) - Subdomain registration service
// Submitted by Lunaweb Team <support@lunaweb.ru>
c6t.ru
cocal.ru
furry-club.ru
horsefucker.ru
p7z.ru
pidor.sbs
q9p.ru
*.c6t.ru
*.cocal.ru
*.furry-club.ru
*.horsefucker.ru
*.p7z.ru
*.pidor.sbs
*.q9p.ru

```
