### PR TITLE
Add EECD private domains.

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13350,6 +13350,16 @@ twmail.org
 mymailer.com.tw
 url.tw
 
+// EECD : https://sub.eecd.cc
+// Submitted by EECD Team <support@ee.cd>
+ee.cd
+ad.sd
+g201.com
+love.gd
+my.uy
+vps.cd
+wxyz.cc
+
 // Electromagnetic Field : https://www.emfcamp.org
 // Submitted by <noc@emfcamp.org>
 at.emf.camp


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact: abuse@ee.cd**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://eecd.cc/abuse/

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

EECD are the registry for these seven second-level domains(ee.cd / my.uy / vps.cd / love.gd / g201.com / ad.sd / wxyz.cc). We primarily collaborate with registrars through contractual agreements, enabling anyone to register their third-level domains on the registrar platforms.

**Organization Website: https://sub.eecd.cc**
**Support Email: support@ee.cd**

## Reason for PSL Inclusion

Our domains host independent user-registered subdomains. We request addition to the PSL's private domains section to define clear site boundaries for browsers. This ensures each subdomain is treated as a separate site, preventing cross-subdomain cookie leakage and guaranteeing user data isolation.

**Number of users this request is being made to serve: 2000+(current)**

## DNS Verification
DNS TXT records have been added to the respective zones. We will maintain these records as required for verification.

```
dig +short TXT _psl.ee.cd
"https://github.com/publicsuffix/list/pull/2951"

```
```
dig +short TXT _psl.ad.sd
"https://github.com/publicsuffix/list/pull/2951"

```
```
dig +short TXT _psl.g201.com
"https://github.com/publicsuffix/list/pull/2951"

```
```
dig +short TXT _psl.love.gd
"https://github.com/publicsuffix/list/pull/2951"

```
```
dig +short TXT _psl.my.uy
"https://github.com/publicsuffix/list/pull/2951"

```
```
dig +short TXT _psl.vps.cd
"https://github.com/publicsuffix/list/pull/2951"

```
```
dig +short TXT _psl.wxyz.cc
"https://github.com/publicsuffix/list/pull/2951"

```