### PR TITLE
Add lindenlion.net (private domains)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14473,6 +14473,10 @@ co.network
 co.place
 co.technology
 
+// Lindenlion : https://lindenlion.net
+// Submitted by michael@lindenlion.net
+lindenlion.net
+
 // linkyard ldt : https://www.linkyard.ch/
 // Submitted by Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
 linkyard-cloud.ch


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.

 * [x] I am *not* listing third-party limits that I seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example) because there are not rate limits that I am trying to work around. 
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  https://lindenlion.net/abuse
---

> For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.
>
> To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 
>
> PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.
>
> (Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization
Lindenlion is a garage shop of Michael Killian. He is a sole
developer, but also friend and technical helper of many. 
He hosts websites for friends and colleagues. Been doing
that for nearly 20 years. Subdomains of lindenlion.net are 
offered to friends as a low-cost service when they need 
a website but the domain name is not their primary concern.
I am also a medical doctor and the IT services I offer to 
friends, colleagues and fellow researchers are mostly meant 
to help people do useful non-profit work for the better of 
humanity. This includes hosting instances of useful applications
for doing medical research for fellow doctors and researchers.  
I don't sell services in a business sense, but I don't assume that my 
friends trust each other or even know each other. 
So alice.lindenlion.net has nothing to do with bob.lindenlion.net
and every subdomain has their own independent sessions, 
cookies, logins etc. Anything else would be wrong. 
My role is to keep the domain registered, to know what 
the subdomains are used for, but not to tell them what to do or 
not do with their subdomain. If someone loses my trust or if a 
subdomain is used for something I cannot stand behind (eg. 
doing harm to people) I would remove their dns entry.  

**Organization Website:**
https://lindenlion.net (there is no content on this webpage for a 
purpose, people who don't know me shouldn't feel the need to 
contact me to ask for a subdomain. I'm not running a business, but 
providing IT services on the basis of trust gained in real
life. I have added a link with a way to notify me of abuse
on any of my subdomains. 


## Reason for PSL Inclusion

Subdomains of lindenlion.net are not related to each other, they are independent websites by independent parties that might not know (of) each other. Cookies and sessions should not be shared among these. The domain name lindenlion.net is registered for at least 2 years and I am committing to keeping this domain active for at least the next 10 or 20 years, always keeping at least 2 years of registration active. If this would change I would submit a removal request for lindenlion.net to the PSL. 

**Number of THOUSANDS of distinct users this request is being made to serve:**
Less than one thousand. I still believe I qualify for all intents and purposes to be included on the list and the number is not important, but rather the technical and social intentions and implications. 

## DNS Verification
```
dig +short TXT _psl.lindenlion.net
"https://github.com/publicsuffix/list/pull/2985"
```
I will leave this record in place while the entry remains in the PSL, 
so that future (TBD) automation can remove entries where the 
record is not present.
