### PR TITLE
Add Wavor private domains (wavor.app, wavor.site, wavorweb.com)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16244,6 +16244,12 @@ wal.app
 // Submitted by Lorentz Kinde <security@wasmer.io>
 wasmer.app
 
+// Wavor : https://wavor.io
+// Submitted by Wavor Security <security@wavor.io>
+wavor.app
+wavor.site
+wavorweb.com
+
 // Webflow, Inc. : https://www.webflow.com
 // Submitted by Webflow Security Team <security@webflow.com>
 webflow.io


### PR DESCRIPTION
This PR adds Wavor's customer-website subdomain hosts to the PRIVATE section.

Wavor (https://wavor.io) is a business platform. Customers publish their own
websites under subdomains of these registrable domains, e.g. customer.wavor.site.
Each subdomain belongs to a different, independent customer.

Adding these to the PSL lets browsers treat each subdomain (e.g. a.wavor.site vs
b.wavor.site) as its own site, giving per-customer cookie/origin isolation.

Domains (alphabetical, placed after Wasmer / before Webflow):
- wavor.app
- wavor.site
- wavorweb.com

DNS validation: the domain owner is adding _psl.<domain> TXT records pointing to
this PR for each of the three suffixes.

Submitted by Wavor Security <security@wavor.io>.