### PR TITLE
Add sevra.page

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15684,6 +15684,10 @@ biz.ua
 co.ua
 pp.ua
 
+// Sevra : https://www.sevrahq.com
+// Submitted by Carlos Galarza <security@sevrahq.com>
+sevra.page
+
 // Shanghai Accounting Society : https://www.sasf.org.cn
 // Submitted by Information Administration <info@sasf.org.cn>
 as.sh.cn


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s). *(Registration extended 2026-07-08: RDAP now shows expiration **2029-07-05**, auto-renew enabled.)*

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale: **none** — this request does not seek to work around any third-party limit (Cloudflare, Let's Encrypt, or otherwise). The domain runs on Cloudflare with certificates issued for the zone we operate; the request is purely for cookie/site isolation between tenant subdomains.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. *(`security@sevrahq.com` is live — delivery verified 2026-07-08.)*

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://www.sevrahq.com/report

---

### Description of Organization

Sevra (https://www.sevrahq.com) is a hosted knowledge-base platform ("the managed home for brains") built on db.md, an open Apache-2.0 plain-text database standard (https://github.com/carloslfu/db.md). Each customer keeps a knowledge store with us and can publish parts of it as a public website.

**Organization website:** https://www.sevrahq.com
**Domain being submitted:** `sevra.page` — the dedicated publishing domain, deliberately separate from the product/session domain (sevrahq.com).

### Rationale for PSL Inclusion

`sevra.page` hosts **user-generated multi-tenant content**: every customer who publishes gets their own subdomain (`<handle>.sevra.page`) serving their pages and HTML, in the same pattern as `github.io` or `netlify.app`. Sign-ups are open and free, so subdomains are operated by mutually-untrusting parties.

We request inclusion in the PRIVATE section so that browsers treat each tenant subdomain as its own site:

1. **Cookie isolation between tenants.** Without PSL listing, JavaScript on one tenant's site can set `Domain=.sevra.page` cookies that are sent to every other tenant (cookie tossing / session fixation across customers). We already use `__Host-`-prefixed cookies for anything security-relevant, but PSL listing is the correct structural fix for a multi-tenant apex.
2. **Correct site boundaries** for browser storage partitioning, SameSite behavior, and referrer policies between tenants.
3. **Correct treatment by third-party systems** that consume the PSL for identifying registrable domains (search engines, SaaS integrations, security tooling), so one tenant's reputation or state is not attributed to another tenant.

The apex `sevra.page` serves no user sessions itself; the product (and its authentication) lives on sevrahq.com, a separate registrable domain, so listing `sevra.page` carries no risk to our own primary-domain cookies or certificates.

### Expected input/output

With `sevra.page` in the PRIVATE section:

| Input (hostname) | Expected registrable domain |
|---|---|
| `sevra.page` | (none — public suffix) |
| `alice.sevra.page` | `alice.sevra.page` |
| `app.alice.sevra.page` | `alice.sevra.page` |
| `sevrahq.com` (unaffected) | `sevrahq.com` |

A cookie set with `Domain=.sevra.page` must be rejected by conforming browsers; `alice.sevra.page` and `bob.sevra.page` must be treated as distinct sites.

### DNS verification

```
$ dig +short TXT _psl.sevra.page
"https://github.com/publicsuffix/list/pull/3016"
```

The `_psl` TXT record is published on the zone and will remain in place permanently. The record is live and resolving globally.

### Registration term

`sevra.page` is registered with Cloudflare Registrar through **2029-07-05** (extended 2026-07-08; RDAP reflects it) with auto-renew enabled. We commit to maintaining the registration for as long as the entry is listed.
