### PR TITLE
Add new entries for bd and ad domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -347,6 +347,13 @@ org.bd
 sch.bd
 tv.bd
 
+//https://xyz.bd/whois.php
+// Confirmed by registry <support@docify>
+xyz.bd
+club.bd
+names.ad
+qmail.ad
+
 // be : https://www.iana.org/domains/root/db/be.html
 // Confirmed by registry <tech@dns.be> 2008-06-08
 be


### PR DESCRIPTION
## Request to add multiple second-level domains

### .bd domains (Bangladesh)
- xyz.bd
- club.bd

### .ad domains (Andorra)
- names.ad
- qmail.ad

---

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook
  - Cloudflare: https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/
  - Let's Encrypt: https://letsencrypt.org/docs/rate-limits/

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The Guidelines were carefully read and understood, and this request conforms to them.

* [x] The submission follows the Guidelines on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://xyz.bd/abuse

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

**Organization Website:** https://xyz.bd

I am an individual operator managing second-level domain namespaces under the .bd (Bangladesh) and .ad (Andorra) ccTLDs. I operate xyz.bd and club.bd as public domain registration services for users in Bangladesh, functioning similarly to com.bd and net.bd. I also operate names.ad and qmail.ad as public registration namespaces under the .ad ccTLD. I am the submitter and sole technical operator of these domain namespaces, responsible for DNS management, abuse handling, and ongoing maintenance.

---

## Reason for PSL Inclusion

These domains function as second-level registration namespaces where individual users and organizations register subdomains (e.g. mybusiness.xyz.bd, mysite.club.bd). Without PSL inclusion, browsers and third-party services incorrectly treat all subdomains as part of the same registrable domain, causing cookie leakage between unrelated registered names and improper SSL certificate scoping.

We are seeking PSL inclusion for the following reasons:
- Correct cookie isolation between independently registered subdomains
- Proper SSL/TLS certificate handling via Let's Encrypt
- Correct domain boundary enforcement in Cloudflare and other CDN/proxy services

We have not attempted to work around any third-party limits. These domains are independently operated and have more than 2 years remaining on registration. The _psl TXT verification records are in place and will be maintained indefinitely.

**Number of THOUSANDS of distinct users this request is being made to serve:** approximately 1,000+ active subdomain users currently, with active growth.

---

## DNS Verification

```
dig +short TXT _psl.xyz.bd
"https://github.com/publicsuffix/list/pull/2921"
```

```
dig +short TXT _psl.club.bd
"https://github.com/publicsuffix/list/pull/2921"
```

```
dig +short TXT _psl.names.ad
"https://github.com/publicsuffix/list/pull/2921"
```

```
dig +short TXT _psl.qmail.ad
"https://github.com/publicsuffix/list/pull/2921"
```