### PR TITLE
Add shogayaki.site to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15751,6 +15751,10 @@ playstation-cloud.com
 // Submitted by Drew DeVault <sir@cmpwn.com>
 srht.site
 
+// Shogayaki : https://shogayaki.site
+// Submitted by Sina Orojlo <sinawork@aol.com>
+shogayaki.site
+
 // SourceLair PC : https://www.sourcelair.com
 // Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
 apps.lair.io


### PR DESCRIPTION

# Public Suffix List (PSL) Submission
### Checklist of required steps
 * [x] Description of Organization
 * [x] Robust Reason for PSL Inclusion
 * [x] DNS verification via dig
 * [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _psl TXT record in place in the respective zone(s).
**Submitter affirms the following:**
 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)
 * Cloudflare
 * [x] This request was *not* submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The Guidelines were carefully *read* and *understood*, and this request conforms to them.
 * [x] The submission follows the Guidelines on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
**Abuse Contact:**
 * [x] Abuse contact information (email or web form) is available and easily accessible.
   URL where abuse contact or abuse reporting form can be found:
   https://shogayaki.site/abuse
 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
## Description of Organization
I represent the Shogayaki project, which operates a multi-tenant development platform and edge computing environment for distributed engineering teams. Our core focus is providing isolated namespaces (subdomains) to independent developers and team members so they can deploy and manage autonomous serverless functions and web applications. I serve as the lead systems administrator, managing the root domain infrastructure and DNS delegations. By adding our domain to the PSL, we aim to ensure that our users have true administrative and cryptographic independence over their assigned subdomains.
**Organization Website:**
https://shogayaki.site
## Reason for PSL Inclusion
Our domain, shogayaki.site, requires inclusion in the PSL primarily for strict cookie security and domain isolation across our multi-tenant user base. Because our users deploy independent web applications and edge functions (such as Cloudflare Workers) on their respective subdomains, it is a critical security requirement that browsers treat these subdomains as separate origins to prevent cross-subdomain cookie leakage.
Furthermore, without PSL inclusion, cloud providers like Cloudflare treat our domain as a single contiguous zone, meaning independent developers cannot attach their assigned subdomains to their own distinct cloud accounts. By adding shogayaki.site to the PSL, our users will be able to manage their own SSL certificates, set their own cross-origin policies, and route traffic directly to their isolated edge environments seamlessly. I confirm that all domains listed in this private section have a registration term of longer than two years, and we shall maintain more than one year term at all times in order to remain listed.
**Number of THOUSANDS of distinct users this request is being made to serve:**
3000 (Estimate: Current scaling target for independent developer namespaces and edge deployments)
## DNS Verification
```
dig +short TXT _psl.shogayaki.site
"https://github.com/publicsuffix/list/pull/XXXX"

```
*(Note: The TXT record will be deployed with the PR URL immediately after this Pull Request is opened and assigned an ID number).*
