### PR TITLE
Update `.no`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4333,14 +4333,18 @@ no
 fhs.no
 folkebibl.no
 fylkesbibl.no
+gielda.no
+herad.no
 idrett.no
+kommune.no
 museum.no
 priv.no
+suohkan.no
+tjielte.no
+uenorge.no
 vgs.no
 // Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
 dep.no
-herad.no
-kommune.no
 mil.no
 stat.no
 // Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
@@ -4481,6 +4485,7 @@ askøy.no
 askvoll.no
 asnes.no
 åsnes.no
+audnedal.no
 audnedaln.no
 aukra.no
 aure.no
@@ -4643,6 +4648,7 @@ halden.no
 halsa.no
 hamar.no
 hamaroy.no
+hamarøy.no
 hammarfeasta.no
 hámmárfeasta.no
 hammerfest.no
@@ -4697,6 +4703,7 @@ karasjohka.no
 kárášjohka.no
 karasjok.no
 karlsoy.no
+karlsøy.no
 karmoy.no
 karmøy.no
 kautokeino.no
@@ -4885,6 +4892,7 @@ ralingen.no
 rana.no
 randaberg.no
 rauma.no
+re.no
 rendalen.no
 rennebu.no
 rennesoy.no
@@ -5042,6 +5050,7 @@ tysvær.no
 tysvar.no
 ullensaker.no
 ullensvang.no
+ulstein.no
 ulvik.no
 unjarga.no
 unjárga.no

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4486,7 +4486,6 @@ askvoll.no
 asnes.no
 åsnes.no
 audnedal.no
-audnedaln.no
 aukra.no
 aure.no
 aurland.no
@@ -4597,7 +4596,6 @@ forsand.no
 fosnes.no
 fræna.no
 frana.no
-frei.no
 frogn.no
 froland.no
 frosta.no


### PR DESCRIPTION
This updates the `.no` section using Norid's current authoritative records from
[Appendix B](https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/),
[Appendix C](https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/), and
[Appendix D](https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/) 

https://www.norid.no/ is the authoritative source of .no tld and it can be traced from https://www.iana.org/domains/root/db/no.html

Email communication (NI:222317) with the registry `Norid <info@norid.no>` took place on Nov 3, 2025 (cc'd @simon-friedberger) and noted same sources listed above. Partial update applied by #2648.

```
- Geographical SLDs https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
- Additional SLDs by Norid https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
- Additional SLDs by other parties https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
```

This PR, compared with the old section:

- Adds `audnedal.no`, `gielda.no`, `hamarøy.no`, `karlsøy.no`, `re.no`,
  `suohkan.no`, `tjielte.no`, `uenorge.no`, and `ulstein.no`.
- Removes `audnedaln.no` and `frei.no`, which are not in the current Norid records.
- Moves `herad.no` and `kommune.no` from Appendix D to Appendix C to match Norid's
  current classification.

Programmatically parsed by the parser that I created to make sure the same list can be reproduced:

https://github.com/groundcat/psl-norway-parser

The generated output preserves the existing PSL comments, Unicode domain names,
formatting, and suffix-based sorting. It contains 758 unique rules and was
generated reproducibly by `norid_psl.py`.