### PR TITLE
Add boomurl.me (PRIVATE)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12508,6 +12508,10 @@ bluebite.io
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net
 
+// boomurl : https://boomurl.me
+// Submitted by Doron Grinstein <dgrinstein@gmail.com>
+boomurl.me
+
 // Boutir : https://www.boutir.com
 // Submitted by Eric Ng Ka Ka <ngkaka@boutir.com>
 boutir.com


### PR DESCRIPTION
## Description

`boomurl.me` is the serving domain of **boomurl** (https://boomurl.com), a free static-site publishing service. Every published user site is served from its **own subdomain**, `‹name›.boomurl.me` (e.g. `alice.boomurl.me`, `videogame.boomurl.me`). Sites are created by independent, unrelated users.

Adding `boomurl.me` to the PRIVATE section lets browsers and reputation systems treat each `‹name›.boomurl.me` as its own registrable domain, so cookies, `localStorage`/`sessionStorage`, and site-reputation signals do **not** span across unrelated user sites, and one user's site cannot set cookies scoped to the parent domain.

## Type of section

- [x] PRIVATE (this domain hosts distinct, independently-operated user sites)

## Authorization / relationship to the domain

I am the operator of `boomurl.me` / boomurl.com and control its DNS (Cloudflare).

## `_psl` TXT record

A `_psl.boomurl.me` TXT record referencing this pull request will be added immediately after it is opened (per the submission guidelines) and points back to this PR URL.

## Verification

- The subdomains are live now, e.g. `https://videogame.boomurl.me/` and `https://strongfile100.boomurl.me/` each serve a distinct user site.
- Wildcard TLS is in place (`*.boomurl.me`).
