### PR TITLE
Add plima.site to PSL private domains for Plima

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15203,6 +15203,10 @@ us.platform.sh
 // Submitted by Henning Pohl <infra@pley.com>
 pley.games
 
+// Plima : https://plima.ai/
+// Submitted by Florian Stegre <florian@checksub.com>
+plima.site
+
 // Porter : https://porter.run/
 // Submitted by Rudraksh MK <rudi@porter.run>
 onporter.run


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

## Description of Organization

Plima (https://plima.ai/) is a SaaS product operated by Checksub SAS (France). It gives small businesses an AI-managed web presence: each customer gets a mini-website hosted on a dedicated first-level subdomain of plima.site (e.g. atelier-martin.plima.site). Content on these subdomains is controlled by mutually untrusting customers.

Organization Website: https://plima.ai/

## Reason for PSL Inclusion

plima.site exclusively hosts customer sites on first-level subdomains. We request inclusion in the PRIVATE section to (1) isolate cookies between customer sites, so there is no shared cookie scope across different businesses, (2) give each customer subdomain its own reputation for Safe Browsing, search and abuse scoring, and (3) separate Let's Encrypt rate limits per customer subdomain, since certificates are issued per subdomain on demand.

The bare domain plima.site serves only an HTTP 301 redirect to the organization website and sets no cookies. All current and future Plima customers are served by this single entry; the number of subdomains grows with every signup.

## Number of users this request is being made to serve

Every Plima customer receives one subdomain. The platform is newly launched on this domain and onboarding is continuous, so this entry serves all current and future customer sites.

## DNS verification via dig

A _psl TXT record referencing this pull request is published on the domain immediately after this PR is opened (the PR number is needed for the record content): dig +short TXT _psl.plima.site will return the URL of this pull request.

## Syntax, sorting and acknowledgements

The entry is added to the PRIVATE section only, sorted alphabetically (between "Pley AB" and "Porter"), using the standard two-line comment format. I am authorized by the organization to make this request. I have read the Guidelines (https://github.com/publicsuffix/list/wiki/Guidelines) and understand that inclusion rolls out slowly, that removal requests are equally slow, and that this entry should be treated as long-term.