### PR TITLE
Remove `hzc.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15449,10 +15449,6 @@ repl.run
 resindevice.io
 devices.resinstaging.io
 
-// RethinkDB : https://www.rethinkdb.com/
-// Submitted by Chris Kastorff <info@rethinkdb.com>
-hzc.io
-
 // Rico Developments Limited : https://adimo.co
 // Submitted by Colin Brown <hello@adimo.co>
 adimo.co.uk


### PR DESCRIPTION
- Domain for sale on dan.com; nameservers resolved to dan.com records.

```
;; ANSWER SECTION:
hzc.io.                 120     IN      NS      ns1.dan.com.
hzc.io.                 120     IN      NS      ns2.dan.com.
```

- The current registration's creation date is 2020-06-17, after `hzc.io` was added to the PSL in 2016. This may indicate that the original registration lapsed and was later picked up by a different registrant.
- VT reputation data reports 4 malicious analysis results for the suffix.
