### PR TITLE
Add mygov.scot

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15600,9 +15600,10 @@ dedibox.fr
 schokokeks.net
 
 // Scottish Government : https://www.gov.scot
-// Submitted by Martin Ellis <martin.ellis@gov.scot>
+// Submitted by Martin Ellis <digital-publishing@gov.scot>
 gov.scot
 service.gov.scot
+mygov.scot
 
 // Scry Security : http://www.scrysec.com
 // Submitted by Shante Adam <shante@skyhat.io>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

The Scottish Government has also used the **mygov.scot** domain since 2014 for public-facing websites and (soon) services. The most popular of these is www.mygov.scot, which receives about 1M visits per month. There are also some internal-facing services on the same domain.

Since its initial registration in 2014, the mygov.scot domain has been managed by a single team. As of June 2026, subdomains will be owned by different teams in different business areas. A new subdomain will be created that allows "citizens" (and residents, etc.) to log in to a personal account. This will provide access to sensitive data. In future, third-party (but still public sector) services will also be added.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
   - None

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://mygov.scot/give-feedback
  See **Other mygov.scot sites and services**

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---


## Description of Organization

The Scottish Government is the devolved government for Scotland. It provides services to people and businesses in Scotland. The Digital directorate within the Scottish Government will launch a "logged in" version of the mygov.scot informational site in June, and this change is submitted in anticipation of that. It is being submitted now because we understand that propagation of changes to list can take some time.

My role is as a Service Lead and Devops Engineer in the Corporate Operations directorate at the Scottish Government. My responsibilities include the hosting of the gov.scot and mygov.scot apex domains, and the hosting of the www.gov.scot and www.mygov.scot websites. I often work with the Domains team <domains@gov.scot> within the Scottish Government, as they have no engineering support within that team.

My previous submissions to the PSL:
* https://github.com/publicsuffix/list/pull/904 - gov.scot
* https://github.com/publicsuffix/list/pull/1221 - service.gov.scot

**Organization Website:** https://www.gov.scot/

## Reason for PSL Inclusion

The primary motivation for this change is to enforce cookie isolation between these subdomains. Some subdomains will provide logins granting access to sensitive personal information; some to sensitive internal systems; and some will be informational sites (or redirects) that have no login at all. They will operate with different security governance and levels of assurance. We would not want authentication cookies granting access to sensitive information to be inadvertently sent to lower security systems (and neither would users!).

A secondary motivation is to ensure that the different organisations (or parts thereof) using subdomains will not be affected by Let's Encrypt rate limiting applied to another team or organisation. Abuse seems unlikely, but misconfiguration and programmatic error can happen, and this protects other high-profile public services in the event of a problem with one. We believe this change ensures that Let's Encrypt service limits are applied as intended, rather than something that circumvents PSL policy.

While the different organisations that will use the domain are all public sector bodies, treating the domains as "mutually distrusting" affords better security posture for both end users and internal users.

**Number of THOUSANDS of distinct users this request is being made to serve:** <1 (count)
  * While "projects not serving more then thousands of users are quite likely to be declined", we feel this change is in the public interest due to both the number of end users affected and the sensitivity of data involved in some of the subdomains (i.e. government data on individuals). It is a similar use-case to both gov.scot and service.gov.scot, where (technically) mutually distrusting organisations sit on the same domain.

## DNS Verification

```
dig +short TXT _psl.mygov.scot
"https://github.com/publicsuffix/list/pull/2900"
```
