### PR TITLE
Add onbelmo.io (private section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12476,6 +12476,10 @@ bearblog.dev
 *.beget.app
 *.begetcdn.cloud
 
+// Belmo : https://belmo.io
+// Submitted by Chalom <psl@belmo.io>
+onbelmo.io
+
 // Besties : https://besties.house
 // Submitted by Hazel Cora <hazy@besties.house>
 pages.gay


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig — `_psl.onbelmo.io` resolves to this PR's URL (proof posted as a follow-up comment).

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration (`onbelmo.io` expires 2028-06-17), and we shall keep the `_psl` TXT record in place in the respective zone.

**Third-party limits:** Not applicable — this submission does **not** seek to work around any Cloudflare, Let's Encrypt, Apple, or other third-party limit.

* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section, including removing names which are no longer used, retaining the `_psl` DNS entry, and responding to e-mails to the supplied address.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x] A role-based email address has been used (`psl@belmo.io`) and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: **https://onbelmo.io/#abuse**

---

* [x] *Yes, I understand* the cookie/certificate propagation and rollback implications. `onbelmo.io` is a purpose-dedicated tenant-application domain, isolated from our corporate domain `belmo.io` (which is single-tenant and deliberately **not** submitted), so corporate-site impact is minimal by design.

---

## Description of Organization

**Organization Website:** https://belmo.io

Belmo is an application-hosting platform (PaaS). Customers deploy and run their own applications, which are served on per-customer subdomains of a dedicated platform domain — e.g. `app.onbelmo.io`, `<customer>.onbelmo.io`. I am the founder of Belmo and the submitter of this request, acting on behalf of the organization. `onbelmo.io` exists solely as the tenant-application domain; our corporate/brand presence lives separately on `belmo.io`, which is single-tenant and is deliberately excluded from this submission.

## Reason for PSL Inclusion

The purpose is **origin and cookie isolation between independent customers** that share the `onbelmo.io` space. Without a PSL entry, browsers treat `onbelmo.io` as the registrable domain, which allows a script on one customer's subdomain to set domain cookies scoped to `.onbelmo.io` and otherwise blur the security boundary between unrelated tenants. Listing `onbelmo.io` in the PRIVATE section makes each `*.onbelmo.io` subdomain a distinct registrable domain, so cookies, `document.domain`, and related same-site/origin behaviours are correctly scoped per customer — the standard reason multi-tenant hosting domains are listed.

This is **not** an attempt to work around any third-party rate limit; it is purely about correct security boundaries between tenants.

**Number of THOUSANDS of distinct users this request is being made to serve:** Fewer than 2,000 distinct customers today — Belmo is early-stage. This is a current actual count, not an estimate. We are submitting now, ahead of reaching that threshold, to establish the entry early given the long propagation timelines into downstream consumers (browsers, libraries). We understand that inclusion is not guaranteed and may be deferred until the project is larger.

## DNS Verification

The `_psl.onbelmo.io` TXT record will be set to this PR's URL immediately after the PR number is assigned, and the output of `dig +short TXT _psl.onbelmo.io` will be posted as a follow-up comment.
