### PR TITLE
Remove `api.stdlib.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15875,10 +15875,6 @@ indevs.in
 musician.io
 novecore.site
 
-// Standard Library : https://stdlib.com
-// Submitted by Jacob Lee <jacob@stdlib.com>
-api.stdlib.com
-
 // statichost.eu : https://www.statichost.eu
 // Submitted by Eric Selin <admin@statichost.eu>
 statichost.page


### PR DESCRIPTION
- Added by https://github.com/publicsuffix/list/pull/751
- The suffix returns NXDOMAIN through the public DNS resolvers
- Organization site https://stdlib.com/ could not be reached.
- The registration associated with the suffix currently expires on 2026-08-28.
- VT reports 1 malicious result.
- https://github.com/publicsuffix/list/pull/751#issuecomment-5009026326

cc @jacoblee93