### PR TITLE
Add zokl.site (PRIVATE)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16402,6 +16402,10 @@ basicserver.io
 virtualserver.io
 enterprisecloud.nu
 
+// Zokl : https://zokl.io
+// Submitted by Neil Day <neil@ashfordweb.co.uk>
+zokl.site
+
 // Zone.ID: https://zone.id
 // Submitted by Gx1.org <security@gx1.org>
 zone.id


### PR DESCRIPTION
## Description

Adds `zokl.site` to the PRIVATE DOMAINS section.

`zokl.site` is a domain we own and operate. It hosts our customers' websites on
subdomains (`label.zokl.site`), where the subdomains belong to mutually-untrusting
parties. Listing it treats each subdomain as its own registrable domain so cookies and
origins are isolated between tenants — the same rationale as `github.io`,
`herokuapp.com`, `vercel.app`, etc. Our first-party application/dashboard runs on a
separate registrable domain (`zokl.io`), which is deliberately not part of this request.

## Checklist

- [x] Submitting to the **PRIVATE** section.
- [x] Entry placed alphabetically, with a `// Company : URL` + `// Submitted by …` header.
- [x] Domain is registered with more than 2 years remaining and will be kept renewed.
- [x] I control the domain and will add a `_psl.zokl.site` DNS TXT record containing the
      URL of this PR (RFC 8553 proof-of-control) once the PR number is assigned.

Submitted by Neil Day <neil@ashfordweb.co.uk>.