### PR TITLE
Add `codelib.re` Record to Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14774,6 +14774,7 @@ o365.cloud.nospamproxy.com
 // Net libre : https://www.netlib.re
 // Submitted by Philippe PITTOLI <security@netlib.re>
 netlib.re
+codelib.re
 
 // Netlify : https://www.netlify.com
 // Submitted by Jessica Parsons <jessica@netlify.com>


### PR DESCRIPTION
The sibling domain `netlib.re` is already listed in the PSL. To maintain consistent policy, `codelib.re` should follow the same procedure.

The current PSL registry only contains `netlib.re` and is missing the record entry for `codelib.re`. (Ref: #2308)

Explicitly add the `codelib.re` entry to the PSL data file.