### PR TITLE
Add private domains for Code For Host: dev.cv, sch.ac, store.cv

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12752,6 +12752,12 @@ co.com
 // Submitted by Moritz Marquardt <git@momar.de>
 codeberg.page
 
+// Code For Host Inc Ltd. : https://codeforhost.com
+// Submitted by Mehedi Hasan <support@codeforhost.com>
+dev.cv
+sch.ac
+store.cv
+
 // CodeSandbox B.V. : https://codesandbox.io
 // Submitted by Ives van Hoorne <abuse@codesandbox.io>
 csb.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission doesn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/2835, although 
the organization and description were not as substantial 
as desired, which required maintainers' time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace because extra cycles are not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/)
 - MAKE SURE TO UPDATE THE FOLLOWING LIST WITH YOUR LIMITATIONS! REMOVE ENTRIES WHICH DO NOT APPLY AS WELL AS REMOVING THIS LINE!

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail regarding the effort that was made to work directly 
with the third party or parties in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry in, the 
order of commented organization placement, and the order of sorting of entries. 
(Hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically, both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
[support@codeforhost.com](mailto:support@codeforhost.com)

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:  https://www.take.bd/abuse

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
Code for Host Inc Ltd. (https://www.codeforhost.com/) is a technology and infrastructure company specializing in domain registration, web hosting, and cloud-based services. It operates multiple subsidiaries under its ecosystem, including Hostever, which is one of its core brands providing reliable domain and hosting solutions to a wide range of clients.

As part of its expanding digital infrastructure initiatives, Code for Host Inc Ltd. has established a dedicated sub-concern named take.bd (https://www.take.bd/). This entity is responsible for managing and operating specialized top-level domain (TLD) projects such as .dev.cv, .store.cv and .sch.ac These services are designed to support modern domain management, DNS operations, and future-ready internet namespace development.

Through these initiatives, Code for Host Inc Ltd. continues to strengthen its position in the global domain and hosting industry by building scalable and innovative digital identity solutions.

**Organization Website:** https://www.codeforhost.com/

## Reason for PSL Inclusion
Those domains .dev.cv, .store.cv, .sch.ac are used as a public suffix for delegated subdomains that may be assigned to independent users or organizations. Without inclusion in the Public Suffix List, cookie scoping and security policies may incorrectly treat second-level domains under .dev.cv, .store.cv, .sch.ac as a single registrable entity.

Adding .dev.cv, .store.cv, .sch.ac to the PSL ensures correct browser behavior, prevents cookie leakage across unrelated subdomains, and maintains proper security isolation between independently managed subdomains under this namespace.

We are requesting this listing to defend against cross-tenant cookie injection ("cookie tossing"), session fixation, and supercookie scenarios between subdomains. Listing as a public suffix causes user agents to reject such a parent-scoped attribute (RFC 6265 §4.1.2.3 NOTE and §5.3), so cookie scope and same-origin boundaries fall on a single tenant rather than across the whole namespace. This is a defense-in-depth isolation motivation; it is not an attempt to work around any third-party rate limit or vendor restriction. It is the same rationale under which the analogous hosting providers named above were added to the PRIVATE section.

**Number of THOUSANDS of distinct users this request is being made to serve:**

<img width="936" height="678" alt="image" src="https://github.com/user-attachments/assets/8a4bef64-02a4-4ec2-a381-2720a19435ae" />

<img width="1854" height="835" alt="image" src="https://github.com/user-attachments/assets/f08c30f1-75e2-4d17-ab2b-c8694433b2e7" />

Over 4710+ distinct users (current actual count) — distinct individuals who deploy and operate.

## DNS Verification
```
dig +short TXT _psl.dev.cv
"https://github.com/publicsuffix/list/pull/2973"
```
```
dig +short TXT _psl.store.cv
"https://github.com/publicsuffix/list/pull/2973"
```

```
dig +short TXT _psl.sch.ac
"https://github.com/publicsuffix/list/pull/2973"
```