### PR TITLE
Add ing.ng (private)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14155,6 +14155,10 @@ info.at
 // Submitted by June Slater <whois@igloo.to>
 info.cx
 
+// ing.ng : https://ing.ng
+// Submitted by Kartik <dev@ing.ng>
+ing.ng
+
 // Interlegis : http://www.interlegis.leg.br
 // Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
 ac.leg.br


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

* [x] This request was _not_ submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://ing.ng/report-abuse

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

**Organization Website:** https://ing.ng

**ing.ng** operates a free and premium subdomain registration service open to the public. Any user — human or AI agent — can register a `*.ing.ng` subdomain via a public API or web panel, with full DNS control (A/AAAA/CNAME/MX/TXT/NS/SRV), webhook notifications, and optional Web3/ENS identity resolution. Each subdomain belongs to an independent, mutually-untrusting party (user-generated content), not to ing.ng itself.

The submitter (Kartik) is the operator and maintainer of ing.ng, filing on behalf of the service. This submission is for the `ing.ng` apex itself, under which thousands of independent users operate their own subdomains.

## Reason for PSL Inclusion

We request that `ing.ng` be added to the PRIVATE section so each `*.ing.ng` subdomain is treated as its own registrable site. Because the subdomains are controlled by independent, mutually-untrusting users, this is needed for:

1. **Cookie isolation**: prevent one user's subdomain from setting or reading cookies scoped to `ing.ng` that would affect other users' subdomains.
2. **Reputation / abuse isolation**: ensure an abusive `*.ing.ng` site is blocklisted independently, rather than poisoning the reputation of `ing.ng` (and every other user) across browsers and safe-browsing systems.
3. **TLS certificate rate-limit isolation**: each user gets their own certificate bucket without being impacted by sibling subdomains.

This mirrors existing PRIVATE-section entries for multi-tenant platforms (e.g. `vercel.app`, `netlify.app`, `github.io`, `azurewebsites.net`).

**Third-party transparency:** ing.ng DNS is served via Cloudflare; web content may be proxied. This request is **not** intended to circumvent any Cloudflare, Let's Encrypt, or other third-party limit. It is solely for the cookie and abuse-isolation security properties described above.

**Abuse handling:** abuse on a user subdomain can be reported via https://ing.ng/report-abuse (abuse reporting form) or by email to dev@ing.ng.

**Number of THOUSANDS of distinct users this request is being made to serve:** 1200+ registered users and growing steadily.

## DNS Verification

```
$ dig +short TXT _psl.ing.ng
"https://github.com/publicsuffix/list/pull/3000"
```

The `_psl.ing.ng` TXT record is set to this PR's URL (output above) and will remain in place permanently for ongoing PSL re-validation.