### PR TITLE
Add pugi.app (private domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15255,6 +15255,10 @@ nyc.mn
 // Submitted by Kor Nielsen <kor@pubtls.org>
 pubtls.org
 
+// Pugi : https://pugi.app
+// Submitted by Pugi Dev <dev@pugi.io>
+pugi.app
+
 // PythonAnywhere LLP : https://www.pythonanywhere.com
 // Submitted by Giles Thomas <giles@pythonanywhere.com>
 pythonanywhere.com


### PR DESCRIPTION
This adds **pugi.app** to the PRIVATE DOMAINS section.

**What pugi.app is**
pugi.app is the customer-content domain for the Pugi platform. Each subdomain hosts independent, customer-controlled content on its own origin:
- `<slug>.pugi.app` — customer-published web apps
- `preview-<id>.pugi.app` — ephemeral build previews
- `ide-<tenant>-<session>.pugi.app` — per-session in-browser development environments

**Why it belongs on the PSL**
These subdomains are mutually-untrusted (different tenants, customer-supplied code). Without a PSL entry the browser treats `pugi.app` as a single registrable domain, allowing cross-subdomain cookie and `document.domain` access between unrelated tenants. Listing `pugi.app` makes each subdomain a separate site, giving browser-enforced origin isolation — the same model used for `*.app.github.dev`.

**Ownership validation**
A `_psl.pugi.app` TXT record is set to this PR's URL for ownership validation.

Submitted by Pugi Dev <dev@pugi.io>
