### PR TITLE
Remove `of.je`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12507,10 +12507,6 @@ bitbucket.io
 // Submitted by Paul Crowder <paul.crowder@blackbaud.com>
 blackbaudcdn.net
 
-// Blatech : http://www.blatech.net
-// Submitted by Luke Bratch <luke@bratch.co.uk>
-of.je
-
 // Block, Inc. : https://block.xyz
 // Submitted by Jonathan Boice <security@block.xyz>
 square.site


### PR DESCRIPTION
- The suffix did not resolve through any reachable public DNS resolver
- `https://of.je/` was therefore unavailable.
- The two organization sites named in the original submission are defunct: `https://www.blatech.co.uk/` presented an expired certificate, while `https://www.blatech.net/` presented an untrusted certificate chain.
- Identified [3 subdomains](https://subdomainfinder.c99.nl/scans/2026-07-20/of.je) under `of.je` with no malicious or suspicious detections.
- Google search shows [0 result](https://www.google.com/search?q=site%3Aof.je).