### PR TITLE
Remove Protonet GmbH entry

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15264,10 +15264,6 @@ vki.kr
 // Submitted by yumenewa <admin@project-study.com>
 dev.project-study.com
 
-// Protonet GmbH : http://protonet.io
-// Submitted by Martin Meier <admin@protonet.io>
-protonet.io
-
 // PSL Sandbox : https://github.com/groundcat/PSL-Sandbox
 // Submitted by groundcat <psl-sandbox@alumni.upenn.edu>
 platter-app.dev


### PR DESCRIPTION
- Added in 2016 for Protonet's dynamic-DNS service.
- Protonet GmbH [went through insolvency](https://www.horizont.net/tech/nachrichten/Nach-der-Insolvenz-Protonet-lebt-weiter--ein-bisschen-159396) in 2017.
- DNS delegation resolves to domain parking.

```
;; ANSWER SECTION:
protonet.io.            120     IN      NS      ns2.parklogic.com.
protonet.io.            120     IN      NS      ns1.parklogic.com.
```

- The current registration expires on 2026-08-05.
- VT reports 3 malicious and 1 suspicious analysis results for the suffix.

https://github.com/publicsuffix/list/pull/281#issuecomment-5008064424

- The domain is for sale:

<img width="1354" height="292" alt="image" src="https://github.com/user-attachments/assets/7520da70-e402-401f-99e6-29aee406f3d4" />
