### PR TITLE
Add pinegrowsites.com to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15153,14 +15153,14 @@ pplx.app
 // Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
 perspecta.cloud
 
+// Pinegrow : https://pinegrow.com/
+// Submitted by Pinegrow <info@pinegrow.com>
+pinegrowsites.com
+
 // Ping Identity : https://www.pingidentity.com
 // Submitted by Ping Identity <security@pingidentity.com>
 forgeblocks.com
 id.forgerock.io
-
-// Pinegrow : https://pinegrow.com/
-// Submitted by Pinegrow <info@pinegrow.com>
-pinegrowsites.com
 
 // Plain : https://www.plain.com/
 // Submitted by Jesús Hernández <security@plain.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15158,6 +15158,10 @@ perspecta.cloud
 forgeblocks.com
 id.forgerock.io
 
+// Pinegrow : https://pinegrow.com/
+// Submitted by Pinegrow <info@pinegrow.com>
+pinegrowsites.com
+
 // Plain : https://www.plain.com/
 // Submitted by Jesús Hernández <security@plain.com>
 support.site


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing any third-party limits that we seek to work around in our rationale.

  None. This request is not intended to work around Cloudflare, Let's Encrypt, Apple, GitLab, Facebook/iOS, or any other third-party rate limit or product limitation.

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found:
https://pinegrow.com/contact-us/

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

Pinegrow provides website-building and web-development tools for designers and developers. Pinegrow Cloud uses `pinegrowsites.com` as a public hosting domain for websites published by Pinegrow users. Each published site is assigned its own hostname under `pinegrowsites.com`, such as `example-user--example-project.pinegrowsites.com`, and these hostnames may contain content controlled by different Pinegrow users.

This submission is made by an authorized Pinegrow representative responsible for the Pinegrow Cloud hosting infrastructure. Pinegrow operates the DNS, routing, and hosting systems for `pinegrowsites.com`, while individual published subdomains are used for user-created websites and should be treated as mutually untrusted sites.

**Organization Website:**
https://pinegrow.com/

## Reason for PSL Inclusion

`pinegrowsites.com` should be listed in the PRIVATE section because Pinegrow issues subdomains of this domain to different Pinegrow users for their published websites. These subdomains are operated as separate user sites, and one user's site must not be able to affect another user's site or the parent hosting domain through broadly scoped browser cookies or related same-site behaviors.

The primary goal is browser security isolation for user-published content. PSL inclusion will prevent a site hosted at one `pinegrowsites.com` subdomain from setting cookies for all of `.pinegrowsites.com`, and will help browsers and other software identify each user hostname as a separate registrable site boundary. This request is not intended to work around certificate issuance limits, Cloudflare limits, or any other third-party rate limit.

Pinegrow confirms that `pinegrowsites.com` has more than two years remaining on its registration and will maintain more than one year remaining while the domain remains listed. Pinegrow also confirms that it will keep the `_psl.pinegrowsites.com` TXT record in place and will maintain the role-based contact listed in the PSL entry.

**Number of THOUSANDS of distinct users this request is being made to serve:**
8 (Number of current active customers of Pinegrow Web Editor, who will have access to publishing websites on pinegrowsites.com, with each website under a unique subdomain)

## DNS Verification

This PR will add:

```text
pinegrowsites.com
```

Pinegrow added and will keep the following DNS TXT record:

```text
_psl.pinegrowsites.com TXT "https://github.com/publicsuffix/list/pull/2895"
```

Verification command:

```bash
dig +short TXT _psl.pinegrowsites.com
```

Dig output:

```text
"https://github.com/publicsuffix/list/pull/2895"
```