### PR TITLE
Add dropthiis.com to PRIVATE domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13000,6 +13000,10 @@ shoparena.pl
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com
 
+// dropthis : https://dropthis.app
+// Submitted by Damjan Malis <damjan.malis@gmail.com>
+dropthiis.com
+
 // Dreamyoungs, Inc. : https://durumis.com
 // Submitted by Infra Team <infra@durumis.com>
 durumis.com


### PR DESCRIPTION
## Organization

**dropthis** — https://dropthis.app

## What is the domain used for?

`dropthiis.com` is the shared content domain for [dropthis](https://dropthis.app), a publish-as-a-service platform. User-generated content is served at `{slug}.dropthiis.com` subdomains (one subdomain per published "drop"). The product domain (`dropthis.app`) is kept separate from user content.

## Why PSL inclusion?

Without PSL inclusion, a malicious user could publish content at `evil.dropthiis.com` that sets cookies readable by `legit.dropthiis.com`, enabling session fixation and cross-drop data leakage. PSL inclusion makes each subdomain an independent cookie origin.

## Section

PRIVATE

## DNS verification

A `_psl` TXT record pointing to this PR will be added to `dropthiis.com` once this PR URL is known.

## Contact

Damjan Malis — damjan.malis@gmail.com