### PR TITLE
Add moda.page to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14717,6 +14717,10 @@ mocha.app
 mochausercontent.com
 mocha-sandbox.dev
 
+// Moda : https://moda.page
+// Submitted by John Holliman <john@nullframe.ai>
+moda.page
+
 // MODX Systems LLC : https://modx.com
 // Submitted by Elizabeth Southwell <elizabeth@modx.com>
 modx.dev


### PR DESCRIPTION
## What

Adding `moda.page` to the PRIVATE section of the PSL, sorted alphabetically by organization name between the existing **Mocha** and **MODX Systems** entries.

```
// Moda : https://moda.page
// Submitted by John Holliman <john@nullframe.ai>
moda.page
```

## Why

Moda (Nullframe Inc.) is building a website-publishing product where users get a third-level subdomain — `<slug>.moda.page` — as the public URL for their published site. Each tenant's site is independently owned and operated; tenants are not affiliated with one another and do not share trust boundaries.

We want PSL inclusion specifically so that browsers and downstream consumers treat each `<slug>.moda.page` as its own registrable site. Concretely:

- **Cookie isolation.** Without PSL inclusion, a malicious tenant could set a cookie at the `Domain=moda.page` level that all other tenants would receive. PSL inclusion prevents that — browsers refuse to set a cookie at the eTLD.
- **localStorage / IndexedDB / origin-scoped storage.** Browsers and tools that respect the PSL treat each subdomain as a distinct origin owner for various same-site heuristics.
- **Safe Browsing / abuse signals.** Reports about one `<slug>` should not poison reputation for the entire `moda.page` zone or for unrelated sister tenants.

The setup mirrors patterns already in the list — `*.modx.dev`, `*.mocha.app`, etc. are private commercial platforms with the same multi-tenant subdomain model.

## Zone facts

- Domain registered: 2026-05-15 (NameCheap → delegated DNS to Cloudflare).
- Zone is Active in Cloudflare with Universal SSL covering `moda.page` and `*.moda.page`.
- The zone is reserved exclusively for serving customer-published sites — no marketing, app, or internal-tool traffic is hosted on `moda.page`. The Moda product site itself runs on `moda.app` (a separate zone) so PSL inclusion of `moda.page` does not affect Moda's first-party services.
- Until PSL approval lands, we do not advertise `moda.page` as a PSL domain to customers, and our serving code does not set `Domain=.moda.page` cookies — all cookies are host-only (`__Host-` prefix). This is documented internally as the bridging strategy during the PSL waiting period.

Happy to provide any additional ownership or operational verification — including adding a `_psl.moda.page` TXT record if that's part of current intake. Just let me know.