### PR TITLE
Add nit.lat and update comments in public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15204,6 +15204,11 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
+// Prisma S.U.R.L. : https://nic.nit.lat
+// Submitted by Yunior Alejandro Cristia Gutierrez <contacto@nit.lat>
+// Abuse reports to <abuse@nit.lat>
+nit.lat
+
 // PROJECT ELIV : https://eliv.kr/
 // Submitted by PROJECT ELIV DomainName Team <team@eliv.kr>
 c01.kr


### PR DESCRIPTION
Added new entries for nit.lat and updated comments.

# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)
 - Let's Encrypt

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the Guidelines on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://nit.lat/contacto

---

(Link: about propagation/expectations)

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

I am Yunior Cristia, the founder and technical administrator of Prisma S.U.R.L. and Neti Network. We operate a domain registration and hosting infrastructure, acting as a private registry for the `nit.lat` extension. Our core focus is providing third-level domains to end customers and external resellers through our automated API and WHMCS modules.

**Organization Website:**
https://nit.lat

## Reason for PSL Inclusion

We operate `nit.lat` as a private Top-Level Domain (pTLD) offering subdomains (e.g., customer.nit.lat) to independent users and external resellers. We require inclusion in the PRIVATE section of the PSL to ensure strict security isolation between our clients, preventing cross-domain cookie bleeding. Additionally, inclusion allows our clients to generate independent SSL certificates (such as Let's Encrypt) without hitting the strict rate limits of our base domain. I confirm that the `nit.lat` domain has a registration term longer than two years and we will maintain the `_psl` TXT record in our DNS zone.

**Number of THOUSANDS of distinct users this request is being made to serve:**
1

## DNS Verification