### PR TITLE
Add Agent37 (agent37.app) to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11321,6 +11321,10 @@ adobeioruntime.net
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 africa.com
 
+// Agent37 : https://www.agent37.com/
+// Submitted by Vishnu Krishnaprasad <info@agent37.com>
+agent37.app
+
 // AgentbaseAI Inc. : https://assistant-ui.com
 // Submitted by Simon Farshid <security@assistant-ui.com>
 *.auiusercontent.com


### PR DESCRIPTION
> **DRAFT — not ready for review.** Two TODOs before marking ready: (1) fill the distinct-user count for agent37.app, (2) fill the abuse-contact URL and ensure the agent37.app Safe Browsing flag is cleared.

### Checklist
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig (will add the `_psl` TXT once this PR number is final)
* [x] Each domain has and shall maintain ≥2 years on registration; we shall keep the `_psl` TXT record (agent37.app renewed)
* [x] This request was *not* submitted to work around any third-party limit
* [x] Submitter acknowledges responsibility to maintain the section
* [x] Guidelines read and understood; submission conforms to formatting/sorting
* [x] Role-based, actively-monitored email (≤30-day response): info@agent37.com
* [ ] Abuse contact accessible — URL: **TODO**
* [x] *Yes, I understand* the cookie/cert impact and rollback timing; *proceed anyway*

## Description of Organization
**Organization Website:** https://www.agent37.com

Agent37 runs a managed agent-hosting platform. Each customer provisions isolated, individually-owned agent instances, and every instance is served on its own dedicated subdomain under `agent37.app` (e.g. `abc1234567.agent37.app`), plus per-service subdomains per instance. These instances belong to mutually-distrusting customers running independent workloads. I am a founder of Agent37 and the authorized owner of `agent37.app`, submitting on behalf of the organization.

## Reason for PSL Inclusion
We request `agent37.app` in the PRIVATE section so that each `*.agent37.app` instance subdomain is treated as its own registrable domain (eTLD+1). The primary purpose is cookie and origin isolation between mutually-distrusting tenants: today a cookie scoped to `agent37.app` is shared across all customer instances and browsers treat every instance as the same site. Listing `agent37.app` makes each customer instance a separate site, preventing cross-tenant cookies and supercookies, consistent with how comparable multi-tenant platforms (vercel.app, web.app, workers.dev) are listed. The domain holds more than two years of registration remaining and we will maintain the `_psl` record for as long as the entry should remain.

**Number of THOUSANDS of distinct users this request is being made to serve:** TODO

## DNS Verification
```
dig +short TXT _psl.agent37.app
"https://github.com/publicsuffix/list/pull/<this PR number>"
```
(record added once the PR number is assigned)
