### PR TITLE
Add lfa.zone (private domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14433,6 +14433,10 @@ leapcell.app
 leapcell.dev
 leapcell.online
 
+// lfa.zone : https://lfa.zone
+// Submitted by application.ist <support@application.ist>
+lfa.zone
+
 // Liara : https://liara.ir
 // Submitted by Amirhossein Badinloo <info@liara.ir>
 liara.run


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
   - No third-party rate limits are being worked around by this submission.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://lfa.zone

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

**Organization Website:** https://lfa.zone

lfa.zone is the app-runtime domain of a multi-tenant, local-first application platform. The platform enables third-party developers to publish isolated web applications, each served on its own subdomain of the form `<slug>.lfa.zone`. The platform is operated by kookyleo, an individual developer and the domain registrant. Each subdomain hosts a distinct application with its own data, users, and trust boundary — no application shares state with another.

The platform is architected around a local-first data model: application data is stored and processed client-side, with cloud sync as an optional layer. Third-party app developers integrate via a published SDK; each registered app slug receives its own `<slug>.lfa.zone` origin at deployment time. The submitter (kookyleo) is the sole administrator of the lfa.zone domain and is responsible for subdomain allocation and DNS management.

The platform is currently in active development and early rollout, targeting developers building privacy-preserving, offline-capable web tools.

## Reason for PSL Inclusion

lfa.zone requires PSL inclusion for the same fundamental reason as `github.io`, `workers.dev`, `vercel.app`, and similar platforms: each `<slug>.lfa.zone` subdomain is a fully independent registrable site hosting an application from a distinct third-party developer. These applications are mutually distrusting — they must not share cookies, storage, or certificate scope with one another or with the root domain `lfa.zone`.

Without PSL inclusion, browsers treat all `*.lfa.zone` subdomains as belonging to the same registrable domain as `lfa.zone` itself, which would allow cookie leakage across application boundaries (e.g., a cookie set on `app1.lfa.zone` could be scoped to `.lfa.zone` and read by `app2.lfa.zone`). This violates the isolation guarantees the platform provides to its app developers and their users.

PSL inclusion ensures that each `<slug>.lfa.zone` is treated as a separate effective top-level domain, providing proper cookie isolation, independent Let's Encrypt certificate issuance per subdomain, and correct browser security-boundary enforcement. This is the canonical use case for PRIVATE section PSL entries: a platform issuing subdomains to mutually distrusting third-party operators.

The domain `lfa.zone` is registered and maintained by the submitter with more than two years remaining on its registration. The `_psl.lfa.zone` DNS TXT validation record has been added pointing to this PR.

**Number of THOUSANDS of distinct users this request is being made to serve:** The platform is in early rollout. Current distinct subdomain operators: ~10 (developers in closed beta). Target scale is thousands of distinct app operators within 12 months of public launch.

## DNS Verification

The `_psl.lfa.zone` TXT record has been set to point to this pull request URL.

```
dig +short TXT _psl.lfa.zone
"https://github.com/publicsuffix/list/pull/2943"
```

(The exact PR URL will be confirmed once this PR is assigned a number and the DNS record is live — TTL 300s.)