### PR TITLE
Add sendoracloud.app (PRIVATE)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15641,6 +15641,10 @@ sellfy.store
 // Submitted by Assaf Stern <domains@comstar.co.il>
 minisite.ms
 
+// Sendora Cloud : https://sendoracloud.com
+// Submitted by Paramvir Singh <0091param@gmail.com>
+sendoracloud.app
+
 // Senseering GmbH : https://www.senseering.de
 // Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
 senseering.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale — **none apply.** This request is solely for credential-manager (saved-password) origin isolation between mutually-distrusting tenant subdomains. We are **not** working around any Cloudflare, Let's Encrypt, or Apple limit.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section (removing unused names, retaining the `_psl` DNS entry, and responding to e-mails to the supplied address).

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. (`abuse@sendoracloud.com` — role-based, monitored, with a documented triage runbook.)

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: **https://sendoracloud.com/abuse**

* [x] *Yes, I understand.* I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway.* (The listed domain `sendoracloud.app` is a dedicated per-tenant hosting zone, separate from our corporate/control-plane `sendoracloud.com`, so the affected surface is exactly the intended one.)

---

## Description of Organization

**Organization Website:** https://sendoracloud.com

Sendora Cloud is a customer-engagement and mobile-SDK platform (deep links, push, analytics, and end-user authentication for our customers' apps), operated by a single founding engineer. I am the submitter and the technical owner of the domain; I make this request directly as an individual, not on behalf of a third party.

The platform is multi-tenant: each customer ("project") that integrates our SDK is provisioned an isolated end-user origin at `<project>.sendoracloud.app`, which hosts that tenant's own end-user-facing pages — password reset, email verification, and the WebAuthn passkey ceremony. The end users of one tenant app are distinct, unrelated people from the end users of another tenant app; they share only our hosting.

`sendoracloud.app` is a **dedicated** domain used only for this per-tenant hosting. Our corporate site, dashboard, control-plane, and marketing all live on the separate `sendoracloud.com` and are **not** part of this request.

## Reason for PSL Inclusion

We request a PRIVATE-section entry for **saved-password (credential-manager) isolation** between mutually-distrusting tenants hosted on sibling subdomains of a single registrable domain. On iOS (iCloud Keychain / Passwords) and Android (Google Password Manager), the OS credential manager stores and offers **saved passwords by registrable domain (eTLD+1)** — which is defined by the PSL. So a password an end user saves for `tenant-a.sendoracloud.app` is grouped under `sendoracloud.app` and offered by the OS on `tenant-b.sendoracloud.app`, a cross-tenant credential-confusion and leakage risk between two unrelated consumer apps that merely share our hosting. This grouping is enforced by the OS credential manager and **cannot** be overridden by any server-sent mechanism (Associated Domains / `webcredentials`, Digital Asset Links, or cookie attributes) — only a PSL entry makes each `<tenant>.sendoracloud.app` its own registrable site.

To be precise about scope (addressing the earlier review of this PR): we have narrowed the rationale to exactly the one mechanism that requires the PSL. We are **not** relying on cookie isolation — we set only host-only cookies, with no `Domain`-scoped cookies on this zone (enforced in our CI), which already isolates cookies per host without the PSL. We are **not** relying on WebAuthn — our passkey `rpId` is already per-subdomain (`<tenant>.sendoracloud.app`), which isolates passkeys without the PSL. The **sole** isolation the PSL provides that we cannot otherwise achieve is the saved-password / credential-manager eTLD+1 grouping.

This is the same rationale under which other multi-tenant hosting domains appear in the PRIVATE section (e.g. `*.vercel.app`, `*.netlify.app`, `*.web.app`, `github.io`, `*.pages.dev`). `sendoracloud.app` is registered for a term of **more than two years** and we will maintain more than one year remaining for as long as it is listed, keeping the `_psl` TXT record published.

**Number of THOUSANDS of distinct users this request is being made to serve:**

**Well under 1 — approximately 5–6 distinct tenant organizations operating subnames today (current actual count, not an estimate).** We understand the ~2000–3000 guideline and that this request may be **declined or deferred on user-count grounds**; we state the real figure rather than inflate it, and are glad to hold this PR open or resubmit as tenant adoption grows.

## DNS Verification

```
$ dig +short TXT _psl.sendoracloud.app
"https://github.com/publicsuffix/list/pull/2946"
```

The record is published and will remain in place to announce continued inclusion.
