### PR TITLE
Add lunarabbit.app (LunaRabbit Inc.)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14567,7 +14567,7 @@ barsy.co.uk
 barsyonline.co.uk
 
 // LunaRabbit Inc. : https://lunarabbit.ai
-// Submitted by Jinwoo Jeong <jin@lunarabbit.ai>
+// Submitted by Jinwoo Jeong <contact@lunarabbit.ai>
 lunarabbit.app
 
 // Lutra : https://lutra.ai

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14566,6 +14566,10 @@ barsy.uk
 barsy.co.uk
 barsyonline.co.uk
 
+// LunaRabbit Inc. : https://lunarabbit.ai
+// Submitted by Jinwoo Jeong <jin@lunarabbit.ai>
+lunarabbit.app
+
 // Lutra : https://lutra.ai
 // Submitted by Joshua Newman <public-suffix-list@lutra.ai>
 *.lutrausercontent.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example) — N/A: we are not seeking to work around any third-party limit.
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: contact@lunarabbit.ai

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

Note: `lunarabbit.app` is a separate registrable domain from our primary organization domain (`lunarabbit.ai`). All login/session cookies live only on `lunarabbit.ai`, so `lunarabbit.app` carries no first-party auth state and there is no risk to our organization's website cookies.

---

## Description of Organization

LunaRabbit Inc. is a US (Delaware) C-Corporation that builds an AI platform at https://lunarabbit.ai. I am the founder and an engineer at LunaRabbit, responsible for our platform infrastructure and this submission. LunaRabbit lets users build and deploy web applications through an in-app builder; each resulting application is served on its own isolated subdomain under `lunarabbit.app` (e.g. `myapp.lunarabbit.app`). These subdomains host user-controlled content that is independent and mutually untrusting.

**Organization Website:** https://lunarabbit.ai

## Reason for PSL Inclusion

We are requesting `lunarabbit.app` be added to the PRIVATE section of the PSL for cookie and origin isolation between user-deployed applications.

Each user-deployed app is served on its own subdomain (e.g. `myapp.lunarabbit.app`, `otherapp.lunarabbit.app`). Without PSL inclusion, a cookie set on `.lunarabbit.app` by one user's application would be readable by all other user applications under `lunarabbit.app`. Because these subdomains host content controlled by different, mutually-untrusting parties, this enables supercookies and cookie-tossing across tenants.

Adding `lunarabbit.app` to the PSL ensures browsers treat each subdomain as a separate registrable domain, preventing cross-subdomain cookie attacks and enforcing proper origin isolation. This is the same use case as other platform providers already listed in the PSL, such as Vercel (`vercel.app`), Cloudflare Pages (`pages.dev`), and Perplexity (`pplx.app`, see #2821).

The domain `lunarabbit.app` is registered through 2029-06-19, and we commit to maintaining the registration in good standing with more than one year remaining at all times.

**Number of users this request is being made to serve:** Thousands.

## DNS Verification

```
dig +short TXT _psl.lunarabbit.app
"https://github.com/publicsuffix/list/pull/2981"
```

The `_psl` TXT record is in place and will be maintained permanently.