### PR TITLE
Add vibehost.space for cross-tenant cookie isolation

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13888,6 +13888,10 @@ whitesnow.jp
 zombie.jp
 heteml.net
 
+// GNTC, Inc. : https://gntc.com/
+// Submitted by VibeHost Security <security@vibehost.com>
+vibehost.space
+
 // GoDaddy Registry : https://registry.godaddy
 // Submitted by Rohan Durrant <tldns@registry.godaddy>
 graphic.design


### PR DESCRIPTION
  # Public Suffix List (PSL) Submission

  <!--
  Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well
   as a number of acknowledgements from the submitter. This template must be included with each PR, and the
  submitting party MUST provide responses to all of the elements in order to be considered.
  -->

  <!-- #### READ THIS FIRST ####

  If you haven't yet, please read our guidelines:
  https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

  Also, read them again, as many skip that part and
  get confused about why their PR is delayed or does
  not get accepted when their submission doesn't follow them.

  A recent PR using the current template is
  https://github.com/publicsuffix/list/pull/2835, although
  the organization and description were not as substantial
  as desired, which required maintainers' time to visit the
  requestor's website to further research.
  Having more robust org/desc improves the PR processing
  pace because extra cycles are not lost to research.
  For an example of what an excellent description in a PR looks like
  see https://github.com/publicsuffix/list/pull/615,
  although that example uses an earlier template.
  -->

  ### Checklist of required steps

  * [x] Description of Organization
  * [x] Robust Reason for PSL Inclusion
  * [x] DNS verification via dig

  * [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on
  registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

  __Submitter affirms the following:__
  <!--
  Third-party Limits are used elsewhere, such as at Cloudflare, Let's
  Encrypt, Apple, GitLab or others, and having an entry in the PSL alters
  the manner in which those third-party systems or products treat
  a given domain name or sub-domains within it.

  To be clear, it is appropriate to address how those limits impact
  your domain(s) directly with that third-party, and it is inappropriate
  to submit entries to the PSL as a means to work around those limits or
  restrictions.
  -->

   * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those
  between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a
  well-documented example) — N/A: this submission does not seek to work around any third-party limit; no such
  limits apply.

  <!--
  The purpose of the question above is to expose limit workarounds.
  If there are third party limits that the PR seeks to overcome, those
  must be listed within the rationale section of this request, and
  provide a good level of detail regarding the effort that was made to work directly
  with the third party or parties in attempting to address this within their
  rationale response below.
  In all cases, software and services should be discouraged from use of
  the PSL as a rate-limiting tool, and provide clear instructions to their
  own clients, partners and users on the manner in which they can directly
  request rate limit increases.
  We treat the following as an attestation in the public record of the
  requesting party that they are not attempting to bypass rate limits through
  the PR.
  -->

   * [x] This request was _not_ submitted with the objective of working around other third-party limits.

  <!--
  Submitter will maintain domains in good standing or may lose section.

  The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull
  request, there is a commitment by the submitter that they are going to review and maintain their relevant
  section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if
  the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to
  resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further
  identifies that it is their responsibility to review their submitted section within the PSL, submitting
  updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter
  to provide (and keep up to date) a reachable email address within the section, and to maintain that address
  as it may change over time, so that they receive notices.
  -->

   * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their
  section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding
  to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries
  or the entire section.

  <!--
  The guidelines describe which section to place the entry in, the
  order of commented organization placement, and the order of sorting of entries.
  (Hint: TLD then SLD, ascending sorting) Although it seems pedantic,
  the sorting and formatting rules help ensure all of the automation
  that uses the PSL operates correctly. Typically, both are solved or
  neither.
  -->

   * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and
  _understood_, and this request conforms to them.
   * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on
  formatting and sorting.

  <!--
  Sorting and formatting of the entries is outlined in the guidelines
  and non-conforming requests are one of the largest sources of delay,
  so getting this right initially will aid successfully having it
  proceed. Mislocated entries and trailing spaces should be avoided.
  -->

  <!--
  In your submission, please include a role-based email address (e.g. security@example.com) rather than a
  personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain
  contact with your organization, independent of personnel changes.
  This email address will be used for any required verification or inquiries regarding your PSL listing. This
  inbox must be actively maintained and monitored for future communications from the PSL project for as long as
   the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30
  days, as maintaining timely communication is required for continued inclusion in the PSL.
  -->

   * [x] A role-based email address has been used and this inbox is actively monitored with a response time of
  no more than 30 days.

  **Abuse Contact:**

  <!--
  Please confirm that you have accessible abuse contact information on your website.

  At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can
   be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the
  registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are
  detected. For example, if you provide subdomains at example.com, where users may register subdomains such as
  clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find
  the relevant abuse contact information.
  -->

  * [x] Abuse contact information (email or web form) is available and easily accessible.

    URL where abuse contact or abuse reporting form can be found: https://vibehost.com/security/

  ---

  For PRIVATE section requests that are submitting entries for domains that match their organization website's
  primary domain, please understand that this can have impacts that may not match the desired outcome and take
  a long time to roll back, if at all.

  To ensure that requested changes are entirely intentional, make sure that you read the affectation and
  propagation expectations, that you understand them, and confirm this understanding.

  PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other
  parties using the PSL will refresh or update.

  <!--
  Seriously, carefully read the downline flow of the PSL and the
  guidelines. Your request could very likely alter the cookie and
  certificate (as well as other) behaviours on your core domain name in
  ways that could be problematic for your business.

  Rollbacks are really not predictable, as those who use or incorporate
  the PSL do what they do, and when. It is not within the PSL volunteers'
  control to do anything about that.

  The volunteers are busy with new requests, and rollbacks are lowest
  priority, so if something gets broken by your PR, it will potentially
  stay that way for an indefinite period of time (typically long).
  -->

  (Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expe
  ctations-on-derivative-propagation-use-or-inclusion))

   * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the
  rollback timing is acceptable. *Proceed anyway*.
  ---

  ## Description of Organization

  **Organization Website:** https://gntc.com/

  GNTC, Inc. builds and operates VibeHost (https://vibehost.com/), a hosting platform for AI-built and
  "vibe-coded" web applications. Each application a customer deploys is served from its own dedicated subdomain
   of `vibehost.space` (`<app>.vibehost.space`), serving that customer's own uploaded HTML, CSS and JavaScript
  — the same one-app-per-subdomain hosting model operated by Vercel (`vercel.app`, `vusercontent.net`),
  Cloudflare Pages (`pages.dev`) and Netlify (`netlify.app`), all already listed in the PRIVATE section. I am
  submitting this on behalf of GNTC as an engineer on the VibeHost platform team responsible for its tenant
  isolation; `security@vibehost.com` is our monitored role mailbox for this listing.

  ## Reason for PSL Inclusion

  VibeHost hosts independent, mutually-untrusted user content on sibling subdomains of a single shared parent,
`vibehost.space`. Because that parent is an ordinary registrable domain, browsers currently treat every
  `<app>.vibehost.space` as part of one site. Per RFC 6265 §4.1.2.3 a host such as `alice.vibehost.space` may
  set a cookie scoped to `Domain=vibehost.space` (over the wire or via `document.cookie`), and a cookie
  carrying that Domain attribute is then sent to every sibling subdomain — the section's own example notes a
  `Domain=example.com` cookie is returned to `example.com`, `www.example.com` and `www.corp.example.com`.

  We are requesting this listing to defend against cross-tenant cookie injection ("cookie tossing"), session
  fixation, and supercookie scenarios between sibling tenants. Listing `vibehost.space` as a public suffix
  causes user agents to reject such a parent-scoped `Domain` attribute (RFC 6265 §4.1.2.3 NOTE and §5.3), so
  cookie scope and same-origin boundaries fall on a single tenant rather than across the whole namespace. This
  is a defense-in-depth isolation motivation; it is **not** an attempt to work around any third-party rate
  limit or vendor restriction. It is the same rationale under which the analogous hosting providers named above
   were added to the PRIVATE section.

  We confirm that `vibehost.space` holds more than two years of registration term (expiry 2032-04-21) and that
  we will maintain more than one year of remaining term and keep the `_psl` record in place for as long as the
  entry remains listed.

  **Number of THOUSANDS of distinct users this request is being made to serve:**
  Over 100,000 distinct users (current actual count) — distinct individuals who deploy and operate apps on
  `*.vibehost.space`, not visitor/audience counts.

  ## DNS Verification

  ```
dig +short TXT _psl.vibehost.space
"https://github.com/publicsuffix/list/pull/2932"
  ```

  (XXXX will be this PR's number. The `_psl` TXT record will be created in the `vibehost.space` Cloudflare zone
   immediately after the PR number is assigned, and will be kept in place for as long as the entry remains
  listed.)
