### PR TITLE
Add wildcard entries for web.core.windows.net and web.core.usgovcloudapi.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14690,13 +14690,13 @@ cloudapp.net
 trafficmanager.net
 blob.core.usgovcloudapi.net
 file.core.usgovcloudapi.net
-web.core.usgovcloudapi.net
+*.web.core.usgovcloudapi.net
 servicebus.usgovcloudapi.net
 usgovcloudapp.net
 usgovtrafficmanager.net
 blob.core.windows.net
 file.core.windows.net
-web.core.windows.net
+*.web.core.windows.net
 servicebus.windows.net
 azure-api.us
 azurewebsites.us


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not being lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

Email Address: abuse@microsoft.com 
  URL where abuse contact or abuse reporting form can be found: https://msrc.microsoft.com/report/abuse 

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.
---

## Description of Organization

Microsoft Corporation is a global leader in technology, headquartered in the United States. Its cloud platform, Azure, ranks among the world’s top cloud service providers. Guided by its mission to empower every person and every organization on the planet to achieve more, Microsoft continues to drive innovation and transformation across industries.

**Organization Website:**
https://www.microsoft.com/

## Reason for PSL Inclusion
Promoting these two suffixes to wildcards (*.web.core.windows.net, *.web.core.usgovcloudapi.net) makes each <account>.z<N>.web.core.<cloud> its own registrable domain, giving every storage account a clean, independent origin boundary. The primary purpose is cookie / origin security isolation between independent customer tenants. This benefits every PSL consumer (browsers, cookie libraries, CORS and same-site logic, certificate scoping). This mirrors the wildcard-only multi-tenant pattern already present in the list (e.g. *.azurecontainer.io). The flat entries are already deployed and in effect, so this change tightens isolation without expanding namespace surface.

These are PRIVATE-section domains under Microsoft-owned registrations (windows.net, usgovcloudapi.net) on Microsoft's corporate registrar; we will maintain >1 year registration term and keep the _psl TXT records in place. We are not seeking to work around any third-party limit.

**Number of users this request is being made to serve:** Azure currently supports millions of users.

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
