### PR TITLE
Add zozostacks.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16433,4 +16433,8 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// Zozo : https://zozostacks.dev
+// Submitted by Ryan Graham <rg@ryangraham.ca>
+zozostacks.dev
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale — there are none; no third-party limit workaround is sought.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
   — The listed address (`rg@ryangraham.ca`) is the personal address of the operator. Zozo is a single-operator service and this is the organization contact; it is actively monitored and will respond well within 30 days. If a role-based address at the domain is preferred, I will set one up (e.g. `psl@zozostacks.dev`) and update the entry.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://zozostacks.dev (contact/abuse email in the page footer)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
   — `zozostacks.dev` is a dedicated tenant-origins domain acquired specifically for PSL listing. The apex intentionally serves only a static, cookie-free informational page; the organization's own web properties live elsewhere and are unaffected.

---

## Description of Organization

Zozo is a harness that orchestrates vendor coding-agent runtimes (Claude Code, Codex) so subscription-backed coding agents can be driven programmatically — it watches a customer's GitHub backlog and drains ready issues into pull requests while the customer is away. The hosted product provisions each customer (tenant) an isolated stack — their own dashboard web application, workers, and data — served from a dedicated subdomain of `zozostacks.dev`. I am Ryan Graham, the individual developer and operator of Zozo, and the party responsible for the `zozostacks.dev` registration, its DNS, and this submission.

**Organization Website:** https://zozostacks.dev

## Reason for PSL Inclusion

Cookie and browser-storage isolation between customer tenants. Each tenant's stack at `<slug>.zozostacks.dev` is a full authenticated web application operated on behalf of a distinct customer, holding that customer's session cookies and credentials for their own source-code repositories. Without PSL listing, all tenant origins share `zozostacks.dev` as their registrable domain, so cookies scoped to the parent domain, and related same-site assumptions, would span customers. Listing `zozostacks.dev` in the PRIVATE section makes each tenant subdomain its own effective TLD+1 so browsers isolate cookies, storage, and service workers per tenant.

The domain is dedicated to this purpose: it was registered specifically as the tenant-origins domain, separate from the organization's own web origin, and its apex serves only a static informational page (no cookies, no JavaScript). Tenant slugs are immutable and never recycled across customers, so a listed suffix never changes meaning. `zozostacks.dev` is registered through July 2029 (3-year term) and will be maintained with more than 1 year of remaining term for as long as it is listed. No third-party rate-limit workaround (Let's Encrypt, Cloudflare, iOS/Facebook, etc.) is sought — certificates and DNS are handled through the operator's own Cloudflare account.

**Number of THOUSANDS of distinct users this request is being made to serve:** <1 today — the hosted service is invite-gated and pre-launch. This submission is made ahead of general availability deliberately: per-tenant origin isolation is a security prerequisite for onboarding customers at all, and PSL processing lead time means it must precede launch rather than follow it.

## DNS verification

The `_psl` TXT record pointing at this PR is in place:

```
$ dig +short TXT _psl.zozostacks.dev
"https://github.com/publicsuffix/list/pull/3057"
```
