### PR TITLE
Add grok.me (xAI) to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16326,6 +16326,10 @@ weeklylottery.org.uk
 wpenginepowered.com
 js.wpenginepowered.com
 
+// xAI : https://x.ai/
+// Submitted by Asim Shrestha <security@x.ai>
+grok.me
+
 // XenonCloud GbR : https://xenoncloud.net
 // Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>
 *.xenonconnect.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.

* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://x.ai/.well-known/security.txt

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

## Description of Organization

**Organization Website:** https://x.ai

xAI is an AI company and the makers of the Grok family of models. This submission is for **grok.me**, the domain behind Grok's app-builder feature: end users build and publish their own web applications, each served from its own subdomain (e.g. `myapp.grok.me`). The submitter is an engineer at xAI filing on behalf of the company; `security@x.ai` is our established role contact for domain, brand-protection, and security matters. Crucially, the `*.grok.me` subdomains are operated by **independent, mutually-untrusting end users** (user-generated content), not by xAI itself.

## Reason for PSL Inclusion

We request that `grok.me` be added to the PRIVATE section so each `*.grok.me` subdomain is treated as its own registrable site. Because the subdomains are controlled by independent, mutually-untrusting users, this is needed for:

1. **Cookie isolation**: prevent one user's subdomain from setting or reading cookies scoped to the `grok.me` apex that would affect other users' subdomains.
2. **Reputation / abuse isolation**: ensure an abusive or malicious `*.grok.me` site is assessed and blocklisted independently, rather than poisoning the reputation of `grok.me` (and therefore every other user) across browsers, ISPs, and safe-browsing systems.
3. **Certificate scoping**: prevent a single party from obtaining certificates spanning the shared registrable space.

This mirrors existing PRIVATE-section entries for user-content platforms (e.g. `vercel.app`, `netlify.app`, `github.io`, `lovable.app`).

**Third-party transparency:** grok.me is served via Cloudflare (DNS/CDN) and Vercel (subdomain hosting). This request is **not** intended to circumvent any Cloudflare, Vercel, or Let's Encrypt limit. It is solely for the cookie and abuse-isolation security properties described above.

**Abuse handling:** abuse on a user subdomain can be reported to `abuse@x.ai`, published via `https://x.ai/.well-known/security.txt`.

**Number of THOUSANDS of distinct users this request is being made to serve:** Estimated in the hundreds of thousands of distinct end users, each publishing one or more apps on their own `*.grok.me` subdomain (estimate).

## DNS Verification

```
dig +short TXT _psl.grok.me
"https://github.com/publicsuffix/list/pull/2993"
```

The `_psl.grok.me` TXT record is set to this PR's URL (output above). The apex `grok.me` redirects to `https://grok.com`; all user content lives on the `*.grok.me` subdomains.

