### PR TITLE
Add qd.je to public suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12960,6 +12960,7 @@ qzz.io
 us.kg
 xx.kg
 dpdns.org
+qd.je
 
 // Discord Inc : https://discord.com
 // Submitted by Sahn Lam <slam@discordapp.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [x] [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [x] [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:  
  https://www.digiplat.com/abuse

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

**Organization Website:**  
https://www.digiplat.com

Digiplat provides managed namespaces/suffixes used by customers for hosted addresses and subdomains. I am submitting this request as a Digiplat user (not an owner/operator) because `qd.je` is currently offered as an available suffix on the platform but is not yet reflected in the Public Suffix List. This PR is intended to align the PSL with the suffixes currently available to users so behavior is consistent across browser and service ecosystems.

**Submitter contact email:**  
theofficialeverything@gmail.com

## Reason for PSL Inclusion

`qd.je` appears to be available for user addresses on Digiplat, but it is not currently listed in the PSL under Digiplat’s private section. As a result, users on this suffix can run into inconsistent behavior in PSL-dependent services. One practical issue observed is reduced compatibility/usability with Cloudflare-related setups for `qd.je` domains.

This request aims to add `qd.je` so this actively used, multi-tenant suffix is treated consistently with Digiplat’s other listed suffixes. This request is not intended to bypass third-party limits; it is to correct PSL coverage for an existing user-facing suffix. To the best of my knowledge as a user, this change reflects current platform usage and need.

**Number of THOUSANDS of distinct users this request is being made to serve:**  
3 (estimate)

## DNS Verification

```bash
dig +short TXT _psl.qd.je
"https://github.com/publicsuffix/list/pull/2875"
```