### PR TITLE
Add droply.id (PRIVATE section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13023,6 +13023,10 @@ dreamhosters.com
 // Submitted by Infra Team <infra@durumis.com>
 durumis.com
 
+// Droply : https://droply.host
+// Submitted by Ney Gelbcke Junior <contact@droply.host>
+droply.id
+
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org>
 duckdns.org


### PR DESCRIPTION
### Checklist of required steps
* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The Guidelines were carefully read and understood, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**
* [x] Abuse contact information (email or web form) is available and easily accessible.
  URL where abuse contact or abuse reporting form can be found: https://droply.host/legal/acceptable-use

* [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

## Description of Organization
**Organization Website:** https://droply.host

Droply is a no-code static website hosting service. Customers upload or migrate a website and it is served on a subdomain of a dedicated content domain, droply.id (for example, alice.droply.id), over automatic HTTPS. The domain droply.id is used exclusively to serve independent customers' content; Droply's own application, user accounts, and billing run on a separate registrable domain, droply.host. I am the operator and engineer of Droply and I am submitting this request on behalf of the service. Each droply.id subdomain hosts a distinct customer's untrusted, user-controlled site.

## Reason for PSL Inclusion
Every customer site is served on its own subdomain of the single shared registrable domain droply.id. Without a PSL entry, browsers compute the same eTLD+1 (droply.id) for every customer, which (a) lets one customer's page set a Domain=.droply.id "supercookie" that is sent to every other customer's subdomain, and (b) causes reputation contagion, where a Safe Browsing or blocklist flag on any single customer subdomain is applied to the entire droply.id apex and thus to all customers. Adding droply.id to the PRIVATE section makes each customer subdomain its own eTLD+1, isolating cookies and Safe Browsing reputation per tenant — the same pattern used by github.io, *.vercel.app, and similar multi-tenant hosts. This is a cookie-security and tenant-isolation request; it is not an attempt to work around any third-party rate limit. droply.id is registered with more than two years remaining and we will keep it renewed with more than one year of term and maintain the _psl TXT record.

**Number of THOUSANDS of distinct users this request is being made to serve:** Fewer than 1 thousand at present — Droply is at an early/launch stage; this is an honest current estimate, expected to grow.

## DNS Verification
dig +short TXT _psl.droply.id
"https://github.com/publicsuffix/list/pull/3036"
