### PR TITLE
submission: add puter hosting ruls to PSL

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15249,6 +15249,7 @@ puter.app
 puter.dev
 puter.host
 puter.site
+puter.work
 
 // PythonAnywhere LLP : https://www.pythonanywhere.com
 // Submitted by Giles Thomas <giles@pythonanywhere.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15243,6 +15243,13 @@ nyc.mn
 // Submitted by Kor Nielsen <kor@pubtls.org>
 pubtls.org
 
+// Puter : https://puter.com
+// Submitted by Puter Security Team <security@puter.com>
+puter.app
+puter.dev
+puter.host
+puter.site
+
 // PythonAnywhere LLP : https://www.pythonanywhere.com
 // Submitted by Giles Thomas <giles@pythonanywhere.com>
 pythonanywhere.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15246,8 +15246,6 @@ pubtls.org
 // Puter : https://puter.com
 // Submitted by Puter Security Team <security@puter.com>
 puter.app
-puter.dev
-puter.host
 puter.site
 puter.work
 


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig

- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

- [x] This request was _not_ submitted with the objective of working around other third-party limits.

- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the \_psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

- [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
- [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

- [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://github.com/HeyPuter/puter/#support (lists `security@puter.com`, which receives both vulnerability disclosure and abuse reports)

---

- [x] _Yes, I understand_. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. _Proceed anyway_.

---

## Description of Organization

Puter is an open-source internet operating system that provides a cloud-based desktop environment with file storage, productivity apps, and a developer platform. Users get personal accounts under which they store files, host static sites, and run third-party apps. The project is open source (https://github.com/HeyPuter/puter) with a substantial public following, and it is run by Puter Technologies, Inc.

I (Daniel Salazar) am submitting this request on behalf of Puter Technologies, Inc., where I work on platform infrastructure. The submission covers the production domains under which we provision user-controlled subdomains and host third-party content.

**Organization Website:** https://puter.com

## Reason for PSL Inclusion

Puter assigns subdomains directly to end users and to third-party application content under five dedicated domains: `puter.site`, `puter.app`, `puter.dev`, `puter.host`, and `puter.work`. For example, every Puter user can host a static site at `<sitename>.puter.site`, and similar user/third-party content is published under the `.app`, `.dev`, `.host`, and `.work` siblings. Because user-controlled and third-party content lives under these names — one party per subdomain, many parties per zone — we need browsers and TLS clients to treat each subdomain as a registrable boundary so that:

- Cookies set by one user's subdomain cannot be scoped up to a parent that another user controls.
- TLS certificate issuance (Let's Encrypt) treats each user's subdomain as its own registrable name for rate-limit and validation purposes.
- Same-site/same-origin policies in browsers correctly isolate one customer's content from another's.

We are intentionally *not* listing `puter.com` or any of its subdomains. `puter.com` hosts our primary web application and marketing site, and all subdomains under it (e.g. `apps.puter.com`, `docs.puter.com`, `api.puter.com`, `dav.puter.com`) are Puter-controlled — we do not carve off user-assigned subdomains directly under `puter.com`, so no PSL boundary is required there.

All domains in this submission are registered with multi-year terms and will be maintained with more than one year remaining for as long as they are listed. We will keep the required `_psl` TXT records in place in each zone.

This request is not an attempt to bypass any third-party rate limit. We have not coordinated with Cloudflare, Let's Encrypt, Apple, GitLab, or any other vendor to obtain elevated limits in lieu of PSL listing.

**Number of THOUSANDS of distinct users this request is being made to serve:**
Puter has more than 1,200,000 registered users (>1200 thousand). This is an actual count, not an estimate.

## DNS Verification

```
dig +short TXT _psl.puter.app
"https://github.com/publicsuffix/list/pull/2914"

dig +short TXT _psl.puter.site
"https://github.com/publicsuffix/list/pull/2914"

dig +short TXT _psl.puter.work
"https://github.com/publicsuffix/list/pull/2914"
```

