### PR TITLE
Add book.online

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16198,12 +16198,12 @@ webflowtest.io
 *.webhare.dev
 
 // WebHotelier Technologies Ltd : https://www.webhotelier.net/
-// Submitted by Apostolos Tsakpinis <apostolos.tsakpinis@gmail.com>
-book.online
+// Submitted by Apostolos Tsakpinis <cto@webhotelier.net>
 bookonline.app
 hotelwithflight.com
 reserve-online.com
 reserve-online.net
+book.online
 
 // WebPros International, LLC : https://webpros.com/
 // Submitted by Nicolas Rochelemagne <public.suffix@webpros.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16199,6 +16199,7 @@ webflowtest.io
 
 // WebHotelier Technologies Ltd : https://www.webhotelier.net/
 // Submitted by Apostolos Tsakpinis <apostolos.tsakpinis@gmail.com>
+book.online
 bookonline.app
 hotelwithflight.com
 reserve-online.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16199,9 +16199,7 @@ webflowtest.io
 
 // WebHotelier Technologies Ltd : https://www.webhotelier.net/
 // Submitted by Apostolos Tsakpinis <cto@webhotelier.net>
-bookonline.app
 hotelwithflight.com
-reserve-online.com
 reserve-online.net
 book.online
 


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.webhotelier.net/contact

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

webhotelier | primalres offers an ecosystem that covers many aspects of hotel & property management — designed for hospitality businesses of any type or size. It includes the webhotelier booking engine, the primalres channel manager, and cloud-based PMS platforms, among others.

This PR is related to the booking engine which hosts thousands of different hotel businesses under the subdomain of their choosing.

The submitter is the CTO of webhotelier | primalres.

**Organization Website:** https://www.webhotelier.net/

## Reason for PSL Inclusion

Follow-up to: https://github.com/publicsuffix/list/pull/1254

Cookie Security between subdomains. Each property is a completely separate business and we want to prevent cross-engine cookie pollination.

**Number of THOUSANDS of distinct users this request is being made to serve:**
12,740 individual hotels and other accommodations. This is the current actual count and not an estimate.

## DNS Verification

```
dig +short TXT _psl.book.online
"https://github.com/publicsuffix/list/pull/2890"
```