### PR TITLE
Remove `go.tj` (no longer associated with ccTLD operator)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5802,7 +5802,6 @@ biz.tj
 co.tj
 com.tj
 edu.tj
-go.tj
 gov.tj
 int.tj
 mil.tj


### PR DESCRIPTION
Remove `go.tj` from the PSL pending registry confirmation.

The domain appears to be a privately registered second-level domain rather than a registry-controlled public suffix. WHOIS information shows an individual registrant, registrar assignment, and external nameservers.

A confirmation request has been sent to the .TJ registry to verify whether `go.tj` is an official reserved/delegated namespace or a normal registrable domain.

This change can be revisited if the registry confirms that `go.tj` remains an intended public suffix.

WHOIS records:


```
Domain Name: go.tj
Description: Регистрация доменного имени

SUBMITTED BY
Name: Suvanov Artur
Address: ул. Зарафшан 3, 21
Phone: +998903474322
E-Mail: suvanov@gmail.com

DOMAIN OWNER
Name: Suvanov Artur
Address:
  street: ул. Зарафшан 3, 21
  city: Ташкент
  state: город Ташкент

ADMINISTRATIVE CONTACT
NIC Handle: Suvanov Artur
Name: Suvanov Artur
Address:
  street: ул. Зарафшан 3, 21
  city: Ташкент
  postal code: 100000
  state: город Ташкент
Phone: +998903474322
E-Mail: suvanov@gmail.com

TECHNICAL CONTACT
NIC Handle: Suvanov Artur
Name: Suvanov Artur
Address:
  street: ул. Зарафшан 3, 21
  city: Ташкент
  postal code: 100000
  state: город Ташкент
Phone: +998903474322
E-Mail: suvanov@gmail.com

DNS-SERVERS FOR DOMAIN
Primary DNS-Server:
  hostname: dns1.ahost.uz
Secondary DNS-Server:
  hostname: dns2.ahost.uz
Secondary DNS-Server:
  hostname: ns1.ahost.cloud
Secondary DNS-Server:
  hostname: ns2.ahost.cloud

REGISTRATION DATA
Registrar: WEBHOST LLC
Registration Date: 23 Apr 2026
```

⚠️ This PR changes an entry in the ICANN section 