### PR TITLE
Add localsites.es (private section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14521,6 +14521,10 @@ ggff.net
 // Submitted by Lann Martin <security@localcert.dev>
 *.user.localcert.dev
 
+// LocalSites : https://localsites.es
+// Submitted by David Navarro <info@localsites.es>
+localsites.es
+
 // Localtonet : https://localtonet.com/
 // Submitted by Burak Isleyici <support@localtonet.com>
 localtonet.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _psl TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] Not applicable — we are not seeking to work around any third-party limits (Cloudflare, Let's Encrypt, iOS/Facebook, etc.).
* [x] This request was not submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section, retaining the _psl DNS entry and responding to e-mails to the supplied address.
* [x] The Guidelines were carefully read and understood.
* [x] The submission follows the Guidelines on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

URL where abuse contact or abuse reporting form can be found: https://localsites.es/aviso-legal

* [x] Yes, I understand. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. Proceed anyway.

## Description of Organization

LocalSites (LOCALSITES SL, NIF B50649409, based in Albacete, Spain — https://localsites.es/) is a website building and hosting platform for local businesses. Each business gets its own subdomain ({business}.localsites.es) with its own content, contact details, branding and a contact/lead form; the owner manages the site by signing in with their own Google account (OAuth). The subdomains are operated by different, unrelated businesses (locksmiths, plumbers, drain-cleaning services, etc. across different Spanish cities), not internal projects of a single entity. I am David Navarro, the operator of the platform, submitting on its behalf.

**Organization Website:** https://localsites.es/

## Reason for PSL Inclusion

We request inclusion in the PRIVATE section so that each customer subdomain is treated as a separate registrable domain, giving proper origin/cookie isolation between these independent tenants — the same treatment as comparable hosting platforms already listed (Netlify, Wix, Vercel, GitHub Pages). Each client site sets per-subdomain cookies (a session/CSRF cookie for its contact form and a cookie-consent cookie), and one business's site must not be able to read another business's cookies.

We are NOT attempting to work around any third-party rate limits. localsites.es holds a registration term of more than two years and we will keep the _psl TXT record in place.

Honest note on scale: we currently host ~52 live, independent business sites and are a growing platform. We understand the guidelines mention a minimum of ~2,000–3,000 distinct users; we are below that threshold today and submit this for the maintainers' consideration, understanding it may be declined until we reach that scale.

**Number of THOUSANDS of distinct users:** ~0.05 (approximately 52 businesses, actual current count).

## DNS Verification

A _psl TXT record pointing to this pull request will be added at _psl.localsites.es once the PR number is known.