### PR TITLE
Add xyz.bd, club.bd, names.ad, qmail.ad to the Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -21,7 +21,8 @@ org.ac
 // ad : https://www.iana.org/domains/root/db/ad.html
 // Confirmed by Amadeu Abril i Abril (CORE) <amadeu.abril@corenic.org> 2024-11-17
 ad
-
+names.ad
+qmail.ad
 // ae : https://www.iana.org/domains/root/db/ae.html
 ae
 ac.ae
@@ -346,6 +347,8 @@ net.bd
 org.bd
 sch.bd
 tv.bd
+xyz.bd
+club.bd
 
 // be : https://www.iana.org/domains/root/db/be.html
 // Confirmed by registry <tech@dns.be> 2008-06-08

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -21,8 +21,7 @@ org.ac
 // ad : https://www.iana.org/domains/root/db/ad.html
 // Confirmed by Amadeu Abril i Abril (CORE) <amadeu.abril@corenic.org> 2024-11-17
 ad
-names.ad
-qmail.ad
+
 // ae : https://www.iana.org/domains/root/db/ae.html
 ae
 ac.ae
@@ -347,8 +346,7 @@ net.bd
 org.bd
 sch.bd
 tv.bd
-xyz.bd
-club.bd
+
 
 // be : https://www.iana.org/domains/root/db/be.html
 // Confirmed by registry <tech@dns.be> 2008-06-08
@@ -11256,6 +11254,15 @@ zuerich
 // ===BEGIN PRIVATE DOMAINS===
 
 // (Note: these are in alphabetical order by company name)
+
+// xyz.bd registry
+// https://registry.xyz.bd
+// Confirmed by registry <support@xyz.bd>
+xyz.bd
+club.bd
+names.ad
+qmail.ad
+
 
 // .KRD : https://nic.krd
 co.krd

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -347,7 +347,6 @@ org.bd
 sch.bd
 tv.bd
 
-
 // be : https://www.iana.org/domains/root/db/be.html
 // Confirmed by registry <tech@dns.be> 2008-06-08
 be
@@ -11255,14 +11254,11 @@ zuerich
 
 // (Note: these are in alphabetical order by company name)
 
-// xyz.bd registry
-// https://registry.xyz.bd
-// Confirmed by registry <support@xyz.bd>
+// xyz.bd : https://registry.xyz.bd
 xyz.bd
 club.bd
 names.ad
 qmail.ad
-
 
 // .KRD : https://nic.krd
 co.krd


### PR DESCRIPTION
# Public Suffix List (PSL) Submission
### Checklist of required steps
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).
__Submitter affirms the following:__ 
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address.
* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
---
**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible.
URL where abuse contact or abuse reporting form can be found:  
https://xyz.bd/abuse
Email: abuse@xyz.bd
---
* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---
## Description of Organization
xyz.bd is a public domain registration service providing second-level domains under the .bd and .ad namespaces for individuals, developers, and businesses.

The platform operates a multi-tenant domain infrastructure where users can register and manage domains through a self-service registry portal at https://registry.xyz.bd/. It is actively used for personal websites, business presence, and community projects.

**Organization Website:**  
https://xyz.bd/
---
## Reason for PSL Inclusion
This submission adds the following domains as new public suffixes:
- xyz.bd
- club.bd
- names.ad
- qmail.ad

These domains are in active use with thousands of registered domains and continuous growth. They are fully integrated into the registry dashboard and follow a multi-tenant model where each customer receives an independently managed domain.

The addition of these suffixes ensures proper cookie isolation between unrelated users, prevents cross-origin data leakage, and aligns browser behavior with the intended multi-tenant usage of the domains.

**Number of THOUSANDS of distinct users this request is being made to serve:**  
1+ (~1,000-5,000 active users, current estimate)
---
## DNS Verification
```
dig +short TXT _psl.xyz.bd
"https://github.com/publicsuffix/list/pull/2923"
```
```
dig +short TXT _psl.club.bd
"https://github.com/publicsuffix/list/pull/2923"
```
```
dig +short TXT _psl.names.ad
"https://github.com/publicsuffix/list/pull/2923"
```
```
dig +short TXT _psl.qmail.ad
"https://github.com/publicsuffix/list/pull/2923"
```
We commit to maintaining these records indefinitely.