### PR TITLE
Add IPv64.net dynamic DNS domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14198,6 +14198,28 @@ botdash.net
 botda.sh
 botdash.xyz
 
+// IPv64.net : https://ipv64.net/
+// Submitted by Dennis Schröder <info@ipv64.net>
+any64.de
+api64.de
+dns64.de
+dyndns64.de
+dynipv6.de
+eth64.de
+home64.de
+iot64.de
+ipv64.de
+lan64.de
+nas64.de
+root64.de
+route64.de
+srv64.de
+tcp64.de
+udp64.de
+vpn64.de
+wan64.de
+ipv64.net
+
 // IONOS SE : https://www.ionos.com/
 // IONOS Group SE : https://www.ionos-group.com/
 // Submitted by Henrik Willert <security@ionos.com>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14209,6 +14209,7 @@ eth64.de
 home64.de
 iot64.de
 ipv64.de
+ipv64.net
 lan64.de
 nas64.de
 root64.de
@@ -14218,7 +14219,6 @@ tcp64.de
 udp64.de
 vpn64.de
 wan64.de
-ipv64.net
 
 // IONOS SE : https://www.ionos.com/
 // IONOS Group SE : https://www.ionos-group.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14200,25 +14200,9 @@ botdash.xyz
 
 // IPv64.net : https://ipv64.net/
 // Submitted by Dennis Schröder <info@ipv64.net>
-any64.de
-api64.de
-dns64.de
-dyndns64.de
-dynipv6.de
-eth64.de
 home64.de
-iot64.de
 ipv64.de
 ipv64.net
-lan64.de
-nas64.de
-root64.de
-route64.de
-srv64.de
-tcp64.de
-udp64.de
-vpn64.de
-wan64.de
 
 // IONOS SE : https://www.ionos.com/
 // IONOS Group SE : https://www.ionos-group.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14198,12 +14198,6 @@ botdash.net
 botda.sh
 botdash.xyz
 
-// IPv64.net : https://ipv64.net/
-// Submitted by Dennis Schröder <info@ipv64.net>
-home64.de
-ipv64.de
-ipv64.net
-
 // IONOS SE : https://www.ionos.com/
 // IONOS Group SE : https://www.ionos-group.com/
 // Submitted by Henrik Willert <security@ionos.com>
@@ -14227,6 +14221,12 @@ iopsys.se
 // IPiFony Systems, Inc. : https://www.ipifony.com/
 // Submitted by Matthew Hardeman <mhardeman@ipifony.com>
 ipifony.net
+
+// IPv64.net : https://ipv64.net/
+// Submitted by Dennis Schröder <info@ipv64.net>
+home64.de
+ipv64.de
+ipv64.net
 
 // ir.md : https://nic.ir.md
 // Submitted by Ali Soizi <info@nic.ir.md>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization

* [x] Robust Reason for PSL Inclusion

* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [[Issue #1245](https://github.com/publicsuffix/list/issues/1245)](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

No third-party limits are being used as rationale for this request. This request is not intended to work around Cloudflare, Let's Encrypt, Apple, GitLab, Facebook/iOS, analytics, certificate issuance, rate limiting, vendor restrictions, or any other third-party limits.

* [x] This request was *not* submitted with the objective of working around other third-party limits.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

* [x] The [[Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines)](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully *read* and *understood*, and this request conforms to them.

* [x] The submission follows the [[Guidelines](https://github.com/publicsuffix/list/wiki/Format)](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  https://ipv64.net/

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

IPv64.net is a Dynamic DNS, DNS management, healthcheck, VPN gateway, CDN/reverse proxy and related internet infrastructure service operated by Prox IT UG (haftungsbeschränkt), Germany.

The part of the service relevant to this request is the IPv64.net Dynamic DNS service. IPv64.net allows registered users to create and operate free subdomains below IPv64-controlled Dynamic DNS base domains, such as `example.ipv64.net`, `example.home64.de`, or `example.dyndns64.de`. These subdomains are then used by independent users for routers, homeservers, NAS systems, VPN endpoints, IoT devices, labs, and other self-hosted internet services.

The submitting party is Prox IT UG (haftungsbeschränkt), represented by Dennis Schröder, Geschäftsführer / managing director. The submitter controls the listed domains and is responsible for the operation, maintenance, and abuse handling of the IPv64.net Dynamic DNS namespace. A role-based contact address is used in the PSL section so that the Public Suffix List project can continue to reach the operator independent of individual personnel changes.

**Organization Website:**
https://ipv64.net/

## Reason for PSL Inclusion

IPv64.net provides Dynamic DNS base domains under which many independent users can create and control their own subdomains. These users are mutually untrusted parties. A user controlling `foo.ipv64.net` should not be able to set cookies or receive same-site treatment for `bar.ipv64.net`, and the same applies to the other IPv64-controlled Dynamic DNS base domains included in this request.

The purpose of this request is therefore cookie security, browser site isolation, and correct registrable-domain boundary handling for independent IPv64.net Dynamic DNS users. Without PSL inclusion, unrelated user-controlled subdomains under the same IPv64.net Dynamic DNS base domain may be treated as belonging to the same registrable site by software relying on the Public Suffix List. Listing these base domains in the PRIVATE section makes each customer/user subdomain the registrable domain boundary, which is the intended security model for this namespace.

This request is not intended to work around any third-party rate limits, vendor restrictions, certificate authority limits, Cloudflare limits, Let's Encrypt limits, analytics restrictions, Apple/Facebook/iOS behavior, or similar platform-specific policies. No third-party limits are part of the rationale for this submission.

All submitted domains are controlled by IPv64.net / Prox IT UG (haftungsbeschränkt), are used as public Dynamic DNS base domains, and are intended to remain in active use. Each listed domain has and shall maintain at least two years remaining on registration at the time of submission, and we shall maintain more than one year of registration term while the entries remain listed. The `_psl` TXT validation records will remain in place in the respective zones for as long as the entries remain in the Public Suffix List.

There are no past Public Suffix List issues or pull requests specifically related to this IPv64.net section that we are aware of.

**Number of THOUSANDS of distinct users this request is being made to serve:**
~ 65.000 

This is the current actual count of distinct IPv64.net users using or able to use subnames below the requested IPv64.net Dynamic DNS base domains.

## DNS Verification

The following DNS TXT verification records will be created for this pull request. Replace `XXXX` with the actual pull request number once assigned.

```text

=== home64.de ===
"https://github.com/publicsuffix/list/pull/3009"
=== ipv64.de ===
"https://github.com/publicsuffix/list/pull/3009"
=== ipv64.net ===
"https://github.com/publicsuffix/list/pull/3009"
```