### PR TITLE
Add aryl.cloud and aryl.app to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12418,6 +12418,7 @@ arvanedge.ir
 
 // Aryl : https://aryl.cloud
 // Submitted by Aryl Team <admin@aryl.cloud>
+aryl.app
 aryl.cloud
 
 // ASEINet : https://www.aseinet.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12416,6 +12416,10 @@ f5.si
 // Submitted by ArvanCloud CDN <cdn@arvancloud.ir>
 arvanedge.ir
 
+// Aryl : https://aryl.cloud
+// Submitted by Aryl Team <admin@aryl.cloud>
+aryl.cloud
+
 // ASEINet : https://www.aseinet.com/
 // Submitted by Asei SEKIGUCHI <mail@aseinet.com>
 user.aseinet.ne.jp

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12416,8 +12416,8 @@ f5.si
 // Submitted by ArvanCloud CDN <cdn@arvancloud.ir>
 arvanedge.ir
 
-// Aryl : https://aryl.cloud
-// Submitted by Aryl Team <admin@aryl.cloud>
+// ArylLabs : https://aryllabs.com
+// Submitted by sijuel@aryllabs.com
 aryl.app
 aryl.cloud
 


### PR DESCRIPTION
Adding aryl.cloud and aryl.app to the private domains section for our smart pages platform.