### PR TITLE
Add kamrul.us to the PRIVATE section of the Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14351,6 +14351,10 @@ website.k2.cloud
 kaas.gg
 khplay.nl
 
+// Kamrul.us : https://sub.kamrul.us/
+// Submitted by Kamrul Hossain <engineer@kamrul.us>
+kamrul.us
+
 // Kapsi : https://kapsi.fi
 // Submitted by Tomi Juntunen <erani@kapsi.fi>
 kapsi.fi


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization

* [x] Robust Reason for PSL Inclusion

* [ ] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [ ] We are listing any third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)

* [x] This request was *not* submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The Guidelines were carefully read and understood, and this request conforms to them.

* [x] The submission follows the Guidelines on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found:

https://sub.kamrul.us/abuse

* [x] Yes, I understand. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. Proceed anyway.

## Description of Organization

**Organization Website:**

https://sub.kamrul.us/

I am the owner and administrator of kamrul.us.

The domain is used to provide independently managed subdomains for educational, development, testing, laboratory, and collaborative projects. Subdomains are used by myself, friends, classmates, teachers, and collaborators for websites, applications, experiments, and academic projects.

The service provides subdomains for different users and projects which may be managed independently.

Administrative Contact:

[engineer@kamrul.us](mailto:engineer@kamrul.us)

## Reason for PSL Inclusion

The purpose of this request is to provide proper cookie isolation and security separation between independently managed subdomains under kamrul.us.

The domain is used for educational projects, development environments, testing services, personal websites, and collaborative work. Different users may operate separate subdomains, and inclusion in the Public Suffix List would help browsers treat these subdomains as independent boundaries.

Subdomains are provided to friends, classmates, teachers, and collaborators for their own projects and services.

This request is not intended to bypass any third-party limitations, restrictions, certificate limits, Cloudflare limits, or rate limits.

**Number of THOUSANDS of distinct users this request is being made to serve:**

0.5 (approximately 500+ users, including students, teachers, collaborators, and expected future users)


## DNS Verification

DNS verification record will be added after a pull request number is assigned.

Administrative Contact:
[engineer@kamrul.us](mailto:engineer@kamrul.us)

Abuse Contact:
https://sub.kamrul.us/abuse