### PR TITLE
Remove `*.cryptonomic.net`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12838,10 +12838,6 @@ craft.me
 // Submitted by Ales Krajnik <ales.krajnik@craynic.com>
 realm.cz
 
-// Cryptonomic : https://cryptonomic.net/
-// Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
-*.cryptonomic.net
-
 // cyber_Folks S.A. : https://cyberfolks.pl
 // Submitted by Bartlomiej Kida <security@cyberfolks.pl>
 cfolks.pl


### PR DESCRIPTION
- The entry `*.cryptonomic.net` was added in 2016 (#127) for a "planned" free public-subdomain service. 
- The domain `cryptonomic.net` does not resolve.
- It was noticed as abandoned in 2017 in #472
- The contact address on file, `public-suffix-list@cryptonomic.net` does not accept mail.

`SERVFAIL` status noted:

```
; <<>> DiG 9.20.18-1ubuntu2.1-Ubuntu <<>> @1.1.1.1 NS cryptonomic.net.
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 57635
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 8f8995531bd8c9d5 (echoed)
;; QUESTION SECTION:
;cryptonomic.net.               IN      NS

;; Query time: 0 msec
;; SERVER: 1.1.1.1#53(1.1.1.1) (UDP)
;; WHEN: Sat Jul 18 00:56:03 UTC 2026
;; MSG SIZE  rcvd: 56
```