### PR TITLE
Remove deployagent entries

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12914,12 +12914,6 @@ deno-staging.dev
 deno.net
 sandbox.deno.net
 
-// DeployAgent : https://deployagent.com
-// Submitted by Danny <security@deployagent.com>
-deployagent.com
-piebox.site
-deployagent.space
-
 // deSEC : https://desec.io/
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io


### PR DESCRIPTION
https://github.com/publicsuffix/list/pull/2857#issuecomment-4312369894

This was merged with the following issues:

Domain was registered 2026/4/2, User counts wasn't specified to per entry, and no proof was provided:

https://www.google.com/search?q=site:deployagent.space (no results)
https://www.virustotal.com/gui/domain/deployagent.space/relations (1 subdomain)
https://subdomainfinder.c99.nl/scans/2026-04-24/deployagent.space (1 subdomain)

https://www.google.com/search?q=site:piebox.site (no results)
https://www.virustotal.com/gui/domain/piebox.site/relations (1 subdomain)
https://subdomainfinder.c99.nl/scans/2026-04-24/deployagent.space (1 subdomain)

Previous PR had similar issue, when checked:

https://www.google.com/search?q=site:deployagent.com (1 result on subdomain)
https://www.virustotal.com/gui/domain/deployagent.com/relations (6 subdomains, malicious on virustotal by 3 security vendors)
https://subdomainfinder.c99.nl/scans/2026-04-24/deployagent.com (3 subdomains)

---

https://github.com/publicsuffix/list/pull/2830#issuecomment-5018849173 (By @groundcat)

- `https://deployagent.com/`, which is both the suffix site and the organization website listed in the submission, currently returns HTTP 404.
- Public reputation data currently identifies 8 subdomains under `deployagent.com`, materially fewer than the approximately 1,800 deployed applications claimed when the entry was submitted.
- Three security vendors currently flag the suffix as malicious. The original submission described prior phishing deployments, so please also confirm whether those incidents have been remediated and whether abuse handling remains active.
- The other entries have no current malicious or suspicious detections, but public reputation data identifies only 6 subdomains under `piebox.site` and 3 under `deployagent.space`.

Checked all three domains:

  - deployagent.com: 3 malicious, 0 suspicious; 8 identified subdomains.
  - piebox.site: 0 malicious, 0 suspicious; 6 identified subdomains.
  - deployagent.space: 0 malicious, 0 suspicious; 3 identified subdomains.
 
 
Related: #2857 #2830



