### PR TITLE
Add avn.zone and rxd.zone to PSL private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16411,4 +16411,9 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// Name Zone : https://avn.zone : https://rxd.zone
+// Submitted by Craig Donnachie <craig.donnachie+psl@gmail.com>
+avn.zone
+rxd.zone
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale — none apply; no third-party limit workaround is sought (see rationale).
* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  https://avn.zone/help#abuse and https://rxd.zone/help#abuse

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

Name Zone is a DNS gateway service that lets verified owners of blockchain-registered
names manage public DNS records for a corresponding subdomain. It operates two zones:
avn.zone (for Avian Name System names, e.g. the on-chain owner of "bob.avn" controls
DNS for bob.avn.zone) and rxd.zone (for Radiant Wave names, e.g. "bob.rxd" controls
bob.rxd.zone). Ownership is verified cryptographically: users prove control of the
blockchain address holding the name via a signed-message challenge, and every DNS
change is re-checked against current on-chain ownership. The service supports
A/AAAA/CNAME records plus scoped ACME DNS-01 TXT challenges, so each subdomain owner
can host independently (GitHub Pages, Vercel, self-hosted, etc.) with their own TLS
certificates. The software is open source: https://github.com/cdonnachie/namezone

I am the submitter, Craig Donnachie — the individual operator of the service: I run
the authoritative nameservers, the PowerDNS infrastructure, and the web application
for both zones, and I control both domain registrations.

**Organization Website:** https://avn.zone (second zone in this section: https://rxd.zone)

## Reason for PSL Inclusion

Each subdomain under these zones is operated by a different, mutually-untrusting
party (whoever owns the corresponding blockchain name), while the parent domains are
operated by us. This is the classic delegated-namespace case the PRIVATE section
exists for:

1. **Cookie/site isolation.** Without PSL inclusion, one user's site at
   bob.avn.zone can set domain-wide cookies affecting alice.avn.zone and every other
   user, enabling session fixation and tracking across unrelated sites. PSL
   inclusion makes each user subdomain its own effective registrable domain.

2. **Reputation isolation.** Subdomain operators host independent content. Treating
   each subdomain as its own registrable domain lets reputation systems (Safe
   Browsing, mail filters, blocklists) act on the responsible subdomain rather than
   penalising every unrelated subdomain under the shared parent.

3. **Correct TLS issuance semantics.** Users obtain their own certificates for
   their subdomains via ACME DNS-01. PSL listing gives CAs and clients the correct
   registrable-domain boundary for these independently-controlled names. (We are
   not seeking to work around any issuance or rate limits — current issuance volume
   is nowhere near any third-party limit; this is about correct domain boundaries.)

Both domains have more than two years remaining on their registrations and will be
maintained above one year remaining for as long as they are listed, along with the
_psl TXT records.

**Number of THOUSANDS of distinct users this request is being made to serve:**

0.002 (actual count: 2 distinct subdomain operators). This is below the usual
threshold and we acknowledge that. The eligible population is 55 Avian ANS names
and 1,899 Radiant Wave names currently registered on-chain (actual counts, not
estimates), each of which can activate a subdomain by proving ownership. The
Avian count is expected to grow: DNS use of ANS names has not yet been promoted
to that community, and this service is the first consumer of them. We are
requesting inclusion early and deliberately: subdomains are claimed
permissionlessly by mutually-untrusting parties, so the cookie-isolation and
shared-reputation problems exist from the first user onward, and we want the
boundary in place before scale arrives rather than after an incident.


## DNS Verification

```
$ dig +short TXT _psl.avn.zone @8.8.8.8
"https://github.com/publicsuffix/list/pull/3014"
```

```
$ dig +short TXT _psl.rxd.zone @8.8.8.8
"https://github.com/publicsuffix/list/pull/3014"
```
