### PR TITLE
Add mygeevos.ai (Geevos) to PRIVATE DOMAINS

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13737,6 +13737,10 @@ independent-review.uk
 public-inquiry.uk
 royal-commission.uk
 
+// Geevos : https://geevos.ai
+// Submitted by Abdullah Alowais <aahnsa@gmail.com>
+mygeevos.ai
+
 // Gehirn Inc. : https://www.gehirn.co.jp/
 // Submitted by Kohei YOSHIDA <tech@gehirn.co.jp>
 gehirn.ne.jp


### PR DESCRIPTION
# Add mygeevos.ai (Geevos) to PRIVATE DOMAINS

**Entity:** Geevos — an AI-powered website/app builder (https://geevos.ai). Each customer is provisioned
a site at `<customer-slug>.mygeevos.ai`.

**Why this addition is needed:** We host many independent, mutually-distrusting customer sites as
subdomains of `mygeevos.ai` (the same model as `vercel.app`, `github.io`, and `pages.dev`). Listing
`mygeevos.ai` in the PRIVATE section makes each `<slug>.mygeevos.ai` its own registrable boundary, so a
cookie / localStorage / same-origin scope set on one customer's subdomain cannot be read or written by
another customer's subdomain. Without the listing, all customer subdomains share `mygeevos.ai` as their
registrable domain, which is a cross-customer security boundary problem.

**Expected behavior after merge**

| Input | `getPublicSuffix()` | `getRegistrableDomain()` |
|---|---|---|
| `mygeevos.ai` | `mygeevos.ai` | `null` |
| `alice.mygeevos.ai` | `mygeevos.ai` | `alice.mygeevos.ai` |
| `bob.mygeevos.ai` | `mygeevos.ai` | `bob.mygeevos.ai` |

i.e. `alice.mygeevos.ai` and `bob.mygeevos.ai` are distinct registrable domains and therefore distinct
cookie/security boundaries.

**Registration & maintenance**
- `mygeevos.ai` is registered and under our control (DNS on Cloudflare).
- It has **at least 2 years** remaining on its registration.
- We commit to keeping the registration in good standing and to keeping the `_psl` DNS TXT record in place
  to announce continued inclusion.

**`_psl` validation record:** a `_psl.mygeevos.ai` DNS TXT record pointing to this PR's URL is in place
(per the submission guidelines).
