### PR TITLE
Add whshly.co (Whooshly) to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16282,6 +16282,10 @@ remotewd.com
 // Submitted by Anthony Ryan <servers@whatbox.ca>
 box.ca
 
+// Whooshly : https://whooshly.co
+// Submitted by Ankur Shrestha <ankur@kmfv.cc>
+whshly.co
+
 // WIARD Enterprises : https://wiardweb.com
 // Submitted by Kidd Hustle <kiddhustle@wiardweb.com>
 pages.wiardweb.com


### PR DESCRIPTION
## Public Suffix List (PSL) Submission

### Description of Organization
[Whooshly](https://whooshly.co) is a pay-once campaign-link toolkit (branded short links, dynamic QR codes, UTM tooling, and hosted pages). We operate **`whshly.co`** as our hosted-content domain: each customer account is provisioned an independent subdomain (e.g. `acme.whshly.co`) under which that customer builds and hosts their own landing pages. Every subdomain is controlled by a distinct, mutually-untrusted end user.

### Robust Reason for PSL Inclusion
We request that `whshly.co` be added to the PRIVATE section so user agents and security systems treat each `<account>.whshly.co` subdomain as a separate registrable site. Because every subdomain hosts independent, user-generated content for a different customer, this provides:

- **Cookie isolation between tenants** — a `Set-Cookie` on one customer's subdomain must not be scopeable to sibling subdomains or the apex.
- **Independent reputation / security scoping** — a policy or reputation action taken against one customer's subdomain (e.g. by browser safe-browsing or scanning services) should not affect other customers' subdomains or the apex.

This is the same multi-tenant subdomain-hosting rationale for which other providers are already listed in the PRIVATE section (e.g. `github.io`, `vercel.app`, `netlify.app`, `pages.dev`).

### DNS Verification
A `_psl.whshly.co` TXT record pointing to this pull request will be published:

```
dig +short TXT _psl.whshly.co
"https://github.com/publicsuffix/list/pull/<this PR number>"
```

### Checklist of required steps
- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig (`_psl.whshly.co` TXT → this PR URL, being published)
- [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**
- [x] There are **no** third-party limits this request seeks to work around (this is a genuine multi-tenant subdomain-isolation need, not a rate-limit workaround).
- [x] This request was _not_ submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges it is their responsibility to maintain the domains within their section — removing unused names, retaining the `_psl` DNS entry, and responding to e-mails at the supplied address.

### Syntax
Single addition to the PRIVATE section, placed alphabetically by organization (between `Whatbox Inc.` and `WIARD Enterprises`):

```
// Whooshly : https://whooshly.co
// Submitted by Ankur Shrestha <ankur@kmfv.cc>
whshly.co
```
