### PR TITLE
Add ck.gg (private section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12636,6 +12636,10 @@ discourse.diy
 discourse.group
 discourse.team
 
+// ck.gg : https://ck.gg
+// Submitted by Jack Fuchs <j@ck.gg>
+ck.gg
+
 // Clerk : https://www.clerk.dev
 // Submitted by Colin Sidoti <systems@clerk.dev>
 clerk.app


### PR DESCRIPTION
ck.gg leases its subdomains (e.g. sta.ck.gg, ha.ck.gg) exclusively to unrelated third parties, who run fully independent sites on them via NS delegation — own DNS zone, own TLS certificates, own email.

Live examples operated by independent lessees today: che.ck.gg, sideki.ck.gg, feedba.ck.gg.

Cookie isolation and per-lessee Let's Encrypt limits are the motivation. DNS `_psl.ck.gg` TXT record pointing to this PR will be set immediately after opening it.

Website: https://ck.gg — catalog and lease terms: https://ck.gg/terms