### PR TITLE
Add InstaWP private section (instawp.site/.xyz/.co/.link/.dev/.app)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14142,6 +14142,15 @@ info.at
 // Submitted by June Slater <whois@igloo.to>
 info.cx
 
+// InstaWP : https://instawp.com
+// Submitted by Vikas Singhal <security@instawp.com>
+instawp.app
+instawp.co
+instawp.dev
+instawp.link
+instawp.site
+instawp.xyz
+
 // Interlegis : http://www.interlegis.leg.br
 // Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
 ac.leg.br


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section (removing unused names, retaining the `_psl` DNS entry, and responding to e-mails to the supplied address).
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://instawp.com/report-abuse/

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*. (We have confirmed no feature relies on apex-wide cookies across these parent domains — each customer site is isolated to its own subdomain.)

## Description of Organization

**Organization Website:** https://instawp.com

InstaWP is a WordPress hosting and sandbox platform. Customers create WordPress sites that are each provisioned on their own dedicated subdomain under a small set of shared parent domains (e.g. `customer-site.instawp.site`, `customer-site.instawp.xyz`). Each subdomain is operated by a different, independent customer; the parent domains are infrastructure boundaries, not single websites.

I am Vikas Singhal, founder/CEO of InstaWP, submitting on behalf of the organization. The role-based contact `security@instawp.com` is monitored by our team. These six parent domains are all registered and operated by InstaWP and are each renewed well beyond a two-year horizon.

## Reason for PSL Inclusion

The primary reason is **cookie security / cross-tenant isolation**. Because these parents are not currently on the PSL, the registrable domain for `a.instawp.site` and `b.instawp.site` is the shared `instawp.site`. That means one customer's site can set a `Domain=.instawp.site` cookie that every other customer's site will send back — a cross-tenant cookie injection/fixation exposure on a multi-tenant platform that hosts arbitrary user-controlled WordPress content. Listing each parent in the PRIVATE section moves the boundary to `<customer>.instawp.<tld>`, giving every customer subdomain an independent registrable-domain boundary and eliminating that shared-cookie surface.

The secondary reason is **reputation isolation**. Like every shared-subdomain platform, abuse on a single customer subdomain can cause reputation vendors to tag the shared parent, which then bleeds onto every legitimate customer subdomain under it. PSL inclusion lets browsers and most reputation systems treat each customer subdomain as an independent site.

This mirrors existing PRIVATE-section entries for comparable WordPress/hosting platforms — e.g. `vibehost.space` (PR #2932, added explicitly for cross-tenant cookie isolation), `wpenginepowered.com` (WP Engine), `pantheonsite.io` (Pantheon), `elementor.cloud` (Elementor), and `wpmudev.host` (WPMU DEV).

This request is **not** submitted to work around any third-party rate limit; our purpose is cookie isolation and reputation separation, and we manage certificate issuance within applicable provider limits today.

**Number of THOUSANDS of distinct users this request is being made to serve:** Tens of thousands of distinct customers (estimate). As a concrete, verifiable proxy, there are currently ~25,000 active customer sandbox sites live across these six parent domains.

## DNS Verification

`_psl` TXT records pointing to this PR are being published for all six suffixes. Verification (`dig +short TXT _psl.<domain>`) output will be posted in a comment below once propagated.

```
dig +short TXT _psl.instawp.site
dig +short TXT _psl.instawp.dev
dig +short TXT _psl.instawp.xyz
dig +short TXT _psl.instawp.co
dig +short TXT _psl.instawp.link
dig +short TXT _psl.instawp.app
```
