### PR TITLE
Add myblocofy.com (Blocofy)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12500,6 +12500,10 @@ of.je
 // Submitted by Jonathan Boice <security@block.xyz>
 square.site
 
+// Blocofy : https://blocofy.com
+// Submitted by Blocofy <hostmaster@blocofy.com>
+myblocofy.com
+
 // Blue Bite, LLC : https://bluebite.com
 // Submitted by Joshua Weiss <admin.engineering@bluebite.com>
 bluebite.io


### PR DESCRIPTION
## Submission: `myblocofy.com` (PRIVATE section)

**Organization:** Blocofy — https://blocofy.com
**Suffix requested:** `myblocofy.com`

### Rationale
Blocofy is a multi-tenant website builder (Shopify-style). Every customer site is served on its own subdomain `<slug>.myblocofy.com` (analogous to `myshopify.com`). Without a PSL entry, browsers treat `myblocofy.com` as the registrable domain, so per-tenant cookies set by customer-configured third parties (analytics / advertising pixels) can be scoped to the shared parent `.myblocofy.com` and leak across unrelated tenants. Listing `myblocofy.com` makes browsers treat each `<slug>.myblocofy.com` as a separate registrable domain, restoring per-tenant cookie isolation — the same rationale as the existing `myshopify.com` entry.

### Expected behavior
- Before: `publicsuffix("a.myblocofy.com")` → `myblocofy.com`
- After:  `publicsuffix("a.myblocofy.com")` → `a.myblocofy.com`

### Validation
- `make test-syntax` (pslint) passes locally.
- `_psl.myblocofy.com` TXT record pointing to this PR URL will be added to the `myblocofy.com` zone and kept in place to signal continued inclusion.

Only one suffix is requested; no public-suffix wildcard. Happy to adjust formatting/placement as needed.