### PR TITLE
Add oniconic.app (Iconic)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14126,6 +14126,10 @@ co.cz
 *.moonscale.io
 moonscale.net
 
+// Iconic : https://withiconic.ai
+// Submitted by Izu Elechi <izu@joincharm.com>
+oniconic.app
+
 // iDOT Services Limited : http://www.domain.gr.com
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 gr.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).
  * Note: `oniconic.app` was registered on 2026-07-13 and renewed the same day through July 2028 (RDAP now reflects the extended expiration). We shall keep the `_psl` TXT record in place for as long as the entry remains in the PSL.

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/) — disclosed for transparency in the rationale below; certificate issuance limits are not the objective of this request, and we would engage Let's Encrypt directly for rate-limit adjustments if we ever needed them.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
   * Note: the listed address (izu@joincharm.com) is the founder's address and is actively monitored with well under 30-day response time. We will stand up a role-based address on our own domain and submit an update to the section's contact line if the maintainers require it.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://withiconic.ai/terms (contact email is also linked from https://withiconic.ai/privacy; both pages are linked from the footer of every page, including every customer site)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
   * `oniconic.app` is a dedicated customer-sites domain. Our organization's own website lives on a separate domain (withiconic.ai), which is not part of this request, so the listing does not affect our primary website's cookies.
---

## Description of Organization

Iconic (a product of The San Francisco Design Company) is a website-building platform: customers describe the site they want, build it in a chat-based editor, and publish it. Every published customer site is served on its own subdomain of `oniconic.app` (for example `fern-foundry.oniconic.app`), which exists solely to host customer sites — it is not our corporate domain. I am Izu Elechi, the founder, and I operate the platform's DNS and hosting infrastructure; I am submitting this request on behalf of the organization and will maintain this section.

**Organization Website:** https://withiconic.ai

## Reason for PSL Inclusion

Cookie security and isolation between mutually untrusting tenants. Each subdomain of `oniconic.app` is a different customer's published website, and sites can include customer-authored content and scripts. Listing `oniconic.app` in the private section ensures browsers treat each customer site as a separate registrable domain: cookies set by one site can never be scoped to a parent domain shared with other customers' sites, and per-site reputation/limits in browsers and crawlers apply per customer rather than to the whole platform.

For transparency: PSL inclusion also interacts with Let's Encrypt's per-registered-domain issuance limits. That is a side effect we are disclosing, not the purpose of this request — if issuance limits ever became a constraint we would take that up with Let's Encrypt directly through their rate-limit adjustment process.

Registrations on `oniconic.app` are subdomains we assign to our own customers; the domain holds registration with our registrar and we commit to maintaining the `_psl` DNS record and the accuracy of this section over time.

**Number of THOUSANDS of distinct users this request is being made to serve:**

Fewer than one thousand today (actual count): the platform is in early access, and customer sites are being published on `oniconic.app` now. We are requesting the entry ahead of general availability deliberately, so that no cookie ever spans two customers' sites — retrofitting the boundary after launch would break existing sites' cookies.

## DNS Verification

```
dig +short TXT _psl.oniconic.app
"https://github.com/publicsuffix/list/pull/3039"
```

The record is live and will remain in place for as long as the entry remains in the PSL.
