### PR TITLE
Add doapps.cloud (PRIVATE) — [do] multi-tenant app hosting

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13011,6 +13011,12 @@ dyn.now
 heimdns.online
 ddns.wtf
 
+// do : https://do-awesome.com
+// Submitted by do-awesome (Do Compute LLC) <support@do-awesome.com>
+doapps.cloud
+preview.doapps.cloud
+staging.doapps.cloud
+
 // DotArai : https://www.dotarai.com/
 // Submitted by Atsadawat Netcharadsang <atsadawat@dotarai.co.th>
 online.th


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are NOT using a PSL entry to work around any third-party limit (Cloudflare / Let's Encrypt / Apple / GitLab rate-limits or similar). This submission exists solely to establish per-subdomain site boundaries for multi-tenant isolation and reputation firewalling. No third-party limit workaround is sought.

---

## Description of Organization

[do] (https://do-awesome.com), operated by Do Compute LLC, is a hosted application platform: users describe an app in plain English, the platform builds and deploys it, and each app goes live at its own subdomain under `doapps.cloud`. It is a multi-tenant SaaS — many independent customers, each owning one or more app subdomains, all under the single registrable domain `doapps.cloud` that we own and operate. The authoritative DNS for `doapps.cloud` is served from our AWS Route 53 zone.

## Reason for PSL Inclusion

Customer apps are deployed to per-tenant subdomains:

- `{username}-{appname}.doapps.cloud` (paid apex pool)
- `{username}-{appname}.preview.doapps.cloud` (free-tier pool)
- `{username}-{appname}.staging.doapps.cloud` (staging pool)

Because these subdomains belong to mutually-untrusting customers, they must be treated by browsers and security infrastructure as **separate sites**, exactly as `*.herokuapp.com`, `*.github.io`, and `*.vercel.app` are. Without a PSL entry:

1. **Cookie / storage isolation:** a `Domain=.doapps.cloud` (or registrable-domain level) cookie is shared across every tenant; localStorage/CORS "same site" checks collapse tenants together. This is a cross-tenant data-leak surface.
2. **Reputation firewalling:** Safe Browsing, spam blocklists, and abuse heuristics that act at the registrable-domain level would let one abusive tenant subdomain poison the reputation of `doapps.cloud` and therefore every other tenant. A PSL entry scopes reputation to the individual subdomain.

We are requesting three suffixes so that all three per-tenant pools (apex, preview, staging) each get true per-subdomain isolation; listing only the apex would leave the preview and staging pools sharing a single site boundary.

## Domains

```
// do : https://do-awesome.com
// Submitted by do-awesome (Do Compute LLC) <support@do-awesome.com>
doapps.cloud
preview.doapps.cloud
staging.doapps.cloud
```

## DNS verification (RFC 8553 `_psl`)

`_psl` TXT records have been added to the zone, each pointing to this PR URL. After propagation:

```
$ dig +short TXT _psl.doapps.cloud
"https://github.com/publicsuffix/list/pull/3059"

$ dig +short TXT _psl.preview.doapps.cloud
"https://github.com/publicsuffix/list/pull/3059"

$ dig +short TXT _psl.staging.doapps.cloud
"https://github.com/publicsuffix/list/pull/3059"
```

These `_psl` records will remain in place post-merge to signal continued inclusion.
