### PR TITLE
Add *.ai.rdpa.co to Redpanda Data entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15378,6 +15378,7 @@ instances.spawn.cc
 
 // Redpanda Data : https://redpanda.com
 // Submitted by Infrastructure Team <security@redpanda.com>
+*.ai.rdpa.co
 *.clusters.rdpa.co
 *.srvrless.rdpa.co
 


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - None - this request is not seeking to work around any third-party limits

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: security@redpanda.com

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyways*.

---

## Description of Organization

Redpanda is a streaming data platform providing Kafka-compatible message streaming infrastructure, and a multi-tenant AI data platform built on top of it. This PR amends the existing **Redpanda Data** section (added in #2679) with one additional entry, under the same organization contact (security@redpanda.com).

I am an engineer at Redpanda Data, responsible for the AI platform's multi-tenant infrastructure, working with the same infrastructure team that maintains our existing PSL section and the rdpa.co DNS.

Our existing entries (`*.clusters.rdpa.co`, `*.srvrless.rdpa.co`) cover customer-controlled dedicated cluster instances. This request adds `*.ai.rdpa.co`: the production zone for our multi-tenant AI platform. Each label under `ai.rdpa.co` is a separately operated cell whose service endpoints host customer tenant workspaces at per-tenant subdomains (e.g. `<tenant-id>.aigw.<cell>.ai.rdpa.co`). Customers control the content served there — AI agent endpoints, MCP servers, APIs, and OAuth/OIDC surfaces, each with independent authentication, authorization, and data — and share these URLs publicly with their own users and third-party AI clients.

**Organization Website:** https://redpanda.com

## Reason for PSL Inclusion

Same rationale as our existing entries from #2679: establishing proper security boundaries between customer-controlled environments in a multi-tenant cloud platform.

Each subdomain matched by `*.ai.rdpa.co` is a separately operated cell hosting customer-controlled tenant environments. Without PSL inclusion:

1. **Cookie isolation and CSRF prevention**: cookies could be scoped across unrelated cells and services under the shared parent domain, creating cross-site request forgery vulnerabilities and potential data exposure between unrelated customer environments. Each cell's service endpoints must be treated as separate sites.

2. **Browser permissions and settings isolation**: browser permissions (storage quotas, credentials, site settings) granted for one cell's endpoints could inappropriately apply to others, violating isolation guarantees.

3. **Security reputation**: a malicious actor abusing one customer environment could affect the reputation and security posture of all other environments sharing the parent domain.

The rdpa.co domain has registration extending beyond 2 years, and we commit to maintaining the `_psl` DNS verification records indefinitely while these domains remain in use, as we already do for the existing entries.

**Number of users this request is being made to serve:** enterprise customer tenants on our AI platform, whose agent and MCP endpoints are shared publicly with their own users (actively onboarding; expected to grow to the scale of our existing cluster entries)

## DNS Verification

```
dig +short TXT _psl.ai.rdpa.co
"https://github.com/publicsuffix/list/pull/3015"
```

Note: the `ai.rdpa.co` zone and its `_psl` TXT record are provisioned through the same infrastructure-as-code change that creates the zone and are rolling out now — the record will resolve as above shortly. The existing `_psl.rdpa.co`, `_psl.clusters.rdpa.co`, and `_psl.srvrless.rdpa.co` records from #2679 remain in place.
