### PR TITLE
Remove Deta entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12924,11 +12924,6 @@ deployagent.space
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io
 
-// Deta : https://www.deta.sh/
-// Submitted by Aavash Shrestha <aavash@deta.sh>
-deta.app
-deta.dev
-
 // Deuxfleurs : https://deuxfleurs.fr
 // Submitted by Aeddis Desauw <ca@deuxfleurs.fr>
 deuxfleurs.eu


### PR DESCRIPTION
- Both domains are for sale. 
- One of them was sold for 16 bucks.

<img width="1186" height="938" alt="image" src="https://github.com/user-attachments/assets/3af7d41f-bd8a-49fa-b3da-3b55ef76b065" />

https://www.namecheap.com/market/buynow/deta.app/?collection_ref=buynow

<img width="1192" height="595" alt="image" src="https://github.com/user-attachments/assets/c7cba516-903c-4def-8764-e1b1d8570aca" />

https://www.namecheap.com/market/sale/tFP6jBezFao9cWPpfneq5x/deta.dev/?collection_ref=recent

- Neither suffix's website could be loaded over HTTPS at the time of this check, although both names still resolve in public DNS.
- The original organization website at `www.deta.sh` could not be loaded over HTTPS.
- Public reputation data reports **3 malicious** detections for each suffix. 

#1511
