### PR TITLE
Remove `senseering.net`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15692,10 +15692,6 @@ sellfy.store
 // Submitted by Assaf Stern <domains@comstar.co.il>
 minisite.ms
 
-// Senseering GmbH : https://www.senseering.de
-// Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
-senseering.net
-
 // Servebolt AS : https://servebolt.com
 // Submitted by Daniel Kjeserud <cloudops@servebolt.com>
 servebolt.cloud


### PR DESCRIPTION
- Added by #946
- The suffix does not resolve through any reachable public DNS resolver, and `https://senseering.net/` could not be reached at the time of this check.
- The organization URL recorded in the original submission, `https://www.senseering.de/`, currently returns HTTP 404.
- Public reputation data currently [identifies](https://www.virustotal.com/gui/domain/senseering.net/relations) only 3 subdomains. One public categorization labels the domain “Suspicious”

WHOIS:

```
   Domain Name: SENSEERING.NET
   Registry Domain ID: 2345034087_DOMAIN_NET-VRSN
   Registrar WHOIS Server: whois.registrar.amazon
   Registrar URL: http://registrar.amazon.com
   Updated Date: 2025-11-15T13:09:32Z
   Creation Date: 2018-12-20T13:06:45Z
   Registry Expiry Date: 2026-12-20T13:06:45Z
```
