### PR TITLE
Add dirb.app to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12963,6 +12963,10 @@ us.kg
 xx.kg
 dpdns.org
 
+// DirectionBoard : https://dirb.app
+// Submitted by Ivan <hostmaster@dirb.ai>
+dirb.app
+
 // Discord Inc : https://discord.com
 // Submitted by Sahn Lam <slam@discordapp.com>
 discordsays.com


### PR DESCRIPTION
### What is being requested

Add `dirb.app` to the PRIVATE section of the Public Suffix List.

### Who is making the request

I am the owner and operator of `dirb.app`. The domain is registered to us and its authoritative DNS is under our control (`ns1.vultr.com` / `ns2.vultr.com`).

Contact: hostmaster@dirb.ai

### Why

`dirb.app` is a multi-tenant application hosting platform. Customers are issued subdomains of the form `{customer}.dirb.app`, and each subdomain is controlled by a different, mutually-untrusting party who can deploy arbitrary web content there.

Because `dirb.app` is currently treated as an ordinary registrable domain, browsers consider all `{customer}.dirb.app` sites to be same-site siblings. Any one customer can therefore set or read cookies scoped to `.dirb.app`, and those cookies are visible to every other customer's site. We need browsers to treat each `{customer}.dirb.app` as an independent registrable site, so that cookies, storage and permissions are isolated between tenants.

This is the same rationale as existing PRIVATE entries for other subdomain hosting platforms (e.g. `github.io`, `vercel.app`, `pages.dev`).

### DNS validation

The `_psl` TXT record for the domain will be set to the URL of this pull request as soon as the PR number exists, and I will comment here to confirm once it is live and resolving:

```
_psl.dirb.app.  IN  TXT  "https://github.com/publicsuffix/list/pull/<this PR>"
```

### Confirmations

- [x] The request comes from the domain owner.
- [x] The entry is placed in the PRIVATE section, in alphabetical order by company name (between `DigitalPlat` and `Discord Inc`).
- [x] The entry includes a description line and a submitter contact line.
- [x] The contact address is a role address on a domain we control.
