### PR TITLE
Add qd.je to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12960,6 +12960,7 @@ qzz.io
 us.kg
 xx.kg
 dpdns.org
+qd.je
 
 // Discord Inc : https://discord.com
 // Submitted by Sahn Lam <slam@discordapp.com>


### PR DESCRIPTION
## Summary

This pull request updates the Public Suffix List with changes from my fork (`Cookiesmuch:list`) into `publicsuffix/list:main`.

## What changed

- Synced list updates from `Cookiesmuch:list:main`
- Includes all additions/removals/modifications shown in the comparison:
  `publicsuffix/list@main...Cookiesmuch:list@main`

## Why

To contribute the latest suffix rule updates from my fork back to the upstream PSL repository, keeping the canonical list current and accurate.

## Scope / impact

- **Data-only change** (Public Suffix List entries)
- No application/runtime code changes
- Downstream consumers of PSL data may observe domain parsing/registration-boundary behavior updates for affected suffixes

## Validation

- Reviewed the compare diff for correctness and intended rule changes
- Confirmed changes are limited to PSL list content

## Compare link

- https://github.com/publicsuffix/list/compare/main...Cookiesmuch:list:main?expand=1