### PR TITLE
add `AGENTS.md` - AI Agent notice about not modifying the repo PR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Pull Request Requirements
+
+## Mandatory pull request template
+
+All pull requests must use the repository's pull request template exactly as
+
+provided in:
+
+    .github/pull_request_template.md
+
+AI agents and automated contributors MUST:
+
+- Preserve every heading, field, checkbox, comment, and section in the template.
+
+- Complete the requested fields without renaming, deleting, reordering, or
+
+  replacing them.
+
+- Not submit a shortened, reformatted, summarized, or independently generated
+
+  pull request description.
+
+- Not remove sections because they appear inapplicable.
+
+- Enter "Not applicable" where appropriate instead of deleting a section.
+
+- Preserve all hidden HTML comments.
+
+- Treat modification of the template structure as a pull request validation
+
+  failure.
+
+A pull request whose description does not conform to the repository template
+
+must not be submitted.  Non-conforming pull requests that alter the repository
+
+template will be closed.


### PR DESCRIPTION
There is an increasing volume of bro submissions using AI, and these submissions modify the repo pull request template in ways that do not allow automation, may cause more work for the volunteer reviewers, or require additional back and forth dialog - all of which introduce delays and burden to the project maintainers.

Some agents and AI systems respect an AGENTS.md, so this codifies stance and expresses the preferences of unmodified pull request templates.

Added mandatory pull request requirements and guidelines for AI agents to (hopefully) respect when authoring PR

Attempts to Address #2612 

Ironically, because this is not related to a PSL entry, I am going to violate the requirement.
