### PR TITLE
Add smoothly.to

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15718,6 +15718,10 @@ veterinaire.fr
 // Submitted by Dan Kozak <dan@smoove.io>
 vp4.me
 
+// Smoothly AB : https://smoothly.dev
+// Submitted by Fredrik Ankarskold <fredrik@smoothly.dev>
+smoothly.to
+
 // Snowflake Inc : https://www.snowflake.com/
 // Submitted by Sam Haar <psl@snowflake.com>
 *.snowflake.app


### PR DESCRIPTION
### Description of changes
Adding smoothly.to to the PRIVATE DOMAINS section. smoothly.to is
a multi-tenant SaaS platform — customers receive subdomains
(acme.smoothly.to, bob.smoothly.to) under our single registered
domain. We need PSL registration so browsers prevent cross-customer
cookie attacks (cookie tossing).

### Affected URL(s)
smoothly.to and any *.smoothly.to subdomain.

### Authentication
DNS TXT record at _psl.smoothly.to points to this PR (added per
the maintainer guidelines).

### Section
PRIVATE DOMAINS

### Owner
Smoothly AB. Operational contact: Fredrik Ankarskold
<fredrik@smoothly.dev>.

### Why this is a private domain
We control the apex (smoothly.to) and issue subdomains
programmatically to paying customers. Every subdomain is operated
by a different end-user. Without PSL coverage, any one customer
could set cookies that bleed onto all the others.