### PR TITLE
Add ikiro.pro to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14105,6 +14105,10 @@ iliadboxos.it
 imagine.diy
 imagine-proxy.work
 
+// Ikiro : https://ikiro.io
+// Submitted by Ikiro <security@ikiro.io>
+ikiro.pro
+
 // Incsub, LLC : https://incsub.com/
 // Submitted by Aaron Edwards <sysadmins@incsub.com>
 smushcdn.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - Cloudflare — not applicable; we are not seeking to work around Cloudflare subdomain account limits.
 - Let's Encrypt — not applicable; we use Vercel-managed TLS for hosted subdomains.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://ikiro.pro/.well-known/security.txt

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

**Organization Website:** https://ikiro.io

Ikiro is a hosted website platform for creators and small businesses. Users publish public sites at first-class subdomains such as `https://{slug}.ikiro.pro`. The content host (`ikiro.pro`) is intentionally separate from the authenticated application origin (`ikiro.io`) so user-authored pages cannot share application cookie scope.

The submitter is an engineer representing Ikiro and is responsible for DNS and hosting operations for `ikiro.pro`.

## Reason for PSL Inclusion

Ikiro issues subdomains on `ikiro.pro` to mutually untrusted parties. Each customer receives an isolated public site namespace (`{slug}.ikiro.pro`). Without PSL listing, browsers may treat all customer subdomains as the same site for cookie and storage isolation purposes, which is inappropriate for our multi-tenant hosting model.

We are requesting PRIVATE section inclusion for `ikiro.pro` as defense in depth alongside our existing controls: public pages use a no-script CSP, the content host does not set cookies, and the app origin remains on a separate registrable domain. PSL inclusion helps ensure cookie and site-data isolation between customer subdomains in modern browsers.

We are not using this request to bypass Cloudflare, Let's Encrypt, or social-platform rate limits. Our TLS is provisioned through our hosting provider (Vercel) on wildcard `*.ikiro.pro`.

`ikiro.pro` is registered and maintained by Ikiro with more than two years remaining on registration. We will maintain the required `_psl` TXT record for the life of the listing.

**Number of THOUSANDS of distinct users this request is being made to serve:**

Pre-launch (estimate at public beta: 3+ thousand distinct subdomain holders within 12 months of launch). Current production proof serves engineering and founder validation traffic; public beta is gated on this PSL submission and related security closeout.

## DNS Verification

```
dig +short TXT _psl.ikiro.pro
"https://github.com/publicsuffix/list/pull/2949"
```

TXT record at `_psl.ikiro.pro` will be added at Porkbun DNS immediately after PR creation.
