### PR TITLE
Add ownsitehq.com (PRIVATE)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14353,6 +14353,10 @@ myjino.ru
 *.spectrum.myjino.ru
 *.vps.myjino.ru
 
+// JKA Logic LLC : https://jkalogic.com/
+// Submitted by Justin Adams <justin@jkalogic.com>
+ownsitehq.com
+
 // Jotelulu S.L. : https://jotelulu.com
 // Submitted by Daniel Fariña <ingenieria@jotelulu.com>
 jote.cloud


### PR DESCRIPTION
### Why
ownsitehq.com is a website building and hosting platform operated by JKA Logic LLC. Each customer's site is served on its own subdomain (`customername.ownsitehq.com`). We request PRIVATE-section inclusion so browsers treat each customer subdomain as its own registrable site, isolating cookies and reputation between independent customers, as github.io, netlify.app, vercel.app, and Cloudflare's pages.dev do.

### Suffix
ownsitehq.com

### _psl DNS record
`_psl.ownsitehq.com TXT "<this PR URL>"` will be added immediately after this PR is opened.

### Validation
- Before inclusion: `a-shop.ownsitehq.com` and `b-shop.ownsitehq.com` are treated as the same registrable site (shared cookie scope / reputation).
- After inclusion: each is its own registrable domain. A cookie set on `a-shop.ownsitehq.com` is not visible to `b-shop.ownsitehq.com`, and a Safe Browsing flag on one does not apply to the other's registrable domain.

### Registration
ownsitehq.com is registered through 2029-07-17 with auto-renew enabled.
