### PR TITLE
Add Hostinger to public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14058,6 +14058,10 @@ ltd.ng
 ngo.ng
 plc.ng
 
+// Hostinger : https://hostinger.com
+// Submitted by Valentinas Cirba <valentinas.cirba@hostinger.com>
+hstgr.cloud
+
 // HostyHosting : https://hostyhosting.com
 hostyhosting.io
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14059,7 +14059,7 @@ ngo.ng
 plc.ng
 
 // Hostinger : https://hostinger.com
-// Submitted by Valentinas Cirba <valentinas.cirba@hostinger.com>
+// Submitted by Valentinas Cirba <domains@hostinger.com>
 hstgr.cloud
 
 // HostyHosting : https://hostyhosting.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission doesn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/2835, although 
the organization and description were not as substantial 
as desired, which required maintainers' time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace because extra cycles are not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)
 - MAKE SURE TO UPDATE THE FOLLOWING LIST WITH YOUR LIMITATIONS! REMOVE ENTRIES WHICH DO NOT APPLY AS WELL AS REMOVING THIS LINE!

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail regarding the effort that was made to work directly 
with the third party or parties in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry in, the 
order of commented organization placement, and the order of sorting of entries. 
(Hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically, both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:** abuse@hostinger.com

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.hostinger.com/report-abuse

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization

Hostinger International Ltd. is a web hosting and cloud infrastructure provider headquartered Lithuania, operating since 2004. Our core business is provisioning hosting, VPS, and managed cloud products for individual developers, small businesses, and agencies, with infrastructure across multiple datacenter regions. The hstgr.cloud namespace is operational infrastructure used by our platform to issue auto-generated hostnames to customer-provisioned resources - specifically VPS instances (e.g. srvNNNNNN.hstgr.cloud) and managed cloud/app instances - so that each customer receives a unique, addressable subdomain immediately on provisioning, independent of whether they have connected a custom domain.

**Organization Website:** https://www.hostinger.com/

## Reason for PSL Inclusion

Subdomains under hstgr.cloud are issued to mutually untrusted, unrelated end customers - each VPS or managed cloud instance is operated by a distinct party with full control over the content served from their assigned subdomain. Without PSL inclusion, user agents and downstream services treat hstgr.cloud as a single registrable domain, which means a customer on customerA.hstgr.cloud can set cookies scoped to .hstgr.cloud that are then transmitted to customerB.hstgr.cloud, and browser same-site/storage-partitioning logic groups all customer instances into one site. Listing hstgr.cloud in the PRIVATE section corrects this: it gives each customer subdomain its own cookie scope, its own site identity for same-site/partitioned-storage purposes, and removes the apex as a viable cookie-injection vector against sibling tenants.

This request is not being submitted to work around any third-party rate limit (Let's Encrypt, Cloudflare, or otherwise); the motivation is the cookie/origin isolation properties above. We have not opened prior issues or PRs related to this namespace. The hstgr.cloud registration is held by Hostinger and will be maintained with at least two years remaining at all times, and we will keep the _psl TXT record in place for as long as the entry is listed.

**Number of THOUSANDS of distinct users this request is being made to serve:** 520 thousands

This is an actual count (not estimate), pulled from Hostinger's internal billingsystems as of [2026-05-11], defined as: distinct customer accounts that currently hold at least one active VPS or managed cloud product with a *.hstgr.cloud hostname assigned. It excludes site visitors, trial accounts without provisioned compute, and customers whose only Hostinger products are shared hosting, domains, or email (those products do not issue hstgr.cloud subdomains and are out of scope).

### Technical usage of hstgr.cloud:

hstgr.cloud is operational DNS infrastructure that Hostinger uses to assign every customer VPS a unique, immediately-resolvable hostname at provisioning time, before the customer connects (or even owns) a custom domain.

### Subdomain format:
srv<numeric-id>.hstgr.cloud

<numeric-id> is the internal VPS identifier (currently 6–7 digits). Each VPS receives wildcard A and AAAA records on creation, pointing at the public IP assigned to that VM. The customer behind that VPS has root, controls everything served from the IP.

### Working examples (live, resolvable now):

dig +short srv829169.hstgr.cloud
dig +short srv553440.hstgr.cloud
dig +short hermes-workspace-btnh.srv578644.hstgr.cloud

You can also enumerate further live subdomains independently via Google's index of the namespace:
  
  ▎ https://www.google.com/search?q=site%3A*.hstgr.cloud

That returns indexed pages hosted on customer VPSes under the namespace, demonstrating both the srvNNNNNN.hstgr.cloud format in production and that distinct subdomains serve distinct, customer-controlled content.

<!-- 
The guidelines state that PSL inclusion is considered only for 
projects that have achieved a minimum of 2000 - 3000 distinct 
users or more. 

To be clear, 'users' is the number of distinct individuals 
working directly with a relationship with the requestor in 
using subnames of the requested space, and is not measured 
as the count of the audience of users that would visit to 
or interact with the namespace(s).

Please provide us this count, and identify if this is current 
actual count or an estimate. -->

## DNS Verification

```
dig +short TXT _psl.hstgr.cloud
"https://github.com/publicsuffix/list/pull/2907"
```

