### PR TITLE
Update `.it`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1569,6 +1569,7 @@ it
 edu.it
 gov.it
 // Regions (3.3.1)
+// https://www.nic.it/en/manage-your-it/forms-and-docs -> "Assignment and Management of domain names"
 abr.it
 abruzzo.it
 aosta-valley.it

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1647,7 +1647,6 @@ trentinos-tirol.it
 trentinostirol.it
 trentinosud-tirol.it
 trentinosüd-tirol.it
-trentinosudtirol.it
 trentinosüdtirol.it
 trentinosued-tirol.it
 trentinosuedtirol.it
@@ -1663,7 +1662,6 @@ umbria.it
 val-d-aosta.it
 val-daosta.it
 vald-aosta.it
-valdaosta.it
 valle-aosta.it
 valle-d-aosta.it
 valle-daosta.it
@@ -1700,7 +1698,6 @@ aosta.it
 aoste.it
 ap.it
 aq.it
-aquila.it
 ar.it
 arezzo.it
 ascoli-piceno.it
@@ -1746,7 +1743,11 @@ bz.it
 ca.it
 cagliari.it
 caltanissetta.it
+campidano-medio.it
+campidanomedio.it
 campobasso.it
+carbonia-iglesias.it
+carboniaiglesias.it
 carrara-massa.it
 carraramassa.it
 caserta.it
@@ -1760,6 +1761,7 @@ cesenaforli.it
 cesenaforlì.it
 ch.it
 chieti.it
+ci.it
 cl.it
 cn.it
 co.it
@@ -1772,6 +1774,8 @@ cs.it
 ct.it
 cuneo.it
 cz.it
+dell-ogliastra.it
+dellogliastra.it
 en.it
 enna.it
 fc.it
@@ -1797,6 +1801,8 @@ go.it
 gorizia.it
 gr.it
 grosseto.it
+iglesias-carbonia.it
+iglesiascarbonia.it
 im.it
 imperia.it
 is.it
@@ -1825,6 +1831,8 @@ matera.it
 mb.it
 mc.it
 me.it
+medio-campidano.it
+mediocampidano.it
 messina.it
 mi.it
 milan.it
@@ -1847,8 +1855,13 @@ no.it
 novara.it
 nu.it
 nuoro.it
+og.it
+ogliastra.it
+olbia-tempio.it
+olbiatempio.it
 or.it
 oristano.it
+ot.it
 pa.it
 padova.it
 padua.it
@@ -1917,6 +1930,8 @@ sv.it
 ta.it
 taranto.it
 te.it
+tempio-olbia.it
+tempioolbia.it
 teramo.it
 terni.it
 tn.it
@@ -1957,6 +1972,7 @@ vibovalentia.it
 vicenza.it
 viterbo.it
 vr.it
+vs.it
 vt.it
 vv.it
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1569,7 +1569,6 @@ it
 edu.it
 gov.it
 // Regions (3.3.1)
-// https://www.nic.it/en/manage-your-it/forms-and-docs -> "Assignment and Management of domain names"
 abr.it
 abruzzo.it
 aosta-valley.it
@@ -1628,7 +1627,6 @@ trentin-sudtirol.it
 trentin-südtirol.it
 trentin-sued-tirol.it
 trentin-suedtirol.it
-trentino.it
 trentino-a-adige.it
 trentino-aadige.it
 trentino-alto-adige.it
@@ -1748,11 +1746,7 @@ bz.it
 ca.it
 cagliari.it
 caltanissetta.it
-campidano-medio.it
-campidanomedio.it
 campobasso.it
-carbonia-iglesias.it
-carboniaiglesias.it
 carrara-massa.it
 carraramassa.it
 caserta.it
@@ -1766,7 +1760,6 @@ cesenaforli.it
 cesenaforlì.it
 ch.it
 chieti.it
-ci.it
 cl.it
 cn.it
 co.it
@@ -1779,8 +1772,6 @@ cs.it
 ct.it
 cuneo.it
 cz.it
