### PR TITLE
Add somewhere.tech, somewhere.site, zuppabase.com (private)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16410,8 +16410,4 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
-// Zuppabase : https://zuppabase.com/
-// Submitted by Somewhere <support@somewhere.tech>
-zuppabase.com
-
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16411,7 +16411,7 @@ nett.to
 zabc.net
 
 // Zuppabase : https://zuppabase.com/
-// Submitted by Uzair Haq <uzairhaq@gmail.com>
+// Submitted by Somewhere <support@somewhere.tech>
 zuppabase.com
 
 // ===END PRIVATE DOMAINS===

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15770,6 +15770,11 @@ mafelo.net
 // Submitted by Solana Name Service <contact@sns.id>
 sol.site
 
+// Somewhere : https://somewhere.tech/
+// Submitted by Uzair Haq <support@somewhere.tech>
+somewhere.tech
+somewhere.site
+
 // Sony Interactive Entertainment LLC : https://sie.com/
 // Submitted by David Coles <david.coles@sony.com>
 playstation-cloud.com
@@ -16404,5 +16409,9 @@ nett.to
 // ZoneABC : https://zoneabc.net
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
+
+// Zuppabase : https://zuppabase.com/
+// Submitted by Uzair Haq <uzairhaq@gmail.com>
+zuppabase.com
 
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
## Description

Adding three private domains under which independent third parties register subdomains:

- **somewhere.tech** / **somewhere.site** — Somewhere is an app-hosting platform. Independent users deploy their own apps to `<name>.somewhere.tech` and `<name>.somewhere.site` subdomains.
- **zuppabase.com** — provisions per-tenant subdomains under `zuppabase.com`.

Each customer subdomain should be treated as its own registrable site so that (a) cookies do not leak across tenants and (b) Safe-Browsing/abuse reputation is scoped to the individual subdomain rather than the shared apex.

## Checklist
- [x] Added under `// ===BEGIN PRIVATE DOMAINS===`
- [x] Entity comment + `Submitted by` header included
- [x] Domains lowercased, no duplicates
- [ ] `_psl` DNS TXT records referencing this PR will be added on all three domains (adding immediately after this PR URL exists)

_psl validation records will point to this PR.