### PR TITLE
Remove Bytemark Hosting entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12573,12 +12573,6 @@ bubbleapps.io
 // Submitted by Klara Mall <dns@bwcloud-os.de>
 *.bwcloud-os-instance.de
 
-// Bytemark Hosting : https://www.bytemark.co.uk
-// Submitted by Paul Cammish <paul.cammish@bytemark.co.uk>
-uk0.bigv.io
-dh.bytemark.co.uk
-vm.bytemark.co.uk
-
 // Caf.js Labs LLC : https://www.cafjs.com
 // Submitted by Antonio Lain <antlai@cafjs.com>
 cafjs.com


### PR DESCRIPTION
- uk0.bigv.io came from PR #745 while the two bytemark.co.uk suffixes came from PR #620; added in 2018–2019 for customer virtual machines and control panels.
- `dh.bytemark.co.uk` and `vm.bytemark.co.uk` return NXDOMAIN. Subdomains exist but none of them is accessible.
- `uk0.bigv.io` still resolves, but VT identifies no subdomains under it.
- The Bytemark website now redirects to Hosting UK's migration page, which describes moving Bytemark services and customer virtual machines away from the legacy BigV platform. https://hostinguk.net/bytemark
- Related: #1753  
- https://github.com/publicsuffix/list/pull/745#issuecomment-5009322840