### PR TITLE
Add local-8000.site (ShareLocalHost)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15144,6 +15144,10 @@ oy.lc
 // Submitted by Derek Myers <derek@pagefog.com>
 pgfog.com
 
+// Pagelet : https://sharelocal.host
+// Submitted by Alan <killua8p@gmail.com>
+local-8000.site
+
 // Pantheon Systems, Inc. : https://pantheon.io/
 // Submitted by Gary Dylina <gary@pantheon.io>
 gotpantheon.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15144,10 +15144,6 @@ oy.lc
 // Submitted by Derek Myers <derek@pagefog.com>
 pgfog.com
 
-// Pagelet : https://sharelocal.host
-// Submitted by Alan <killua8p@gmail.com>
-local-8000.site
-
 // Pantheon Systems, Inc. : https://pantheon.io/
 // Submitted by Gary Dylina <gary@pantheon.io>
 gotpantheon.com
@@ -15695,6 +15691,10 @@ as.sh.cn
 vicp.fun
 yicp.fun
 zicp.fun
+
+// ShareLocalHost : https://sharelocal.host
+// Submitted by Alan <killua8p@gmail.com>
+local-8000.site
 
 // Sheezy.Art : https://sheezy.art
 // Submitted by Nyoom <admin@sheezy.art>


### PR DESCRIPTION
### Description of Organization

ShareLocalHost (https://sharelocal.host) is an HTML artifact hosting service for AI agents: agents publish self-contained HTML pages (reports, dashboards, code reviews) via an API and share the resulting URL with humans.

Organization website: https://sharelocal.host (the API host; the full service contract is served at that URL)

### Reason for PSL Inclusion

local-8000.site is the content-serving domain. Each published page is untrusted third-party content served on its own subdomain (`{id}.local-8000.site` or `{slug}-{id}.local-8000.site`) — the same model as github.io / pages.dev. Subdomains belong to mutually untrusting publishers, so we request private-section inclusion to:

- prevent cross-subdomain cookie setting (`Domain=.local-8000.site` cookie-tossing/bombing between pages),
- make sibling pages cross-site for SameSite and storage-partitioning purposes,
- scope reputation/Safe-Browsing decisions toward individual subdomains.

The registrable apex serves no user content (it redirects to the API docs). We understand and accept that PSL inclusion is effectively permanent and rolls out gradually with client updates.

### DNS Verification

A `_psl.local-8000.site` TXT record pointing to this pull request will be published immediately after the PR is opened (the record needs the PR URL, hence after).

Abuse contact: killua8p@gmail.com