### PR TITLE
Add missing ia.bo social domain to .bo registry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -481,6 +481,7 @@ deporte.bo
 ecologia.bo
 economia.bo
 empresa.bo
+ia.bo
 indigena.bo
 industria.bo
 info.bo


### PR DESCRIPTION
**Description:**
This PR adds the `.ia.bo` domain to the existing list of Social Domains for Bolivia (`.bo`). 

While most of the social domains were previously added and confirmed by the registry in November 2024, `.ia.bo` (intended for Artificial Intelligence projects) is missing from the current list. This omission causes services like Cloudflare to treat it as a subdomain rather than a valid public suffix.

**Source of Truth:**
The availability of `.ia.bo` as a valid third-level social domain can be verified directly on the official NIC Bolivia website: https://nic.bo/ (under the domain pricing and types section).

The domain has been placed in strict alphabetical order within the existing `// Social Domains` block.

# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig (N/A - This is an ICANN ccTLD update, not a PRIVATE domain)
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining... (N/A - ICANN section)

__Submitter affirms the following:__ 

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. (Acknowledged, though this is a national ccTLD).

* [x] The Guidelines were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored. (Registry contact: soporte@nic.bo)

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL: https://nic.bo/contacto/

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

NIC Bolivia (Network Information Center Bolivia) is the entity responsible for the administration of the .bo Country Code Top Level Domain (ccTLD). 

I am an independent developer from Bolivia submitting this PR to correct an omission in the official public suffix record. I am not directly affiliated with NIC Bolivia, but I am directly affected by the omission of the official `.ia.bo` extension, which prevents users from proper domain registration and DNS management in services like Cloudflare.

**Organization Website:**
https://nic.bo/

## Reason for PSL Inclusion

This PR updates the ICANN DOMAINS section for the `.bo` ccTLD. Recently, NIC Bolivia added several new "Social Interest Domains" (Dominios de interés social) available for public registration. 

While most of the new extensions were added in a previous PR and confirmed by the registry (`soporte@nic.bo`) on 2024-11-19, the `.ia.bo` (intended for Artificial Intelligence projects) extension was accidentally omitted from the list.

Because `.ia.bo` is a public suffix where anyone can register domains, it belongs in the ICANN section alongside the other `.bo` domains. The current omission causes Cloudflare to block operations for `.ia.bo` domains because they assume `ia.bo` is a subdomain rather than a valid public suffix.

**Number of THOUSANDS of distinct users this request is being made to serve:**
N/A - This is a national ccTLD extension (ICANN section) available to the entire public, not a private namespace.

## DNS Verification

Because this is an official ccTLD extension managed by the Bolivian government (NIC Bolivia) and goes into the **ICANN section**, I cannot add a `_psl` TXT record to the root zone of `ia.bo`.

The official source of truth is the NIC Bolivia website itself, which lists `.ia.bo` as a registerable extension under their pricing and domain types section: https://nic.bo/

Additionally, the registry can be contacted directly at `soporte@nic.bo` to verify this omission, just as they did for the other social domains in November 2024.