### PR TITLE
Add ing.ng (private)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14155,6 +14155,10 @@ info.at
 // Submitted by June Slater <whois@igloo.to>
 info.cx
 
+// ing.ng : https://ing.ng
+// Submitted by Robin <dev@ing.ng>
+ing.ng
+
 // Interlegis : http://www.interlegis.leg.br
 // Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
 ac.leg.br


### PR DESCRIPTION
ing.ng is a live service issuing free and premium *.ing.ng subdomains to the general public (mutually-untrusting parties). PSL inclusion is needed for cross-subdomain cookie/security isolation and correct site boundaries.

The ing.ng registration has more than 2 years remaining at the time of submission (expires 2029-06-08).

We commit to maintaining ing.ng's registration in good standing, keeping more than 1 year left in its term at all times.

Contact: dev@ing.ng