### PR TITLE
Add aivencloud.com subdomains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11333,6 +11333,7 @@ beep.pl
 // Submitted by Aiven Security Team <security+appdomains@aiven.io>
 aiven.app
 aivencloud.com
+*.aivencloud.com
 
 // Akamai : https://www.akamai.com/
 // Submitted by Akamai Team <publicsuffixlist@akamai.com>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission


### Checklist of required steps

* [x] Description of Organization

Organization Website: [aiven.io[ (https://aiven.io/)

Aiven is an Open source data infra-structure company offering streaming and databaser as a managed service. The company aims to simplify data storage and management in the cloud, allowing customers to deploy managed data services across multiple cloud platforms. I am a member of the security team.

* [x] Robust Reason for PSL Inclusion

We previously requested and obtained entries for [aivencloud.com PR#1508] (#1508) and [aiven.app PR#2315] (#2315)

With ~200k entries, our aivencloud.com zone became too big for DNS processing and DNS publishing, so we started migrating these entries to smaller zones (a.aivencloud.com, b.aivencloud.com, etc). These are technical limitations, and not policy restrictions. Our current split allows us to keep individual domains (x.aivencloud.com) to under 20k enties, as of writing the following counts are in these subdomains:

    aivencloud.com - 18312
    a.aivencloud.com - 10183
    b.aivencloud.com - 7808
    c.aivencloud.com - 8160
    d.aivencloud.com - 8833
    e.aivencloud.com - 8705
    f.aivencloud.com - 7124
    g.aivencloud.com - 8463
    h.aivencloud.com - 9676
    i.aivencloud.com - 8876
    j.aivencloud.com - 7962
    k.aivencloud.com - 7185
    l.aivencloud.com - 10641

This new setup now requires we use similar PSL entries to maintain multi-tenant security, such as to indicate these contain entries whose cookies and data should be considered their own registrants/users and not provide cross-side mixing between tenants.

* [x] DNS verification via dig

```
$ dig +short txt _psl.aivencloud.com
"https://github.com/publicsuffix/list/pull/3019"
```

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

aivencloud.com is managed by us and will not be expired within two years. We will maintain _psl TXT records.
`
__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->

 - internal DNS management tooling limitations (git repo sizes)
 - external DNS management tooling limitations [AWS Route53 authoritative zone size](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-entities-records)
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.


 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.


 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.


 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

Direct abuse contact: abuse@aiven.io
Direct security contact: security@aiven.io


* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- Provide the URL where an Internet user can access the abuse contact information -->
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->

  https://aiven.io/contact/

  The websites for aivencloud.com redirects to aiven.io

  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.


(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->

Aiven is an Open source data infra-structure company offering streaming and databases as a managed service. The company aims to simplify data storage and management in the cloud, allowing customers to deploy managed data services across multiple cloud platforms. I am a member of the security team.

<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->

 https://aiven.io/

<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->

We previously requested and obtained entries for [aivencloud.com PR#1508] (#1508) and [aiven.app PR#2315] (#2315)

With ~200k entries, our aivencloud.com zone became too big for DNS processing and DNS publishing, so we started migrating these entries to smaller zones (a.aivencloud.com, b.aivencloud.com, etc). These are technical limitations, and not policy restrictions. Our current split allows us to keep individual domains (x.aivencloud.com) to under 20k enties, as of writing the following counts are in these subdomains:

With ~200k entries, our aivencloud.com zone became too big for DNS processing and DNS publishing, so we started migrating these entries to smaller zones (a.aivencloud.com, b.aivencloud.com, etc). These are technical limitations, and not policy restrictions. Our current split allows us to keep individual domains (x.aivencloud.com) to under 20k enties, as of writing the following counts are in these subdomains:

    aivencloud.com - 18312
    a.aivencloud.com - 10183
    b.aivencloud.com - 7808
    c.aivencloud.com - 8160
    d.aivencloud.com - 8833
    e.aivencloud.com - 8705
    f.aivencloud.com - 7124
    g.aivencloud.com - 8463
    h.aivencloud.com - 9676
    i.aivencloud.com - 8876
    j.aivencloud.com - 7962
    k.aivencloud.com - 7185
    l.aivencloud.com - 10641

This new setup now requires we use similar PSL entries to maintain multi-tenant security, such as to indicate these contain entries whose cookies and data should be considered their own registrants/users and not provide cross-side mixing between tenants.

<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**

<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->

  ~200k

<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->

```
$ dig +short txt _psl.aivencloud.com
"https://github.com/publicsuffix/list/pull/3019"
```
<!-- END FILL IN -->

