### PR TITLE
Add candoai.site (CanDo AI private domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12568,6 +12568,10 @@ vm.bytemark.co.uk
 // Submitted by Antonio Lain <antlai@cafjs.com>
 cafjs.com
 
+// CanDo AI : https://candoai.site/
+// Submitted by Andrew Barrett <andrew@cando.ai>
+candoai.site
+
 // Canva Pty Ltd : https://canva.com/
 // Submitted by Joel Aquilina <publicsuffixlist@canva.com>
 canva-apps.cn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12569,7 +12569,7 @@ vm.bytemark.co.uk
 cafjs.com
 
 // CanDo AI : https://candoai.site/
-// Submitted by Andrew Barrett <andrew@cando.ai>
+// Submitted by Andrew Barrett <hostmaster@candoai.site>
 candoai.site
 
 // Canva Pty Ltd : https://canva.com/


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

   None. This submission does not seek to work around any third-party limit. It is requested solely for cookie-scope isolation between tenant subdomains (see rationale).

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://candoai.site/abuse

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

   Note: `candoai.site` is a dedicated tenant **base** domain. Its apex serves no website and is not our organization's primary/marketing domain, so listing it does not alter cookie or certificate behaviour for any production site at the apex — it only establishes the registrable-domain boundary beneath which isolated tenant subdomains are issued.

---

## Description of Organization

**Organization Website:** https://candoai.site/

CanDo AI operates a multi-tenant website platform. Each customer ("tenant") is served on its own isolated subdomain of the form `<tenant>.candoai.site`, and a single shared application engine resolves which tenant is being served from the HTTP `Host` header; the apex itself hosts no tenant. `candoai.site` is the dedicated base domain under which every tenant subdomain is issued, kept separate from the organization's corporate domain so that no tenant content is ever served from the apex.

I am Andrew Barrett, responsible for the platform's infrastructure, and I operate `candoai.site` on behalf of CanDo AI. I am submitting this request in that operator capacity. The platform's core focus directly connected to this request is the issuance of independent, mutually-isolated tenant subdomains — which is precisely the registrable-domain boundary the PSL governs.

This is the same structural arrangement for which other multi-tenant subdomain platforms are already listed in the PRIVATE section (for example `herokuapp.com`, `netlify.app`, `vercel.app`, and `github.io`): independent customers each operate a subdomain with their own user base, and the parent base domain must form a public-suffix boundary so those tenants are isolated from one another.

## Reason for PSL Inclusion

The reason is **cookie-scope isolation between tenants**. Without listing, browsers treat `candoai.site` as a single registrable domain, which means a page on one tenant subdomain (e.g. `tenant-a.candoai.site`) can set a cookie scoped with `Domain=candoai.site` that is then sent to every other tenant subdomain (`tenant-b.candoai.site`, …). For a multi-tenant platform where each subdomain belongs to a different, unrelated customer, that is a cross-tenant security and privacy boundary failure (cookie injection / session fixation / leakage across tenants).

Listing `candoai.site` as a public suffix makes a `Domain=candoai.site` cookie unrepresentable in the browser, so each tenant subdomain becomes its own isolated cookie origin. This is the standard and intended use of the PRIVATE section, and is the same basis on which the multi-tenant platforms referenced above are listed.

We confirm that `candoai.site` currently holds a registration term of more than two years and that we will maintain it with more than one year of term remaining for as long as it is listed, and that the `_psl` TXT record will remain in place in the zone.

This request is **not** an attempt to work around any third-party rate limit or restriction (e.g. Cloudflare or Let's Encrypt). The sole purpose is the cookie-isolation boundary described above.

**Number of THOUSANDS of distinct users this request is being made to serve:** Approximately 1 (one) thousand today and growing. This is a current actual figure: the first tenant migrating onto the platform is the existing ILA website, which has a database of over 1,000 users. Approximately 10 further tenant sites are planned to onboard, each bringing its own user base, and the platform is built and intended to serve thousands of independent tenant sites at minimum, each with their own users. The ~1,000 figure is an actual current count for the first tenant; the remainder is a near-term estimate as additional tenants onboard.

## DNS Verification

```
dig +short TXT _psl.candoai.site
"https://github.com/publicsuffix/list/pull/2979"
```

This record is in place now and resolves publicly. It will be left in place for as long as the entry is to remain in the PSL.
