### PR TITLE
Remove `onfabrica.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13508,10 +13508,6 @@ on.expo.app
 staging.expo.app
 on.staging.expo.app
 
-// Fabrica Technologies, Inc. : https://www.fabrica.dev/
-// Submitted by Eric Jiang <eric@fabrica.dev>
-onfabrica.com
-
 // fachschaften.org: https://fachschaften.org/
 // Submitted by Felix Schäfer <security@fachschaften.org>
 fspages.org


### PR DESCRIPTION
- The suffix currently resolves only to the loopback address `127.0.0.1` through all reachable public DNS resolvers, and `https://onfabrica.com/` could not be reached for at least 2 years (https://github.com/publicsuffix/list/pull/999#issuecomment-2332985792)
- The original organization site, `https://www.fabrica.dev/`, could not be reached.
- `fabrica.dev` was expired and got re-registered in 2025.
- The domain used by the contact address on file, `eric@fabrica.dev`, has no mail routing or fallback address, so the contact could not be confirmed to accept mail.
- Attempted to reach out in 2024 by GitHub message and email, but no response received (https://github.com/publicsuffix/list/pull/999#issuecomment-2332985792)
