### PR TITLE
Add OnThePixel.net private domains: addictedto.beer, skillissue.gg

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15038,6 +15038,11 @@ simplesite.pl
 // Submitted by ONID Engineering Team <psl@onid.ca>
 onid.ca
 
+// OnThePixel.net : https://onthepixel.net/
+// Submitted by tbb <tbb@onthepixel.net>
+addictedto.beer
+skillissue.gg
+
 // Open Domains : https://open-domains.net
 // Submitted by William Harrison <admin@open-domains.net>
 is-a-fullstack.dev


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

Adds two PRIVATE-section domains under a new **OnThePixel.net** subsection:

```
// OnThePixel.net : https://onthepixel.net/
// Submitted by tbb <tbb@onthepixel.net>
addictedto.beer
skillissue.gg
```

Placed in alphabetical order by organization name (between `ONID` and `Open Domains`), entries sorted by TLD (`.beer` before `.gg`). `pslint.py` and the linter self-test pass with no warnings.

### Checklist of required steps

* [x] The submission follows the Guidelines on formatting and sorting (verified with `linter/pslint.py`).
* [x] The Guidelines were read and this request conforms to the format/sorting rules.
* [ ] Description of Organization — _to be completed by submitter_
* [ ] Robust Reason for PSL Inclusion — _to be completed by submitter_
* [ ] DNS verification via dig — _pending: add `_psl` TXT records (see below) once this PR has a number_
* [ ] Each domain has and shall maintain ≥ 2 years remaining on registration, and the `_psl` TXT record shall be kept in the respective zone(s).
* [ ] This request was _not_ submitted to work around third-party limits.
* [ ] Role-based email address used, inbox monitored (≤ 30 day response).
* [ ] Abuse contact information is available and easily accessible.

> NOTE (submitter): the affirmation boxes above are intentionally left unchecked — please tick them yourself only after confirming each statement is true.

**Abuse Contact:** _URL to be provided by submitter_

## Description of Organization
**Organization Website:** https://onthepixel.net/

_To be completed by the submitter — please describe what OnThePixel.net does, who you are as the submitter, and your role with respect to the org and these domains (≥ 3 sentences)._

## Reason for PSL Inclusion
_To be completed by the submitter — explain why `addictedto.beer` and `skillissue.gg` should be in the PRIVATE section (e.g. cookie isolation / cert issuance between user subdomains), confirm > 2 years registration term, and state the number of distinct users served._

**Number of THOUSANDS of distinct users this request is being made to serve:** _to be provided_

## DNS Verification
Once this PR receives its number `XXXX`, add the following TXT records and confirm with `dig`:

```
dig +short TXT _psl.addictedto.beer
"https://github.com/publicsuffix/list/pull/XXXX"

dig +short TXT _psl.skillissue.gg
"https://github.com/publicsuffix/list/pull/XXXX"
```
