### PR TITLE
Add DNSExit.com free domain suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12966,6 +12966,15 @@ discordsez.com
 // Submitted by Calvin Browne <calvin@dns.business>
 jozi.biz
 
+// DNSExit.com : https://dnsexit.com/domains/free-second-level-domains/
+// Submitted by Jack Chen <admin@dnsexit.com>
+publicvm.com
+2bd.net
+work.gd
+linkpc.net
+jo3.org
+run.place
+
 // DNSHE : https://www.dnshe.com
 // Submitted by DNSHE Team <support@dnshe.com>
 ccwu.cc


### PR DESCRIPTION
Add DNSExit.com free second-level domains to the PRIVATE section.

DNSExit.com is the domain owner/operator and offers these suffixes for independent users to create free subdomains for Dynamic DNS, websites, email, FTP, SSL, and custom name servers:
https://dnsexit.com/domains/free-second-level-domains/

This is for general public utility: DNSExit users are mutually-untrusting parties who can independently register and control subdomains beneath these suffixes. Adding them to the PSL prevents cookies and other registrable-domain decisions from crossing between unrelated DNSExit users.

Requested suffixes:

```text
publicvm.com
2bd.net
work.gd
linkpc.net
jo3.org
run.place
```

Expected examples:

- `example.publicvm.com` registrable domain: `example.publicvm.com`, public suffix: `publicvm.com`
- `example.2bd.net` registrable domain: `example.2bd.net`, public suffix: `2bd.net`
- `example.work.gd` registrable domain: `example.work.gd`, public suffix: `work.gd`
- `example.linkpc.net` registrable domain: `example.linkpc.net`, public suffix: `linkpc.net`
- `example.jo3.org` registrable domain: `example.jo3.org`, public suffix: `jo3.org`
- `example.run.place` registrable domain: `example.run.place`, public suffix: `run.place`

DNS validation TXT records have been published for every suffix and will be left in place after validation:

```text
_psl.publicvm.com TXT "https://github.com/publicsuffix/list/pull/2998"
_psl.2bd.net TXT "https://github.com/publicsuffix/list/pull/2998"
_psl.work.gd TXT "https://github.com/publicsuffix/list/pull/2998"
_psl.linkpc.net TXT "https://github.com/publicsuffix/list/pull/2998"
_psl.jo3.org TXT "https://github.com/publicsuffix/list/pull/2998"
_psl.run.place TXT "https://github.com/publicsuffix/list/pull/2998"
```

The submitted domain names have more than 2 years of registration period remaining beyond the PR submission date. DNSExit.com commits to maintaining these registrations in good standing with more than one year remaining.

Verified public RDAP expiration dates:

```text
publicvm.com  2028-07-19T05:57:17Z
2bd.net       2028-12-26T00:54:49Z
work.gd       2029-06-18T23:59:59.0Z
linkpc.net    2029-11-12T00:23:21Z
jo3.org       2028-12-30T10:41:43.786Z
run.place     2029-06-18T04:52:46.204Z
```
