### PR TITLE
Add lumerahq.app (Lumera) to PRIVATE DOMAINS

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14602,6 +14602,11 @@ barsy.uk
 barsy.co.uk
 barsyonline.co.uk
 
+// Lumera : https://lumerahq.com
+// Submitted by Ram Agrawal <security@lumerahq.com>
+lumerahq.app
+staging.lumerahq.app
+
 // Lutra : https://lutra.ai
 // Submitted by Joshua Newman <public-suffix-list@lutra.ai>
 *.lutrausercontent.com


### PR DESCRIPTION
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The Guidelines were carefully read and understood, and this request conforms to them.
* [x] The submission follows the Guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information is available and easily accessible.

  URL: https://lumerahq.com/abuse

---

**Organization**

Lumera (https://lumerahq.com) is a platform for building finance apps. Each customer gets an isolated workspace and can publish web apps that we host on their own subdomains of `lumerahq.app`, of the form `<app>--<company>.lumerahq.app` (staging uses `<app>--<company>.staging.lumerahq.app`).

**Why we need this**

These subdomains belong to different, unrelated companies, but they all sit under the single registrable domain `lumerahq.app` — so browsers treat them as one site, and one customer's app can set a `Domain=.lumerahq.app` cookie that reaches another customer's app. Listing `lumerahq.app` and `staging.lumerahq.app` makes each app its own site, isolating cookies and storage between customers.

This isn't to work around a third-party rate limit — TLS is served under an existing wildcard certificate and is unaffected.

**DNS verification**

We'll add `_psl` TXT records pointing to this PR in both zones (`_psl.lumerahq.app` and `_psl.staging.lumerahq.app`) as soon as it's opened for review.