-dell-ogliastra.it
-dellogliastra.it
 en.it
 enna.it
 fc.it
@@ -1806,8 +1797,6 @@ go.it
 gorizia.it
 gr.it
 grosseto.it
-iglesias-carbonia.it
-iglesiascarbonia.it
 im.it
 imperia.it
 is.it
@@ -1836,8 +1825,6 @@ matera.it
 mb.it
 mc.it
 me.it
-medio-campidano.it
-mediocampidano.it
 messina.it
 mi.it
 milan.it
@@ -1860,13 +1847,8 @@ no.it
 novara.it
 nu.it
 nuoro.it
-og.it
-ogliastra.it
-olbia-tempio.it
-olbiatempio.it
 or.it
 oristano.it
-ot.it
 pa.it
 padova.it
 padua.it
@@ -1926,14 +1908,15 @@ sondrio.it
 sp.it
 sr.it
 ss.it
+su.it
+sud-sardegna.it
+sudsardegna.it
 südtirol.it
 suedtirol.it
 sv.it
 ta.it
 taranto.it
 te.it
-tempio-olbia.it
-tempioolbia.it
 teramo.it
 terni.it
 tn.it
@@ -1946,6 +1929,7 @@ trani-barletta-andria.it
 traniandriabarletta.it
 tranibarlettaandria.it
 trapani.it
+trentino.it
 trento.it
 treviso.it
 trieste.it
@@ -1964,6 +1948,7 @@ ve.it
 venezia.it
 venice.it
 verbania.it
+verbano-cusio-ossola.it
 vercelli.it
 verona.it
 vi.it
@@ -1972,7 +1957,6 @@ vibovalentia.it
 vicenza.it
 viterbo.it
 vr.it
-vs.it
 vt.it
 vv.it
 


### PR DESCRIPTION
This PR updates entries based on https://www.iana.org/domains/root/db/it.html -> https://www.nic.it/en/manage-your-it/forms-and-docs -> "Assignment and Management of domain names" 

Domain additions have been parsed from their latest published PDF file.

Added from the V8 [PDF file](https://www.nic.it/sites/default/files/documenti/2022/Regulation_assignation_v8.0.pdf):
- `su.it`
- `sud-sardegna.it`
- `sudsardegna.it`
- `verbano-cusio-ossola.it`

This source has been confirmed by `ccTLD .it Registry Hostmaster <hostmaster@nic.it>` on Mar 23, 2026:

```
Dear Sirs,

as answered in the previous email, in order to know the assignation criteria of domains belonging to the geographical struture in the .it please read the relevant Rules and Regulations available on our web site www.nic.it, where you can find the list of domain names.

Moreover the domains that are currently assigned to other registrants were registered before these regulations came into force.
When they will be cancelled they will again belong to the geographical structure.
Thereis no possibility to register geographical domain names by other entities.

--
 .it Registry  -  Hostmaster of the Day

 ----------                                            -------------
 .it Registry                              E-mail: hostmaster@nic.it
 IIT - Istituto del CNR                    Phone:  +39 050 9719811
 Via Giuseppe Moruzzi, 1                   Fax:    +39 050 542420
 56124 Pisa - Italy
```

Moved `trentino.it` to be under `// Provinces (3.3.2)`

Also attempted to address prior PRs #2747, #518 by removing identified privately-registered entries. 

To be safe, preserved some entries present in the PSL but absent from Regulation version 8.0:

- `campidano-medio.it`
- `campidanomedio.it`
- `carbonia-iglesias.it`
- `carboniaiglesias.it`
- `ci.it`
- `dell-ogliastra.it`
- `dellogliastra.it`
- `iglesias-carbonia.it`
- `iglesiascarbonia.it`
- `medio-campidano.it`
- `mediocampidano.it`
- `og.it`
- `ogliastra.it`
- `olbia-tempio.it`
- `olbiatempio.it`
- `ot.it`
- `tempio-olbia.it`
- `tempioolbia.it`
- `vs.it`

WHOIS returns `UNASSIGNABLE` so no risk of takeovers.
