### PR TITLE
Add layupsagents.com (Layups AI)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14432,6 +14432,11 @@ laravel.cloud
 on-forge.com
 on-vapor.com
 
+// Layups AI : https://layups.ai
+// Submitted by Seth Weinheimer <seth@layups.ai>
+layupsagents.com
+*.layupsagents.com
+
 // LCube - Professional hosting e.K. : https://www.lcube-webhosting.de
 // Submitted by Lars Laehn <info@lcube.de>
 git-repos.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address.

---

### Description of Organization

**Layups AI** (https://layups.ai) is a managed AI-agents platform. Customers are organizations; each organization operates one or more managed AI agents. Agents publish web content (dashboards, generated sites, internal tools) for their organization under a nested per-agent namespace:

```
<site>.<agent>.<org>.layupsagents.com
```

`layupsagents.com` is a dedicated apex used solely for this multi-tenant agent-hosting namespace; no shared first-party application is served at the apex or at the `<org>` level.

### Reason for PSL Inclusion

This is a multi-tenant platform where each customer organization — and each agent within it — serves **independent, customer-controlled web content** on its own subdomains. We need a hard security/privacy boundary between tenants so that one customer's agent can never set or read a cookie, nor otherwise share an origin-derived registrable-domain scope, belonging to another customer's agent (the classic "supercookie" / cross-tenant cookie-scope risk on a shared parent domain).

Adding the rule `*.layupsagents.com` makes each `<org>.layupsagents.com` a public suffix, so the **registrable domain becomes `<agent>.<org>.layupsagents.com`** — giving per-agent isolation. The bare `layupsagents.com` rule additionally ensures the apex itself is a public suffix. Browsers and PSL-consuming libraries will then refuse cookies scoped above an individual agent's registrable domain, making cross-tenant cookie bleed structurally impossible rather than policy-enforced.

### Not a workaround for third-party limits

This submission is **not** intended to work around any third-party rate limits or restrictions (e.g. Cloudflare, Let's Encrypt). TLS for these names is issued via Cloudflare Advanced Certificate Manager on the zone; this PSL entry is purely for cross-tenant origin/cookie isolation.

### DNS verification

```
$ dig +short TXT _psl.layupsagents.com
"https://github.com/publicsuffix/list/pull/2992"
```

(The `_psl` TXT record is added to the `layupsagents.com` zone pointing at this PR and will be kept in place.)
