### PR TITLE
Add cavuno.app to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12589,6 +12589,10 @@ carrd.co
 crd.co
 ju.mp
 
+// Cavuno : https://cavuno.com
+// Submitted by Jack Walsh <hi@cavuno.com>
+cavuno.app
+
 // CDDO : https://www.gov.uk/guidance/get-an-api-domain-on-govuk
 // Submitted by Jamie Tanna <jamie.tanna@digital.cabinet-office.gov.uk>
 api.gov.uk


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale — there are **none**. This request is not motivated by Cloudflare, Let's Encrypt, iOS/Facebook, or any other vendor limit; the sole motivation is cookie/session isolation between mutually-untrusting tenant sites, as described in the rationale below.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
   (`hi@cavuno.com` is our shared company inbox, not a personal mailbox; it is monitored daily.)

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://cavuno.com/contact (web contact form; reports also reach us at `hi@cavuno.com`)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway.*
   (Note: the submitted suffix `cavuno.app` is a dedicated tenant-serving domain. Our organization's own website lives on a different registration, `cavuno.com`, which is **not** part of this request, so our corporate-site cookies are unaffected. `cavuno.app` was set up specifically so that nothing of ours needs cookies at its apex.)

---

## Description of Organization

Cavuno is a small software company that builds a multi-tenant job-board platform: customer organizations use Cavuno to run their own niche job boards (their own branding, their own subdomain, and — via our open SDK — their own frontend code). Cavuno provides the hosting, data backend, job ingestion, and candidate/employer account systems; each customer operates an independent site for their own community on top of that. Our corporate website is https://cavuno.com.

I am Jack Walsh, founder and engineer at Cavuno. I administer the `cavuno.app` DNS zone (hosted at Cloudflare) and the platform infrastructure, and I am submitting this request on behalf of the company as the authorized representative of the domain owner.

**Organization Website:** https://cavuno.com

## Reason for PSL Inclusion

`cavuno.app` is the dedicated serving domain for tenant job boards on our platform: each subdomain (e.g. `demo.cavuno.app`) is an independent customer's site. This is the same private-registry pattern as `vercel.app`, `lovable.app`, or `replit.app`: subdomains are allocated to distinct, mutually-untrusting customers, and the code that runs on each subdomain (frontend built on our SDK) is controlled by that customer, not by us.

The reason for inclusion is **cookie and session security between tenants**:

1. **Tenant isolation.** Without a PSL entry, JavaScript on one customer's site can set a cookie scoped to `.cavuno.app`, which every other customer's site would then receive — enabling session fixation, tracking, or cookie-tossing attacks across unrelated customers. A PSL private-section entry makes each `<tenant>.cavuno.app` its own registrable domain, so browsers refuse cross-tenant supercookies.
2. **Isolation from the platform.** Tenant boards handle candidate sign-ins, job applications, and employer accounts; each tenant's session cookies should be confined to that tenant's own subdomain rather than shared across the serving domain.
3. **Deliberate domain separation.** We registered `cavuno.app` exclusively for tenant serving, separate from our corporate apex `cavuno.com`, specifically so it could be listed in the PSL private section cleanly (nothing of ours requires cookies at the `cavuno.app` apex).

Live, demonstrable use: https://demo.cavuno.app is a customer-style board frontend deployed on the domain today, and production tenant boards are migrating onto `cavuno.app` subdomains as the dedicated serving domain rolls out.

Registration term: `cavuno.app` is registered through **2029-07-04** (more than 2 years beyond today's submission date, verifiable via RDAP/WHOIS), and we commit to maintaining its registration in good standing and to keeping more than 1 year of term remaining for as long as the entry is listed.

We are not attempting to work around any third-party limits (Cloudflare, Let's Encrypt, iOS/Facebook, or otherwise); the request exists purely for the tenant cookie-isolation reasons above.

**Number of THOUSANDS of distinct users this request is being made to serve:** ~2 (~2000 distinct users estimate). Distinct individuals interacting directly with tenant subdomains today — board operator organizations plus the registered candidate and employer accounts on their boards (sign-ins, applications, job alerts, messaging) — are in the low thousands and growing as production boards migrate onto `cavuno.app`. This is an estimate, not an exact count; we are happy to provide current figures on request.

## DNS Verification

The `_psl` TXT record on `cavuno.app` is being published at PR-creation time (its content is this pull request's URL) and will be left in place for as long as we want the entry to remain listed:

```
dig +short TXT _psl.cavuno.app
"https://github.com/publicsuffix/list/pull/3002"
```
