### PR TITLE
Add apps.wrkr.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16327,6 +16327,10 @@ weeklylottery.org.uk
 wpenginepowered.com
 js.wpenginepowered.com
 
+// Wrkr : https://wrkr.dev
+// Submitted by Madan Mohan Reddy <nadam54321@gmail.com>
+apps.wrkr.dev
+
 // xAI : https://x.ai/
 // Submitted by Asim Shrestha <security@x.ai>
 grok.me


### PR DESCRIPTION
Add `apps.wrkr.dev` as a private suffix for Wrkr user application hosts.

Wrkr serves user-created applications as `<app>.apps.wrkr.dev`; treating this as a public suffix prevents cookies from one user app being scoped across sibling apps.

Verification TXT: `_psl.apps.wrkr.dev` will point at this PR URL after the PR is opened and the DNS automation runs.