### PR TITLE
Remove `storj.farm`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15905,10 +15905,6 @@ ipfs.w3s.link
 // Submitted by Tony Schirmer <tony@storebase.io>
 storebase.store
 
-// Storj Labs Inc. : https://storj.io/
-// Submitted by Philip Hutchins <hostmaster@storj.io>
-storj.farm
-
 // Strapi : https://strapi.io/
 // Submitted by Florent Baldino <security@strapi.io>
 strapiapp.com


### PR DESCRIPTION
`storj.farm` was added in **2017** by #400 based on the original submission from Storj Labs. 

Storj's main organization remains active, but `storj.farm` is not used.

Public reputation [data](https://www.virustotal.com/gui/domain/storj.farm/relations) currently identifies only 1 subdomain under this suffix.

RDAP shows that the domain was registered on **2020-05-05**, so this is a re-registration likely by a third party.

Confirmation from the original requestor https://github.com/publicsuffix/list/pull/400#issuecomment-5017680878 on 2026-07-19.

RDAP:

```
"eventAction": "registration",
"eventDate": "2020-05-05T20:06:08.867Z"
```