### PR TITLE
Add canva-code.cn to the Public Suffix List

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12571,6 +12571,7 @@ cafjs.com
 // Canva Pty Ltd : https://canva.com/
 // Submitted by Joel Aquilina <publicsuffixlist@canva.com>
 canva-apps.cn
+canva-code.cn
 my.canvasite.cn
 khsj.cn
 canva-apps.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12583,6 +12583,7 @@ cafjs.com
 // Canva Pty Ltd : https://canva.com/
 // Submitted by Joel Aquilina <publicsuffixlist@canva.com>
 canva-apps.cn
+canva-code.cn
 my.canvasite.cn
 khsj.cn
 canva-apps.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->

 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://www.canva.com/en_au/help/report-content/

  Email: abuse@canva.com (monitored)

  `canva-code.cn` also serves a `/.well-known/security.txt` pointing to our abuse/security contacts.

  Role email: publicsuffixlist@canva.com
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Canva is an online graphic design platform supporting presentations, graphics, videos and similar features, used by [~260 million monthly active people](https://www.canva.com/newsroom/news/canva-2025-wrap/#:~:text=Our%20community%20grew%20to%20260M).

Canva Code is a production platform-as-a-service offering within Canva that hosts LLM-generated and user-created Canva Code (HTML/JS/CSS bundled into a single file, embeddable via iframe in Canva designs and websites). It is already live globally on `canvacode.com` and `canva-hosted-embed.com`, which were added to the PSL in #2617. This PR extends that same production product to Canva's users in China, where it is served from `canva-code.cn`.

I am a backend engineer at Canva working on the Canva Code China launch, and I am submitting this on behalf of Canva.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
- https://www.canva.com/
- China: https://www.canva.cn/
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Canva Code provisions each user-created application on its own subdomain so that artefacts are isolated from one another and cookies cannot be set on the parent registrable domain. Each published artefact is served from its own subdomain, for example `artefact-a.canva-code.cn`. Adding `canva-code.cn` to the PRIVATE section makes each `<id>.canva-code.cn` a registrable domain, which keeps one artefact from reading or setting cookies for another and prevents a single bad-actor artefact from affecting the reputation of the parent domain.

This is the same isolation model already accepted for our global Canva Code domains `canvacode.com` and `canva-hosted-embed.com` (#2617). `canva-code.cn` is the China counterpart of that production offering. It is a separate registrable domain (rather than a subdomain of an existing Canva zone) for two reasons: serving user-generated content to users in China requires a China-registered domain with its own ICP filing, so it cannot be served from the global `.com` domains; and we deliberately keep user-generated Canva Code off Canva's primary `canva.cn` domain to isolate its reputation from the apex brand.

The domain is now live and serving. A working example, published with the production pipeline:

- Example artefact subdomain: **`ch7dgxsr4ezafffk.canva-code.cn`**, serving a user-created interactive app at `https://ch7dgxsr4ezafffk.canva-code.cn/codelet/<access-token>/index.html`.
- The access token in the path is short-lived, so a hardcoded URL would go stale. To reach the artefact, open this stable link: https://china-canva.my.canvasite.cn/coffee-brewing-calculator/_assets/remote/embed/codelet/ch7dgxsr4ezafffk/index.html — it responds with a 302 whose `Location` is the current serving URL on `ch7dgxsr4ezafffk.canva-code.cn`, and your browser lands on that subdomain (verifiable in the address bar, or with `curl -sI <link> | grep -i location`).
- The same artefact is embedded in a published Canva website: https://china-canva.my.canvasite.cn/coffee-brewing-calculator

We are not using the PSL to work around any third-party limits.

The domain in this section holds well over two years of registration (expires 2031-05-21) and we will keep the `_psl` TXT record in place for as long as the entry remains listed.

Previous Canva PRs related to this section: #2617, #2898, #2605, #2477, #1739, #1627.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
This is an estimate, since Canva Code has not yet broadly rolled out in China: the population this request is being made to serve is Canva's users in China (https://www.canva.cn/), out of [~260 million monthly active users](https://www.canva.com/newsroom/news/canva-2025-wrap/) of Canva globally — these are the users who publish Canva Code artefacts to subdomains of `canva-code.cn`. As a reference for actual usage of the same product, the global Canva Code domains listed in #2617 currently serve over 1 million monthly users. The domain is live and serving today (see the working example in the rationale above), with availability to users in China rolling out progressively.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
$ dig +short TXT _psl.canva-code.cn
"https://github.com/publicsuffix/list/pull/2980"

$ dig +short TXT _psl.canva.cn
"https://github.com/publicsuffix/list/pull/2980"
"https://github.com/publicsuffix/list/pull/2477"
"https://github.com/publicsuffix/list/pull/1739"
"https://github.com/publicsuffix/list/pull/2605"
"https://github.com/publicsuffix/list/pull/2898"
"https://github.com/publicsuffix/list/pull/1627"
"https://github.com/publicsuffix/list/pull/2617"

$ dig +short TXT _psl.canva.com
"https://github.com/publicsuffix/list/pull/1627"
"https://github.com/publicsuffix/list/pull/1739"
"https://github.com/publicsuffix/list/pull/2477"
"https://github.com/publicsuffix/list/pull/2605"
"https://github.com/publicsuffix/list/pull/2617"
"https://github.com/publicsuffix/list/pull/2898"
"https://github.com/publicsuffix/list/pull/2980"
```

Registration (at least 2 years remaining):

```
$ whois canva-code.cn | grep -i expir
Expiration Time: 2031-05-21
```
<!-- END FILL IN -->