### PR TITLE
Add namc.ir (Namacdoon)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14778,6 +14778,10 @@ cust.retrosnub.co.uk
 // Submitted by Paulus Schoutsen <infra@nabucasa.com>
 ui.nabu.casa
 
+// Namacdoon : https://namacdoon.ir
+// Submitted by MohammadAmin Khodaee <info@namacdoon.ir>
+namc.ir
+
 // Needle Tools GmbH : https://needle.tools
 // Submitted by Felix Herbst <security@needle.tools>
 needle.run


### PR DESCRIPTION
namc.ir is the customer-facing domain of Namacdoon (https://namacdoon.ir), a restaurant direct-ordering platform. Each subdomain ({shop}.namc.ir) is an independent restaurant tenant's website with its own content, operated by a different business.

We request private-section inclusion so that browsers and reputation systems treat each tenant as a separate registrable domain (cookie isolation and per-tenant reputation) — same category as other multi-tenant platform entries.

The `_psl` TXT record on namc.ir referencing this PR will be in place within minutes of opening it (record is added via our DNS API immediately after the PR number is known).

Contact: info@namacdoon.ir (verified working).