### PR TITLE
Add base44-preview.app to Wix.com section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16271,6 +16271,7 @@ daemon.panel.gg
 // Wix.com, Inc. : https://www.wix.com
 // Submitted by Shahar Talmi / Alon Kochba <publicsuffixlist@wix.com>
 base44.app
+base44-preview.app
 base44-sandbox.com
 wixsite.com
 wixstudio.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example) — N/A: this submission does not seek to work around any third-party limit; no such limits apply.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://base44.com/misuse (reachable from the footer of https://base44.com under Legal; `base44.app` redirects there).

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

**Organization Website:** https://base44.com/

base44 is an app-building ("vibe-coding") platform: users describe an application in natural language and base44 generates, hosts, and serves it for them. base44 was acquired by Wix and now operates as part of Wix.com, which is why this entry sits within the existing Wix.com block of the PRIVATE section alongside our previously listed `base44.app` and `base44-sandbox.com`. I am an engineer on the base44 team responsible for our app-hosting and tenant-isolation infrastructure, submitting on behalf of base44/Wix. The role mailbox for this section, `publicsuffixlist@wix.com`, is active and monitored.

**Previous Addition PRs:**
- https://github.com/publicsuffix/list/pull/2736 (added `base44.app` and `base44-sandbox.com`)

## Reason for PSL Inclusion

base44 hosts customer-built applications, each on its own dedicated subdomain serving that customer's own application code. `base44-preview.app` is the apex domain under which we serve **preview deployments** of those apps — every app gets a preview environment at `<app>.base44-preview.app`, separate from its production host. These previews are mutually-untrusted user content sharing one registrable parent domain.

We confirm that `base44-preview.app` holds more than two years of registration term and that we will maintain more than one year of remaining term and keep the `_psl` record in place for as long as the entry remains listed.

**Number of THOUSANDS of distinct users this request is being made to serve:**
Over 250,000 distinct users (individuals who build and operate apps on base44, each able to deploy a preview under `*.base44-preview.app`) — not visitor/audience counts.

## DNS Verification

```
dig +short TXT _psl.base44-preview.app
"https://github.com/publicsuffix/list/pull/2956"
```