### PR TITLE
Add preview.cerenovus.ai and staging-preview.cerenovus.ai (Cerenovus)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12626,6 +12626,11 @@ uk.net
 ae.org
 com.se
 
+// Cerenovus : https://cerenovus.ai
+// Submitted by Ollie Moreland <ollie@cerenovus.ai>
+preview.cerenovus.ai
+staging-preview.cerenovus.ai
+
 // Cityhost LLC : https://cityhost.ua
 // Submitted by Maksym Rivtin <support@cityhost.net.ua>
 cx.ua


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig (`_psl` TXT records will be added and verified immediately after this PR is opened, so the record can reference this PR's URL)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale — there are none; this request is purely for cookie/origin isolation of user-controlled subdomains.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. *(Currently a founder's direct address; will switch to a monitored role address before marking this PR ready if required.)*

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://cerenovus.ai (contact email in site footer; abuse reports actioned by revoking the offending device's forwarding token, which kills its subdomains immediately)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*. — Noting explicitly: the entries are **subdomains** (`preview.cerenovus.ai`, `staging-preview.cerenovus.ai`), not our primary domain `cerenovus.ai`, whose cookie behaviour is unaffected.

---

## Description of Organization

Cerenovus builds Compendium, a collaboration product for small software teams: a shared knowledge vault of linked markdown documents plus tooling that connects team members' development machines (shells, files, and local dev servers) to a common web app. It is developed by a small team and operates the cerenovus.ai domain and its infrastructure. The product includes a "Connected Devices" feature where a daemon on a user's machine can expose a local development web server through our cloud relay.

## Reason for PSL Inclusion

Forwarded dev servers are served on per-forward subdomains: `<random-slug>.preview.cerenovus.ai` (production) and `<random-slug>.staging-preview.cerenovus.ai` (staging). The content on these origins is **user-controlled application code** — arbitrary HTML/JS from whatever the user is developing — analogous to GitHub Codespaces previews (`app.github.dev`, PSL-listed) or repl.it apps (`replit.app`, PSL-listed).

Without PSL listing, all such subdomains share a registrable domain with each other. A malicious or compromised forwarded app could set `Domain=.preview.cerenovus.ai` supercookies affecting every other user's forwarded app (cookie tossing / session fixation across tenants). PSL listing makes each `<slug>.preview.cerenovus.ai` its own registrable domain, giving browser-enforced cookie isolation between mutually-untrusting tenants.

This is not a rate-limit workaround: TLS for these subdomains is a single wildcard certificate per zone issued via delegated DNS-01, and no Let's Encrypt / Cloudflare per-subdomain limits are in play.

## DNS Verification

`_psl.preview.cerenovus.ai` and `_psl.staging-preview.cerenovus.ai` TXT records referencing this PR will be published immediately after opening (the record content must contain the PR URL, which does not exist until submission).

```
dig +short TXT _psl.preview.cerenovus.ai
dig +short TXT _psl.staging-preview.cerenovus.ai
```