### PR TITLE
Add ArylLabs domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16370,4 +16370,10 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// ArylLabs : https://aryllabs.com
+// Submitted by Goutam Boro <info@aryllabs.com>
+aryl.app
+aryl.cloud
+arylhive.com
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
Adding aryl.app, aryl.cloud, and arylhive.com to the Public Suffix List as they are user-generated hosting domains.