### PR TITLE
Add preview.saiusercontent.com and preview.staging.saiusercontent.com (PRIVATE)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15719,6 +15719,11 @@ shopware.store
 // Submitted by Oliver Graebner <security@mo-siemens.io>
 mo-siemens.io
 
+// Simular AI : https://simular.ai
+// Submitted by Li Hau Tan <security@simular.ai>
+preview.saiusercontent.com
+preview.staging.saiusercontent.com
+
 // SinaAppEngine : http://sae.sina.com.cn/
 // Submitted by SinaAppEngine <saesupport@sinacloud.com>
 1kapp.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://simular.ai (abuse reports: security@simular.ai or support@simular.ai — both actively monitored)

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

Simular AI (https://simular.ai) builds Sai, a consumer AI agent that performs computer-based tasks for its users. One of Sai's features lets a user publish agent-generated static sites (interactive reports, dashboards, small web apps) which they can share with other people. These published sites are hosted on our dedicated user-content domain `saiusercontent.com` — a separate registrable domain from our application domains, used exclusively for untrusted user-published content (the same pattern as `github.io` or `googleusercontent.com`).

I am a software engineer at Simular AI and operate the site-publishing serving infrastructure that this request concerns.

**Organization Website:** https://simular.ai

## Reason for PSL Inclusion

Cookie security between mutually-untrusting tenants. Each published site is served on its own subdomain, `<site-id>.preview.saiusercontent.com` (staging equivalent: `<site-id>.preview.staging.saiusercontent.com`), where `<site-id>` is a UUID unique to one user's published site. Content on these subdomains is user-generated and mutually untrusting: without a PSL entry, one tenant's site can set a `Domain=.preview.saiusercontent.com` cookie that is sent to (and can fixate or denial-of-service via cookie-bombing) every other tenant's site. Listing `preview.saiusercontent.com` (and the staging equivalent) makes browsers treat each tenant subdomain as a separate site, preventing cross-tenant cookie planting, aligning SameSite/cache partitioning with the actual trust boundary.

The domain serves production traffic for Sai's site-publishing feature today. This request is not intended to work around any third-party rate limits or restrictions; TLS for the wildcard is issued via Google Cloud Certificate Manager under our own account.

The `saiusercontent.com` registration will be maintained with at least two years remaining, and the `_psl` TXT records will remain in place for as long as the entries are listed.

**Number of THOUSANDS of distinct users this request is being made to serve:** <0.01 thousand distinct publishers today (actual count; the site-publishing feature launched in late June 2026). The parent product has several thousand monthly active users, and publishing is being rolled out to all of them, so the publisher count is expected to grow into the thousands. We understand this may be below the bar for inclusion today; we are submitting early because the entry is a prerequisite for enabling per-tenant cookies/storage safely, and propagation takes months. Happy to park this until adoption grows if the maintainers prefer.

## DNS Verification

```
dig +short TXT _psl.preview.saiusercontent.com
"https://github.com/publicsuffix/list/pull/3032"
```

```
dig +short TXT _psl.preview.staging.saiusercontent.com
"https://github.com/publicsuffix/list/pull/3032"
```

The records will remain in place to announce continued inclusion.

Made with [Cursor](https://cursor.com)



