### PR TITLE
Add nippy.site for cross-tenant cookie isolation

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14824,6 +14824,10 @@ torun.pl
 nh-serv.co.uk
 nimsite.uk
 
+// Nippy : https://nippy.host/
+// Submitted by Nippy Support <support@nippy.host>
+nippy.site
+
 // No-IP.com : https://noip.com/
 // Submitted by Deven Reza <publicsuffixlist@noip.com>
 mmafan.biz


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale.
   - None apply. This submission does not seek to work around any third-party limit; no such limits apply.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://nippy.host/abuse

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

**Organization Website:** https://nippy.host

Nippy is a hosting platform for static sites — frequently AI-generated artifacts from tools like Claude — where each customer's site is served from its own dedicated subdomain of `nippy.site` (`<site>.nippy.site`). Every site serves that customer's own uploaded HTML, CSS and JavaScript, the same one-site-per-subdomain hosting model already operated by Vercel (`vercel.app`), Cloudflare Pages (`pages.dev`) and Netlify (`netlify.app`), all listed in the PRIVATE section. The main application and authenticated dashboard live on the separate registrable domain `nippy.host`, so user-uploaded content is already isolated from platform credentials at the registrable-domain level; this submission closes the remaining cross-tenant boundary between sibling sites within `nippy.site`. I am submitting this as the operator of the platform and the registrant of `nippy.site`; `support@nippy.host` is our monitored role mailbox for this listing (and for abuse reports — `https://nippy.host/abuse` is the public web form that routes there).

## Reason for PSL Inclusion

Nippy hosts independent, mutually-untrusted user content on sibling subdomains of a single shared parent, `nippy.site`. Because that parent is an ordinary registrable domain, browsers currently treat every `<site>.nippy.site` as part of one site. Per RFC 6265 §4.1.2.3, a host such as `alice.nippy.site` may set a cookie scoped to `Domain=nippy.site` (over the wire or via `document.cookie`), and a cookie carrying that Domain attribute is then sent to every sibling subdomain — the section's own example notes a `Domain=example.com` cookie is returned to `example.com`, `www.example.com` and `www.corp.example.com`.

We are requesting this listing to defend against cross-tenant cookie injection ("cookie tossing"), session fixation and supercookie scenarios between sibling tenants. Listing `nippy.site` as a public suffix causes user agents to reject such a parent-scoped `Domain` attribute (RFC 6265 §4.1.2.3 NOTE and §5.3), so cookie scope and same-origin boundaries fall on a single tenant rather than across the whole namespace. This is a defense-in-depth isolation motivation; it is **not** an attempt to work around any third-party rate limit or vendor restriction. It is the same rationale under which the analogous hosting providers named above were added to the PRIVATE section.

A secondary motivation is **domain reputation isolation**: without PSL inclusion, a single abusive subdomain risks Google Safe Browsing (and equivalents) flagging the entire `nippy.site` zone, surfacing a browser interstitial on every unrelated user's site. PSL inclusion makes each `<site>.nippy.site` a distinct principal for reputation purposes, matching how the comparable platforms named above are treated.

We confirm that `nippy.site` holds more than two years of registration term (Registry Expiry Date: 2028-05-01) and that we will maintain more than one year of remaining term and keep the `_psl` record in place for as long as the entry remains listed.

**Number of THOUSANDS of distinct users this request is being made to serve:**

Nippy is a live production service with a growing user base. The need here is structural rather than scale-driven: because the platform serves arbitrary user-uploaded HTML/JS on shared-eTLD+1 subdomains to mutually untrusting parties, the cross-tenant cookie boundary described above cannot be enforced at the application layer — only the PSL closes it. The same boundary is the reason comparable platforms (`vercel.app`, `netlify.app`, `pages.dev`) are listed.

## DNS Verification

```
dig +short TXT _psl.nippy.site
"https://github.com/publicsuffix/list/pull/2966"
```

The `_psl` TXT record is live in the `nippy.site` Cloudflare zone and will be kept in place for as long as the entry remains listed.