### PR TITLE
Add tatnet.app to Private Domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15943,6 +15943,10 @@ gdynia.pl
 med.pl
 sopot.pl
 
+// TatNet : https://tatnet.ru/
+// Submitted by Ildar Manzhikov <manzhikov@icloud.com>
+tatnet.app
+
 // Tave Creative Corp : https://tave.com/
 // Submitted by Adrian Ziemkowski <devops@tave.com>
 taveusercontent.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig — *will add `_psl.tatnet.app` TXT record pointing to this PR URL after creation*

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://tatnet.ru/abuse

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*. The cookie scope on `tatnet.app` is exactly what we want isolated — there is no first-party content on the apex.

---

## Description of Organization

TatNet is an infrastructure-management platform that lets developers deploy web applications, serverless functions, and virtual machines on our hosted infrastructure. The primary marketing/admin site is at `tatnet.ru`; `tatnet.app` is used exclusively as the parent domain for customer applications, where each customer receives a subdomain of the form `<app>.tatnet.app` (analogous to `*.vercel.app`, `*.netlify.app`, `*.fly.dev`, etc.). The apex of `tatnet.app` and `www.tatnet.app` 301-redirect to `tatnet.ru` and host no first-party content.

I am Ildar Manzhikov, founder and primary engineer at TatNet. I am submitting this request on behalf of the platform.

**Organization Website:** https://tatnet.ru/

## Reason for PSL Inclusion

We are requesting that `tatnet.app` be added to the PRIVATE section so that browsers, cookie libraries, and other PSL consumers correctly treat each `<customer>.tatnet.app` as an independent registrable domain rather than as a subdomain of a single shared origin.

The two concrete reasons:

1. **Cookie isolation between mutually-untrusting tenants.** Customers run arbitrary code on their subdomains. Without PSL inclusion, a malicious or buggy customer could set a cookie scoped to `Domain=tatnet.app`, which a cooperating browser would then send to *every* other customer's subdomain. Listing `tatnet.app` makes `tatnet.app` a public suffix and prevents cookie scope from rising above the customer's own subdomain — the same isolation property `*.vercel.app`, `*.netlify.app`, `*.glitch.me`, `*.web.app`, `*.fly.dev`, etc. rely on.

2. **Independent treatment by PSL-consuming services** (TLS issuance rate limits, browser site-grouping, password-manager origin matching, etc.). Each customer should be treated as its own site rather than as a subdirectory of one shared site.

We are not attempting to work around any specific third-party rate limit; the request is driven by the cookie-scope isolation requirement above, which has no in-band workaround.

There is no first-party content on `tatnet.app` itself; the apex and `www` redirect to `tatnet.ru`. Adding `tatnet.app` to the PSL therefore cannot break first-party cookies or auth on that domain.

The domain `tatnet.app` is registered with more than two years remaining and we commit to renewing well in advance and maintaining the `_psl.tatnet.app` TXT record continuously.

**Number of THOUSANDS of distinct users this request is being made to serve: 3000/10000

## DNS Verification

After this PR receives a number, I will publish:

```
dig +short TXT _psl.tatnet.app
"https://github.com/publicsuffix/list/pull/2901"
```

This record will remain in place for the lifetime of our PSL entry.