### PR TITLE
Add STACKIT CDN Subdomain and update company info

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15603,6 +15603,15 @@ dedibox.fr
 // Submitted by Hanno Böck <hanno@schokokeks.org>
 schokokeks.net
 
+// Schwarz Digits Cloud GmbH & Co. KG : https://stackit.com/en
+// Submitted by STACKIT-DNS Team (Simon Stier) <dns@digits.schwarz>
+cdn.onstackit.cloud
+runs.onstackit.cloud
+stackit.gg
+stackit.rocks
+stackit.run
+stackit.zone
+
 // Scottish Government : https://www.gov.scot
 // Submitted by Martin Ellis <martin.ellis@gov.scot>
 gov.scot
@@ -15804,15 +15813,6 @@ bolt.host
 // Stackhero : https://www.stackhero.io
 // Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
 stackhero-network.com
-
-// Schwarz Digits Cloud GmbH & Co. KG : https://stackit.com/en
-// Submitted by STACKIT-DNS Team (Simon Stier) <dns@digits.schwarz>
-cdn.onstackit.cloud
-runs.onstackit.cloud
-stackit.gg
-stackit.rocks
-stackit.run
-stackit.zone
 
 // Stackryze : https://stackryze.com
 // Submitted by Sudheer Bhuvana <security@stackryze.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15805,8 +15805,9 @@ bolt.host
 // Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
 stackhero-network.com
 
-// STACKIT GmbH & Co. KG : https://www.stackit.de/en/
-// Submitted by STACKIT-DNS Team (Simon Stier) <dns@stackit.cloud>
+// Schwarz Digits Cloud GmbH & Co. KG : https://stackit.com/en
+// Submitted by STACKIT-DNS Team (Simon Stier) <dns@digits.schwarz>
+cdn.onstackit.cloud
 runs.onstackit.cloud
 stackit.gg
 stackit.rocks


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: https://stackit.com/en/imprint
---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->
Schwarz Digits Cloud GmbH & Co. KG (operating as STACKIT) is a German cloud provider offering comprehensive managed Infrastructure-as-a-Service (IaaS) and Platform-as-a-Service (PaaS) solutions. I am a CDN Engineer within the organization, submitting this request to update our existing list of registered public suffixes to include our newly launched customer CDN platform. Our infrastructure allows enterprise clients to provision multi-tenant cloud environments, including automated CDN distributions, using dedicated subdomains under our corporate-managed zones.

**Organization Website:** https://stackit.com/en
<!-- Provide the website address of the org as a full URL (i.e. https://example.com) -->

## Reason for PSL Inclusion
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, iOS/Facebook, 
Cloudflare, etc.) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also reference any past issues or PRs 
specifically related to this submission or section.

Provide three or more sentences here that describe the purpose 
for which your PR should be included in the PSL. There is no 
upper limit, but six paragraphs seems like a rational stop.
-->
Our customers share provided domains that are registered and owned natively by us. Specifically, for `cdn.onstackit.cloud`, when a customer provisions a new CDN distribution, they are automatically allocated a unique frontend subdomain (e.g., `<uid>.cdn.onstackit.cloud`) routing to their respective backend. Because individual tenants have autonomous control over their hosted content and DNS routing within these subdomains, we must safeguard these environments from cross-subdomain cookie exchange, session hijacking, and related web vulnerabilities. 

Including these entries in the Private section of the PSL ensures proper cookie isolation and prevents "supercookies" from being set across independent customer applications. All added domains maintain a registration status exceeding two years.

**Regarding Let's Encrypt Rate Limits:**
We want to explicitly clarify that this PSL submission is strictly driven by the security architecture detailed above, and is not an attempt to bypass Let's Encrypt rate limits. The root domain `onstackit.cloud` currently utilizes an increased limit of 10,000 new certificates per Registered Domain every 7 days. Because this domain is shared in parallel by other core STACKIT services, we are independently engaging Let's Encrypt via a separate request to decouple that limit to `cdn.onstackit.cloud` and to scale our ACME account limits. This PSL request is decoupled from that process and focuses entirely on browser-level cookie boundary enforcement.

**Number of THOUSANDS of distinct users this request is being made to serve:** over 550k
<!-- 
The guidelines state that PSL inclusion is considered only for 
projects that have achieved a minimum of 2000 - 3000 distinct 
users or more. 

To be clear, 'users' is the number of distinct individuals 
working directly with a relationship with the requestor in 
using subnames of the requested space, and is not measured 
as the count of the audience of users that would visit to 
or interact with the namespace(s).

Please provide us this count, and identify if this is current 
actual count or an estimate. -->

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
```
dig +short TXT _psl.cdn.onstackit.cloud
"https://github.com/publicsuffix/list/pull/2935"
```
As we changed the company Name, we also renewed the PSL entries of the other domains:
```
dig +short TXT _psl.runs.onstackit.cloud
"https://github.com/publicsuffix/list/pull/2935"

dig +short TXT _psl.stackit.gg
"https://github.com/publicsuffix/list/pull/2935"

dig +short TXT _psl.stackit.rocks
"https://github.com/publicsuffix/list/pull/2935"

dig +short TXT _psl.stackit.run
"https://github.com/publicsuffix/list/pull/2935"

dig +short TXT _psl.stackit.zone
"https://github.com/publicsuffix/list/pull/2935"
```
