### PR TITLE
Add draft2blog.com (Draft2Live) to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13007,6 +13007,10 @@ co.scot
 me.scot
 org.scot
 
+// Draft2Live : https://draft2live.ai
+// Submitted by Luka Hrachov <info@draft2live.ai>
+draft2blog.com
+
 // DrayTek Corp. : https://www.draytek.com/
 // Submitted by Paul Fang <mis@draytek.com>
 drayddns.com


### PR DESCRIPTION
## What / rationale

Draft2Live (https://draft2live.ai) runs a multi-tenant website-builder SaaS. Every customer is issued their own subdomain under `draft2blog.com` — e.g. `customerA.draft2blog.com`, `customerB.draft2blog.com`. These subdomains are operated by independent, mutually-untrusting parties (our customers), so they must be isolated from one another for cookies and same-origin purposes. Adding `draft2blog.com` to the PRIVATE section makes browsers and other PSL consumers treat each `*.draft2blog.com` subdomain as its own registrable domain / site.

## Entry

```
// Draft2Live : https://draft2live.ai
// Submitted by Luka Hrachov <info@draft2live.ai>
draft2blog.com
```

## Guideline checklist

- **Ownership:** I am the domain owner (held in our company's registrar account).
- **Registration term:** `draft2blog.com` is registered through **2029-06-02** (> 2 years remaining).
- **DNS validation (RFC 8553):** a `_psl.draft2blog.com` TXT record points to this PR's URL.
- **Syntax:** `make test-syntax` passes locally; the entry is sorted correctly (between `dotScot` and `DrayTek Corp.`).

## Expected behaviour

- **Before:** `a.draft2blog.com` and `b.draft2blog.com` share the registrable domain `draft2blog.com` (can read/set each other's cookies).
- **After:** each `*.draft2blog.com` is treated as its own site — cookies and origins isolated between customer subdomains.