### PR TITLE
Add South Africa (za)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6789,6 +6789,7 @@ net.ye
 org.ye
 
 // za : https://www.iana.org/domains/root/db/za.html
+za
 ac.za
 agric.za
 alt.za


### PR DESCRIPTION
Interestingly, `za` was not included in the PSL.