### PR TITLE
remove ac.tj from public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5797,7 +5797,6 @@ or.th
 
 // tj : http://www.nic.tj/policy.html
 tj
-ac.tj
 biz.tj
 co.tj
 com.tj


### PR DESCRIPTION
remove ac.tj from PSL due to Active Citizen project domain. Domain own by organisation 
check http://www.nic.tj/whois.html ac.tj for more owner info.

Organization info https://dsc.tj/administration

Abuse contact active.citizen@dsc.tj

About Active Citizen project.
The official platform for connecting Dushanbe residents with municipal services, established at the initiative of the Dushanbe City Administration. Report issues, monitor their resolution, and contribute to the development of our capital city.

