### PR TITLE
Add share.islo.dev: multi-tenant sandbox subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14225,6 +14225,10 @@ test-iserv.de
 iserv.dev
 iserv.host
 
+// Islo : https://islo.dev
+// Submitted by Yonatan Spektor <yonatan@islo.dev>
+share.islo.dev
+
 // Ispmanager : https://www.ispmanager.com/
 // Submitted by Ispmanager infrastructure team <infrastructure@ispmanager.com>
 ispmanager.name


### PR DESCRIPTION
## Organization

**Islo** — https://islo.dev

## Description of the domain(s) to be added

`share.islo.dev` is used to serve content from isolated, multi-tenant sandboxes. Each sandbox is assigned a unique subdomain (e.g., `<sandbox-id>.share.islo.dev`). Sandboxes belong to different, mutually-untrusting tenants.

Without PSL inclusion, a cookie set on `.share.islo.dev` by one tenant's sandbox subdomain would be readable by all other tenant subdomains — a cross-tenant security issue.

Adding `share.islo.dev` to the PSL ensures browsers treat each subdomain as a separate registrable domain, preventing cookie and same-site leakage across tenant boundaries.

## Example subdomains and expected behavior

| Domain | Expected registrable domain |
|---|---|
| `abc123.share.islo.dev` | `abc123.share.islo.dev` |
| `def456.share.islo.dev` | `def456.share.islo.dev` |
| `share.islo.dev` | (public suffix itself — no cookies allowed here) |

A cookie set by `abc123.share.islo.dev` must NOT be accessible to `def456.share.islo.dev`.

## Number of users

Islo serves thousands of sandbox executions. The domain is actively used in production.

## Domain registration

`islo.dev` has more than 2 years remaining on its registration. We commit to maintaining the registration in good standing with more than a year remaining at all times.

## DNS validation

A `_psl` TXT record will be set at `_psl.share.islo.dev` pointing to this PR per RFC 8553, once the PR number is known.


Made with [Cursor](https://cursor.com)