### PR TITLE
Add QiYi Tech PRIVATE domains (j3.ink, l2.ink, p8.ink, 636.ltd)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15282,6 +15282,13 @@ ladesk.com
 *.qualyhqpartner.com
 *.qualyhqportal.com
 
+// QiYi Tech : https://7e.ink/
+// Submitted by Zhang Peng <zp@7e.ink>
+636.ltd
+j3.ink
+l2.ink
+p8.ink
+
 // QuickBackend : https://www.quickbackend.com
 // Submitted by Dani Biro <dani@pymet.com>
 qbuser.com


### PR DESCRIPTION
---
# Public Suffix List (PSL) Submission

### Checklist of required steps
- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**
- [x] This request was **not** submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges that it is our responsibility to maintain the domains within our section. This includes removing names which are no longer used, retaining the `_psl` DNS entry, and responding to emails sent to the supplied address.
- [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully read and understood, and this request conforms to them.
- [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
- [x] A role-based email address has been used and this inbox is actively monitored.

**Abuse Contact:**
- [x] Abuse contact information is available and easily accessible.
URL where abuse contact or abuse reporting form can be found: https://reg.7e.ink/report or mailto:zp@7e.ink

For PRIVATE section requests that are submitting entries for domains matching the organization website's primary domain, please understand this can impact cookies and rollout expectations and is hard to roll back.
- [x] **Yes, I understand**. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. **Proceed anyway**.

## Description of Organization
**Organization Website:** https://7e.ink/
**Organization Name:** 武汉七亿科技有限公司 (Wuhan QiYi Technology Co., Ltd.)

We operate the following properties under this entity:
- **reg.7e.ink** — Public subdomain registration service
- **auth.7e.ink** — Unified OAuth 2.0 identity platform
- **qr.7e.ink** — QR code utilities
- **test.7e.ink** — Testing platform
- **yun.636.su** — Server & infrastructure platform

## Reason for PSL Inclusion
**Estimated addressable user base (ecosystem-wide): ~5,000**

QiYi Tech operates a public subdomain registration service (reg.7e.ink) where unrelated users register and manage independent subdomains across multiple TLD suffixes. We currently offer four TLD suffixes; additional suffixes may be added in subsequent PRs as the service grows.

We request the following suffixes be treated as registrable public suffixes in PSL so browser and cookie boundaries correctly isolate unrelated users:
- `j3.ink`
- `l2.ink`
- `p8.ink`
- `636.ltd`

This is a multi-tenant subdomain namespace where each user controls their own subdomain(s). Without PSL inclusion, cookies and storage between unrelated users' subdomains are not properly isolated. This request is for correct operational safety and tenant isolation, not for circumventing any third-party controls.

**We are committed to maintaining these entries per PSL guidelines, keeping the `_psl` DNS records active and monitoring the abuse contact address.**

## DNS Verification
PSL validation TXT records have been added as required by RFC 8553 for all four domains:
- `_psl.j3.ink`
- `_psl.l2.ink`
- `_psl.p8.ink`
- `_psl.636.ltd`

All pointing to: `https://github.com/publicsuffix/list/pull/2909`

```bash
dig TXT _psl.j3.ink +short
# "https://github.com/publicsuffix/list/pull/2909"

dig TXT _psl.l2.ink +short
# "https://github.com/publicsuffix/list/pull/2909"

dig TXT _psl.p8.ink +short
# "https://github.com/publicsuffix/list/pull/2909"

dig TXT _psl.636.ltd +short
# "https://github.com/publicsuffix/list/pull/2909"
```

Thank you for your review.
