### PR TITLE
Remove `audnedaln.no` (no longer associated with ccTLD operator) 

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4481,7 +4481,6 @@ askøy.no
 askvoll.no
 asnes.no
 åsnes.no
-audnedaln.no
 aukra.no
 aure.no
 aurland.no


### PR DESCRIPTION
Remove `audnedaln.no` from the PSL pending registry confirmation.

The domain appears to no longer be registry-controlled and is currently using external nameservers, and the current nameservers appear to be China-based instead of Norway-based.

No longer listed at https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/ as a part of the Norwegian ccTLD structure.

A confirmation request has been sent to Norid to verify whether `audnedaln.no` remains part of the `.no` geographical name hierarchy. cc'd maintainers. 

Possible duplicate #3029 

⚠️ This PR changes an entry in the ICANN section 