### PR TITLE
Add flagship.services

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13631,6 +13631,10 @@ filegear.me
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
+// Flagship : https://flagshipserver.com
+// Submitted by Harry Winner <harry@flagship.services>
+flagship.services
+
 // FlashDrive : https://flashdrive.io
 // Submitted by Eric Chan <support@flashdrive.io>
 fldrv.com


### PR DESCRIPTION
Adds `flagship.services` to the PRIVATE DOMAINS section.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [ ] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

  *(Left unchecked: we are not seeking to work around any third-party limits via this PR. A transparency note regarding Let's Encrypt rate limits — which we are addressing directly with ISRG, not via the PSL — appears in the Rationale section below for completeness.)*

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://flagshipserver.com/abuse.html

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

**Organization Website:** https://flagshipserver.com

Flagship is a personal-cloud product. Each end user runs their own Flagship server on hardware they own (a home NUC, an old laptop, a Raspberry Pi, etc.) and is reachable at `<server>.<username>.flagship.services`. The defining property of the architecture is that **TLS terminates on the end user's own machine** — the certificate private key is generated locally on the user's box and never leaves it. The `flagship.services` zone itself operates only as an SNI-passthrough/tunnel pipe at the edge: we read the SNI from the cleartext portion of the TLS ClientHello to route TCP, but we cannot decrypt traffic and we never possess any user's cert private key. Each user runs their own Let's Encrypt ACME account, holds their own server identity keypair, and is administratively independent of every other user on the platform.

I am Harry Winner Kamdem, the founder, sole engineer, and authorized representative of Flagship, submitting this request on behalf of the organization. The role-based contact for PSL correspondence is `harry@flagship.services`; the abuse contact is `abuse@flagship.services`. Both inboxes are actively monitored.

The product surface is split across two domains: `flagshipserver.com` is the identity and control-plane domain (a Cloudflare Worker over D1/R2 — usernames, signed install blobs, server registry, routing); `flagship.services` is the user-content domain that this PR concerns. They are deliberately separate origins so user apps cannot reach session cookies or admin state on the control plane via subdomain confusion. The codebase is open source under BUSL-1.1 at https://github.com/harrywinner2/flagship.

## Reason for PSL Inclusion

**Primary rationale: origin and cookie isolation between mutually-untrusting users.**

Each `<server>.<username>.flagship.services` is operated by a different individual, on different hardware, with a different TLS private key, a different ACME account, and zero shared administrative authority. This is the canonical PSL use case — a service that issues subdomains to mutually-untrusting parties — and the isolation in our case is unusually strong because the cryptographic separation continues all the way down to the cert private key: `flagship.services` itself cannot impersonate one user's subdomain when accessing another's, even at the registry level.

Without a PSL entry, browsers treat the entire `flagship.services` registrable domain as one administrative unit. The concrete consequences:

- A cookie set with `Domain=.flagship.services` from any user's subdomain is delivered to every other user's subdomain.
- A cookie set without an explicit `Domain` attribute on `home.alice.flagship.services` is correctly scoped today, but `Set-Cookie` ambiguity (e.g. a misconfigured app that *does* set `Domain=.flagship.services`) silently leaks across users with no error surface for the user to notice.
- SameSite cookie policy treats requests between unrelated users' subdomains as same-site, which weakens CSRF protection that browsers would otherwise provide for free.
- localStorage / IndexedDB partitioning, Service Worker scope, the new HTTP State Tokens proposal, and CHIPS all use the registrable domain as their boundary.

With the PSL entry, each `<username>.flagship.services` becomes its own registrable domain in browsers — equivalent to the way `*.github.io` repository pages, `*.vercel.app` deploys, and `*.glitch.me` projects are isolated from one another today. We cite no precedent that does not already appear in the PRIVATE section.

This rationale stands independently of any third-party rate limit concern. The PR is being submitted to obtain origin/cookie isolation guarantees that the browser security model otherwise denies us.

**User count (in thousands):** <1 (single-digit users today; pre-launch). Flagship's first end-to-end production install was verified on 2026-05-05. The reason we are requesting inclusion now, ahead of the user-count threshold typically cited in the guidelines, is that origin isolation is most valuable when introduced *before* a meaningful user base accumulates state under the existing (incorrect) registrable-domain boundary — adding the PSL entry later forces every active user's cookies and storage to re-partition, which we would prefer to avoid. We respectfully ask that the request be evaluated on the strength of the architectural rationale, and we defer to maintainers' judgment on whether to accept now or wait for scale.

**Domain registration term:** `flagship.services` is registered through 2028-06-24, which is more than two years from the date of this submission. We commit to renewing the domain to maintain at least one year of remaining registration for as long as the entry remains in the PSL.

**Past PRs / issues:** No prior PRs or issues for this domain.

**Transparency note on third-party rate limits.** Let's Encrypt's "Certificates per Registered Domain" rate limit (50 / week, computed at the eTLD+1) does affect `flagship.services` summed globally across all our users. We are addressing that concern *directly with ISRG* via the public rate-limit-adjustment form (submitted 2026-05-05, awaiting review) — which is the appropriate venue for that concern, per the PSL's own guidance to engage third parties on their own terms. We are explicitly disclosing this here so it is not a hidden motivation; the PSL request stands or falls on the cookie/origin isolation rationale above, regardless of how ISRG's review concludes.

## DNS Verification

```
$ dig +short TXT _psl.flagship.services
"https://github.com/publicsuffix/list/pull/2897"
```

The TXT record is in place and will be retained for as long as `flagship.services` remains in the PSL.
