### PR TITLE
Add ing.ng (private)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14155,6 +14155,10 @@ info.at
 // Submitted by June Slater <whois@igloo.to>
 info.cx
 
+// ing.ng : https://ing.ng
+// Submitted by Kartik <dev@ing.ng>
+ing.ng
+
 // Interlegis : http://www.interlegis.leg.br
 // Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
 ac.leg.br


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] **Description of Organization**

**ing.ng** (https://ing.ng) operates a free and premium subdomain registration service. Any user — human or AI agent — can register a `*.ing.ng` subdomain via API or web panel, get full DNS control (A/AAAA/CNAME/MX/TXT/NS/SRV), webhook notifications, and optional Web3/ENS identity resolution. Each subdomain belongs to an independent, mutually-untrusting party.

* [x] **Robust Reason for PSL Inclusion**

We request a PRIVATE-section listing so that browsers, cookie libraries, and reputation/safe-browsing systems treat each `*.ing.ng` subdomain as a separate registrable domain:

- **Cookie / origin isolation** between independent users' subdomains (no shared cookie scope under the parent domain).
- **TLS certificate rate-limit isolation** — each subdomain user gets their own certificate bucket (Let's Encrypt, etc.) without being impacted by sibling subdomains.
- **Reputation isolation** — an abuse or safe-browsing flag on one subdomain must not taint sibling subdomains or the apex.

This mirrors the established pattern for comparable multi-tenant hosting providers already in the private section (e.g. `vercel.app`, `netlify.app`, `github.io`, `azurewebsites.net`).

* [x] **DNS verification via dig**

`_psl.ing.ng` TXT record pointing to this PR's URL will be confirmed via `dig` in a follow-up comment. The record is already deployed and resolving globally.

* [x] **Two-year registration & `_psl` record**

`ing.ng` has more than two years remaining on its registration (expires 2029-06-08 per whois.nic.net.ng). We will keep the `_psl` TXT record in place in the zone for ongoing re-validation.

### Submitter affirms the following

* [x] This request was **not** submitted to work around any third-party limits (e.g. Cloudflare, Let's Encrypt, Apple, GitLab). It addresses cookie/origin and reputation isolation between independent tenants — the PSL's intended purpose.
* [x] The entry was added to the PRIVATE DOMAINS section, sorted alphabetically by organization name.
* [x] The entry includes the required comment block (`// Organization : URL` and `// Submitted by Name <email>`) with a valid, monitored contact address.

### Entry added (private section)

    // ing.ng : https://ing.ng
    // Submitted by Kartik <dev@ing.ng>
    ing.ng