### PR TITLE
Remove `net.ms`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4163,7 +4163,6 @@ ms
 com.ms
 edu.ms
 gov.ms
-net.ms
 org.ms
 
 // mt : https://www.nic.org.mt/go/policy


### PR DESCRIPTION
This PR proposes the removal of net[.]ms from the ICANN section of the Public Suffix List. As of today, net[.]ms is no longer resolving through registry-controlled infrastructure; it is currently delegated to c[.]name-servers[.]ch and d[.]name-servers[.]ch, nameservers with a documented association (related: #2693) with bad-faith registrations. 

The NIC.MS registry has been contacted to confirm whether net[.]ms remains an active, registry-administered namespace and whether its current delegation is intentional. This PR is being opened proactively so that the change is ready to action promptly upon confirmation. 

## WHOIS

```
Domain Name: net[.]ms
Registry Domain ID: 668491-CoCCA
Updated Date:
Creation Date: 2026-04-24T18:15:08Z
Registry Expiry Date: 2027-04-24T18:15:09Z
Registrar Registration Expiration Date: 2027-04-24T18:15:09Z
Registrar: MNINET Registrar
Registrar Street Address: Olveston Drive
Olveston
Montserrat
Registrar Email: sales@mninet.ms
Domain Status: active https://icann.org/epp#active
Name Server: d.name-servers[.]ch
Name Server: c.name-servers[.]ch
DNSSEC: unsigned
>>> Last update of WHOIS database: 2026-04-24T19:01:53.992Z <<<
```