### PR TITLE
Add surething.host (Surething)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15920,6 +15920,10 @@ storage.supabase.co
 supabase.in
 supabase.net
 
+// Surething : https://surething.io
+// Submitted by Surething <psl@surething.io>
+surething.host
+
 // Syncloud : https://syncloud.org
 // Submitted by Boris Rybalkin <syncloud@syncloud.it>
 syncloud.it


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig — the `_psl.surething.host` TXT record pointing to this PR will be added immediately after this PR is opened (needs the PR number); this checkbox will be updated once the record is live.

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s). — registration extension to 2+ years is in progress; will confirm before marking this PR ready for review.

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale — none apply; this request does not seek to work around any third-party limits.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. — `psl@surething.io` is being set up as a monitored role inbox; will confirm before marking ready.

**Abuse Contact:**

* [ ] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: the apex page at `https://surething.host` will host abuse reporting information before any user content goes live on this domain; will confirm before marking ready.

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*. — Note: `surething.host` is a standalone, newly registered domain dedicated exclusively to user-generated content. It hosts no organizational website, sets no cookies at the apex, and is not related to our primary domain `surething.io`, so the cookie/certificate impact of PSL inclusion is precisely the intended outcome.

---

## Description of Organization

Surething (https://surething.io) is an AI agent platform where users work with AI agents to automate everyday workflows (email, calendar, messaging) and to build small web applications through conversation. A newly launched capability lets users publish those AI-built applications to the public web so they can share them with others; each published application is served on its own subdomain of `surething.host` (e.g. `forex-scanner-x7k2.surething.host`), backed by Cloudflare Workers for Platforms with per-application isolation. `surething.host` is used exclusively for this user-generated content — the apex serves only an informational page with abuse reporting contact, and no organizational services, cookies, or authentication will ever live on this domain. I am an engineer at Surething responsible for this publishing infrastructure, submitting on behalf of the organization.

**Organization Website:** https://surething.io

## Reason for PSL Inclusion

Cookie security and reputation isolation for user-generated content, consistent with established practice for this category of domain (e.g. `bolt.host`, `vusercontent.net`, `claudeusercontent.com`, `lovable.app`):

1. **Cookie isolation**: each subdomain hosts an application authored by a different end user. Without PSL inclusion, any user application could set domain-wide cookies affecting visitors of every other user's application. PSL inclusion makes each subdomain its own site boundary.
2. **Security/reputation isolation**: safe-browsing systems and other reputation services treat PSL entries as suffix boundaries. This ensures action against a single abusive subdomain does not affect other users' legitimate applications.
3. The domain registration will be maintained at 2+ years remaining, the `_psl` TXT record will be kept in place, and the entry will be maintained (including removal requests) by the submitting organization.

**Number of THOUSANDS of distinct users this request is being made to serve:** The publishing capability is rolling out to Surething's existing registered user base (thousands of users; we will update this with a precise current count before marking this PR ready for review). Each of these users can publish applications onto distinct subdomains of `surething.host`.

## DNS Verification

The following record will be added immediately after this PR is opened (it must reference this PR's number):

```
dig +short TXT _psl.surething.host
"https://github.com/publicsuffix/list/pull/3007"
```

This section will be updated with the live record once in place.
