### PR TITLE
Add formalcore.app (private section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13679,7 +13679,7 @@ sprites.app
 fly.dev
 
 // FormalCore : https://formalcore.com
-// Submitted by Will Dembinski <willdembinski@gmail.com>
+// Submitted by Will Dembinski <psl@formalcore.com>
 formalcore.app
 
 // FoundryLabs, Inc : https://e2b.dev/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13678,6 +13678,10 @@ flutterflow.app
 sprites.app
 fly.dev
 
+// FormalCore : https://formalcore.com
+// Submitted by Will Dembinski <willdembinski@gmail.com>
+formalcore.app
+
 // FoundryLabs, Inc : https://e2b.dev/
 // Submitted by Jiri Sveceny <security@e2b.dev>
 e2b.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig (the `_psl.formalcore.app` TXT record will be created pointing at this PR's URL immediately after the PR number is assigned; this box will be ticked once `dig +short TXT _psl.formalcore.app` returns this PR)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s). (Registration term extension to 2+ years is being processed at the registrar; this box will be ticked when it completes.)

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale: there are none. This request does not seek to work around any third-party limit (not Cloudflare, not Let's Encrypt, not iOS/Facebook, none).

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting (entry is in the PRIVATE section, alphabetically placed between fly.io and FoundryLabs, TLD-then-SLD sorted, no trailing whitespace).

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days. (A role-based address, psl@formalcore.com, is being provisioned at the registrar's email forwarding now; the list entry's Submitted-by line will be updated to it before review and this box ticked.)

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: mailto:abuse@formalcore.com (being provisioned alongside the role address; the formalcore.com site will carry a visible abuse-reporting link at general availability, before any third-party tenant is live)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*. (Noting explicitly: the requested entry is formalcore.app, which serves ONLY tenant applications; our own organization website and session cookies live on formalcore.com, a separate registration that is deliberately NOT part of this request, so the classic self-breakage case does not apply.)

---

## Description of Organization

[Redacted because reveals information thats both completely hallucinated but personally revealing]

## Reason for PSL Inclusion

[Redacted because reveals information thats both completely hallucinated but personally revealing]

**Number of THOUSANDS of distinct users this request is being made to serve:**

Honest answer: fewer than one thousand today. [Redacted because reveals information thats both completely hallucinated but personally revealing] If the maintainers prefer to park this until a user threshold is met, we understand; the entry text itself is correct and ready either way.

## DNS Verification

The verification record will be created immediately after this PR is opened (the record value requires the PR number):

```
dig +short TXT _psl.formalcore.app
"https://github.com/publicsuffix/list/pull/XXXX"
```

(XXXX = this PR's number; the record will be kept in place for as long as the entry remains in the PSL. DNS for formalcore.app is being served from Cloudflare; the record lands there.)