### PR TITLE
Remove info.at, biz.at

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14147,10 +14147,6 @@ in-vpn.org
 // Submitted by Connor McFarlane <noc@inferno.co.uk>
 oninferno.net
 
-// info.at : http://www.info.at/
-biz.at
-info.at
-
 // info.cx : http://info.cx
 // Submitted by June Slater <whois@igloo.to>
 info.cx


### PR DESCRIPTION
This PR removes `info.at` and `biz.at` from the Public Suffix List.

These domains are no longer operated as public registries or multi-tenant hosting platforms. Subdomains are administered exclusively by the domain owner and are not delegated to unrelated third parties.

There is no original PR, those entries are very old.

DNS TXT records will be added for validation.

* [x] Abuse contact information (email or web form) is available and easily accessible:
https://www.info.at/home/kontakt/
