### PR TITLE
Add allmesh.net (PRIVATE) — Allium mesh naming domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11371,6 +11371,10 @@ ms.show
 // Submitted by Werner Kaltofen <wk@all-inkl.com>
 kasserver.com
 
+// Allium : https://allium.network/
+// Submitted by Vincent Speecke <vincent@aprojits.be>
+allmesh.net
+
 // Altervista : https://www.altervista.org
 // Submitted by Carlo Cannas <tech_staff@altervista.it>
 altervista.org

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11372,7 +11372,7 @@ ms.show
 kasserver.com
 
 // Allium : https://allium.network/
-// Submitted by Vincent Speecke <vincent@aprojits.be>
+// Submitted by Allium Network <security@allium.network>
 allmesh.net
 
 // Altervista : https://www.altervista.org


### PR DESCRIPTION
Apologies — I completely missed the PR template on my first submission, and I understand why that's frustrating for the maintainers. Thank you for the nudge, @simon-friedberger. I've read the guidelines and the template properly now and filled everything in below. I've also switched the entry's contact to a role-based address (`security@allium.network`).

One thing I want to be upfront about rather than have you discover it: **we are a pre-launch research project**, so we do not yet meet the 2,000–3,000 distinct-user threshold. I'm submitting now because the naming/isolation design is being built and I'd rather get the entry right (and get your feedback) early than rush it at launch — but I completely understand if you'd prefer we resubmit once real user numbers exist. Your call, and no hard feelings either way.

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] This request was _not_ submitted with the objective of working around other third-party limits. (Our reason is cookie/origin isolation between mutually-untrusting users — see rationale. We are not seeking to work around any Cloudflare/Let's Encrypt/other rate limits.)
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section (removing unused names, retaining the `_psl` DNS entry, and responding to e-mails to the supplied address).
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting. (Entry placed alphabetically in the PRIVATE section between `all-inkl.com` and `Altervista`.)
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. (`security@allium.network`, published in our live `security.txt`.)

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://allium.network/.well-known/security.txt (`Contact: mailto:security@allium.network`)

---

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*. (`allmesh.net` is a dedicated names-only domain, entirely separate from our primary site `allium.network` — nothing else is hosted on it, so there is no cookie/cert impact on our main domain.)

---

## Description of Organization

Allium is a network-integrity research project for the Tor and I2P anonymity networks. We ingest each network's public router/consensus data hourly and score relays for signs of surveillance, coordinated Sybil behaviour, and traffic tampering, publishing the methodology and findings openly and disclosing suspicious relays to each network's own bad-relay team. Alongside the research, we are building a companion WireGuard mesh-VPN ("Allium Connect") that only routes through relays our engine has vetted.

I'm the submitter and the engineer/founder on the project; I control the `allmesh.net` registration (registrar and DNS are Cloudflare). This submission is on behalf of Allium, not a third party. `allmesh.net` is a **dedicated names-only domain** — it hosts no website and no email; it exists solely to give each mesh user an isolated subdomain for device naming and HTTPS.

**Organization Website:** https://allium.network/

## Reason for PSL Inclusion

Our mesh assigns each **user account its own subdomain** under `allmesh.net` — e.g. `laptop.alice.allmesh.net` and `nas.bob.allmesh.net` — where Alice and Bob are unrelated parties who do not trust each other. We need each user's subdomain to be treated as a separate registrable domain so that browsers apply **cookie and origin isolation** between users, and so that per-user HTTPS certificates (issued home-side via ACME DNS-01) are scoped per user rather than being siblings under one registrable domain. Without a PSL entry, one user's subdomain could set or read cookies scoped to the shared parent, which is exactly the cross-user boundary we must prevent. This is the same design and rationale as managed-mesh naming domains already in the PRIVATE section, such as Tailscale's `ts.net`.

To be explicit per the template: we are **not** submitting this to work around any third-party rate limit. The isolation above is the purpose; any certificate-issuance convenience is incidental and not the reason for the request.

We commit to keeping `allmesh.net` registered with at least two years remaining and to maintaining the `_psl` TXT record for as long as we want the entry to remain. Please also note the honesty caveat at the top: we are pre-launch and do not yet meet the distinct-user minimum, and we defer to your judgment on timing.

**Number of THOUSANDS of distinct users this request is being made to serve:** Currently **0** — we are pre-launch (estimate, actual today is zero registered mesh users). This is a forward-looking submission for a research project preparing for launch; we understand the PSL's 2,000–3,000 distinct-user minimum and are happy to hold or resubmit if you'd prefer we wait until real numbers exist.

## DNS Verification

```
dig +short TXT _psl.allmesh.net
"https://github.com/publicsuffix/list/pull/3018"
```

The record is live and resolves on public resolvers (verified via 1.1.1.1 and 8.8.8.8). We will leave it in place while we want the entry to remain in the PSL.
