### PR TITLE
Add lg.gov.ng to the Nigerian public suffixes

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4295,6 +4295,7 @@ com.ng
 edu.ng
 gov.ng
 i.ng
+lg.gov.ng
 mil.ng
 mobi.ng
 name.ng


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

## Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [ ] DNS verification via `dig` (will be added after the pull request number is assigned)

The following checklist items apply only to **PRIVATE** section submissions and are **not applicable** to this request because this submission modifies the ICANN `.ng` section:

- [ ] Registration term requirement
- [ ] Role-based email address
- [ ] Abuse contact information
- [ ] Private section maintenance acknowledgement

### Submitter affirms the following

- [x] This request originated from an interoperability issue encountered while onboarding a delegated `lg.gov.ng` subdomain to Cloudflare. The requested PSL entry is intended to accurately reflect the existing DNS delegation model confirmed by NIRA, rather than to circumvent a vendor limitation. 
- [x] This request is **not** intended to bypass vendor restrictions or rate limits.
- [x] The PSL Guidelines have been carefully read and understood.
- [x] The submitted change follows the required formatting and alphabetical sorting rules.

---

# Description of Organization

**Organization Website:**

https://whogohost.com

I am submitting this request as a technical representative of a Nigerian web hosting company that provides DNS, domain management, cloud, and hosting services for customers using the `.ng` namespace, including government domains.

While assisting a customer with onboarding the delegated domain `ojodu.lg.gov.ng` to Cloudflare, we discovered that `lg.gov.ng` functions as an independently delegated namespace but is not currently represented in the Public Suffix List.

To verify the delegation, we contacted the Nigerian Internet Registration Association (NIRA), the registry operator for the `.ng` namespace. NIRA confirmed that `ojodu.lg.gov.ng` is already correctly delegated and that no registry action was required.

---

# Reason for PSL Inclusion

This pull request proposes adding `lg.gov.ng` to the ICANN section of the Public Suffix List.

The `lg.gov.ng` namespace is used for Nigerian Local Government Authority domains. Individual Local Government Authority domains are delegated as independent DNS zones beneath this namespace and are administered independently.

For example, `ojodu.lg.gov.ng` is delegated as its own DNS zone rather than existing merely as a hostname beneath `gov.ng`.

Adding `lg.gov.ng` to the Public Suffix List will ensure that browsers and other PSL consumers correctly identify the registrable domain boundary for Local Government Authority domains. This provides proper cookie isolation and aligns browser behaviour with the existing DNS delegation model.

## Background

While onboarding `ojodu.lg.gov.ng` to Cloudflare, it became apparent that `lg.gov.ng` is not currently represented in the Public Suffix List.

Following discussions with NIRA, the registry confirmed that `ojodu.lg.gov.ng` is already an independently delegated DNS zone and that no registry action was required.

During the onboarding process, we discovered that the existing DNS delegation for lg.gov.ng is not currently reflected in the Public Suffix List

NIRA confirmed:

> "No action is required from the registry, as `ojodu.lg.gov.ng` is already correctly delegated; advise the customer to contact Cloudflare Support for guidance on onboarding a delegated subdomain or use a DNS provider that supports delegated subdomain zones."

## Expected Behaviour

### Current

| Domain | Public Suffix | Registrable Domain |
|---------|---------------|-------------------|
| `ojodu.lg.gov.ng` | `gov.ng` | `lg.gov.ng` |

### After this change

| Domain | Public Suffix | Registrable Domain |
|---------|---------------|-------------------|
| `ojodu.lg.gov.ng` | `lg.gov.ng` | `ojodu.lg.gov.ng` |
| `ikeja.lg.gov.ng` | `lg.gov.ng` | `ikeja.lg.gov.ng` |
| `ikorodu.lg.gov.ng` | `lg.gov.ng` | `ikorodu.lg.gov.ng` |

**Estimated number of distinct users served**

Nigeria has 774 Local Government Areas, each capable of operating an independently managed domain beneath `lg.gov.ng`. These domains support local government services used by government staff and the general public. The namespace therefore serves substantially more stakeholders than the minimum threshold outlined in the PSL contribution guidelines.

---

# DNS Verification

Once this pull request has been assigned a PR number, the following DNS TXT record will be published in accordance with the PSL DNS validation process:

```text
_psl.lg.gov.ng. IN TXT "https://github.com/publicsuffix/list/pull/<PR_NUMBER>"
```

The TXT record will remain in place after the pull request is merged, as recommended by the PSL maintainers.