### PR TITLE
Add kaps.run, preview.kaps.run, kapsulesites.com, kapsulecloud.app (Kapsule Group Limited)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14351,6 +14351,13 @@ khplay.nl
 // Submitted by Tomi Juntunen <erani@kapsi.fi>
 kapsi.fi
 
+// Kapsule Group Limited : https://kapsulecloud.com
+// Submitted by Jesse Evenblij <jesse@kapsule.co.nz>
+kaps.run
+preview.kaps.run
+kapsulesites.com
+kapsulecloud.app
+
 // KataBump : https://katabump.com
 // Submitted by Thibault Lapeyre <contact@katabump.com>
 kdns.fr


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section, including removing unused names, retaining the _psl DNS entry, and responding to emails to the supplied address.
* [x] The Guidelines were carefully read and understood, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information is available and easily accessible.

  URL: https://kapsulecloud.com/abuse

* [x] *Yes, I understand.* I could affect cookie/certificate behaviour and rollback timing is acceptable. *Proceed anyway.*

---

## Description of Organization

**Organization Website:** https://kapsulecloud.com

Kapsule Cloud is a New Zealand web hosting and cloud platform operated by Kapsule Group Limited (NZ Company #8428432). We provide website hosting, managed WordPress, email, and developer deployment products. I am Jesse Evenblij, founder and operator, submitting on behalf of the company as the registrant of the domains listed. Our role-based contact for PSL matters is security@kapsulecloud.com, which is actively monitored.

## Reason for PSL Inclusion

We are requesting four domains in the PRIVATE section. All four host per-customer subdomains where different customers operate on sibling subdomains of the same registrable domain, creating cross-tenant cookie-leakage risk that PSL listing resolves:

- **kaps.run** and **preview.kaps.run** — our developer deployment product. Each customer project gets {project}.kaps.run, and pull-request previews get {hash}.preview.kaps.run. Both levels are listed so each project is isolated at each level.
- **kapsulesites.com** — every provisioned hosting site receives a {label}.kapsulesites.com subdomain.
- **kapsulecloud.app** — GitHub-integrated preview deploys land at pr-{n}-{siteId}.kapsulecloud.app, one per customer site.

Without PSL listing, browsers treat all subdomains as sharing one registrable domain, so one customer's code could set cookies scoped to the parent domain that are sent to other customers' subdomains. This is a cookie-security isolation requirement, not an attempt to work around any third-party rate limits (Cloudflare, Let's Encrypt, or otherwise). All four domains have more than two years remaining on registration, and we will maintain the _psl TXT records for as long as the entries remain listed.

**Number of THOUSANDS of distinct users:** The platform is pre-launch; current distinct user count is below the 2000-3000 guideline. Submitting now to establish correct per-customer cookie isolation ahead of multi-tenant public launch, per PSL's preference for submission before or at launch.

## DNS Verification

dig +short TXT _psl.kaps.run
"https://github.com/publicsuffix/list/pull/2940"

dig +short TXT _psl.preview.kaps.run
"https://github.com/publicsuffix/list/pull/2940"

dig +short TXT _psl.kapsulesites.com
"https://github.com/publicsuffix/list/pull/2940"

dig +short TXT _psl.kapsulecloud.app
"https://github.com/publicsuffix/list/pull/2940"