### PR TITLE
chore: Replace broken links, replace IANA db placeholders with specific registry URLs

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6507,7 +6507,7 @@ yt
 // U-Label
 
 // xn--mgbaam7a8h ("Emerat", Arabic) : AE
-// http://nic.ae/english/arabicdomain/rules.jsp
+// http://aeda.ae/
 امارات
 
 // xn--y9a3aq ("hye", Armenian) : AM

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3941,8 +3941,8 @@ ind.kw
 net.kw
 org.kw
 
-// ky : http://www.icta.ky/da_ky_reg_dom.php
-// Confirmed by registry <kysupport@perimeterusa.com> 2008-06-17
+// ky : https://www.iana.org/domains/root/db/ky.html
+// https://www.ofreg.ky/ict/kydomain-introduction
 ky
 com.ky
 edu.ky

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3876,7 +3876,6 @@ presse.km
 veterinaire.km
 
 // kn : https://www.iana.org/domains/root/db/kn.html
-// http://www.dot.kn/domainRules.html
 kn
 edu.kn
 gov.kn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5106,7 +5106,8 @@ voagat.no
 volda.no
 voss.no
 
-// np : http://www.mos.com.np/register.html
+// np : https://www.iana.org/domains/root/db/np.html
+// see also : https://www.mos.com.np/
 *.np
 
 // nr : http://cenpac.net.nr/dns/index.html

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4112,7 +4112,7 @@ mh
 mil
 
 // mk : https://www.iana.org/domains/root/db/mk.html
-// see also: http://dns.marnet.net.mk/postapka.php
+// see also: https://marnet.mk/ -> "ПРАВИЛНИК"
 mk
 com.mk
 edu.mk

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -357,7 +357,7 @@ bf
 gov.bf
 
 // bg : https://www.iana.org/domains/root/db/bg.html
-// https://www.register.bg/user/static/rules/en/index.html
+// https://www.register.bg/ -> "Terms and Conditions"
 bg
 0.bg
 1.bg

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1985,7 +1985,7 @@ co.je
 net.je
 org.je
 
-// jm : http://www.com.jm/register.html
+// jm : https://www.iana.org/domains/root/db/jm.html
 *.jm
 
 // jo : https://www.dns.jo/JoFamily.aspx

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4314,7 +4314,7 @@ net.ng
 org.ng
 sch.ng
 
-// ni : http://www.nic.ni/
+// ni : https://www.nic.ni/
 ni
 ac.ni
 biz.ni

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -681,7 +681,7 @@ wiki.br
 xyz.br
 zlg.br
 
-// bs : http://www.nic.bs/rules.html
+// bs : http://www.register.bs/rules.html
 bs
 com.bs
 edu.bs

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1207,7 +1207,7 @@ mil.gh
 net.gh
 org.gh
 
-// gi : http://www.nic.gi/rules.html
+// gi : https://www.nic.gi/rules.html
 gi
 com.gi
 edu.gi

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4148,7 +4148,7 @@ edu.mn
 gov.mn
 org.mn
 
-// mo : http://www.monic.net.mo/
+// mo : https://www.monic.mo/
 mo
 com.mo
 edu.mo

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -750,7 +750,7 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: https://www.cira.ca/en/resources/documents/cybersecurity/overview-domain-name-system-dns/ -> "How are nodes delegated?" 
+// gc.ca: https://www.cira.ca/en/resources/documents/cybersecurity/overview-domain-name-system-dns/ -> "How are nodes delegated?"
 // see also: https://design.canada.ca/specifications/mandatory-elements/domains-urls.html
 gc.ca
 
@@ -5462,9 +5462,11 @@ post
 // pr : https://www.iana.org/domains/root/db/pr.html
 // see also : https://www.domains.pr/
 pr
+ac.pr
 biz.pr
 com.pr
 edu.pr
+est.pr
 gov.pr
 info.pr
 isla.pr
@@ -5472,8 +5474,6 @@ name.pr
 net.pr
 org.pr
 pro.pr
-ac.pr
-est.pr
 prof.pr
 
 // pro : http://registry.pro/get-pro

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1536,7 +1536,7 @@ net.io
 nom.io
 org.io
 
-// iq : http://www.cmc.iq/english/iq/iqregister1.htm
+// iq : https://cmc.iq/
 iq
 com.iq
 edu.iq

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4300,7 +4300,8 @@ rec.nf
 store.nf
 web.nf
 
-// ng : http://www.nira.org.ng/index.php/join-us/register-ng-domain/189-nira-slds
+// ng : https://www.iana.org/domains/root/db/ng.html
+// see also : https://www.nira.org.ng/
 ng
 com.ng
 edu.ng

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5880,9 +5880,8 @@ mil.to
 net.to
 org.to
 
-// tr : https://nic.tr/
-// see also: https://nic.tr/forms/eng/policies.pdf
-// see also: https://nic.tr/index.php?USRACTN=PRICELST
+// tr : https://www.trabis.gov.tr/
+// see also: https://www.btk.gov.tr/en/internet-domain-names-legislation
 tr
 av.tr
 bbs.tr

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4036,7 +4036,6 @@ sc.ls
 // lt : https://www.iana.org/domains/root/db/lt.html
 // see also : https://www.domreg.lt/
 lt
-// gov.lt : http://www.gov.lt/index_en.php
 gov.lt
 
 // lu : http://www.dns.lu/en/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5472,7 +5472,6 @@ name.pr
 net.pr
 org.pr
 pro.pr
-// these aren't mentioned on nic.pr, but on https://www.iana.org/domains/root/db/pr.html
 ac.pr
 est.pr
 prof.pr

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3882,7 +3882,7 @@ gov.kn
 net.kn
 org.kn
 
-// kp : http://www.kcce.kp/en_index.php
+// kp : http://www.star.co.kp/
 kp
 com.kp
 edu.kp

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5602,7 +5602,7 @@ gov.sb
 net.sb
 org.sb
 
-// sc : http://www.nic.sc/
+// sc : https://www.nic.sc/en/policies.html
 sc
 com.sc
 edu.sc

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5717,7 +5717,8 @@ gouv.sn
 org.sn
 univ.sn
 
-// so : http://sonic.so/policies/
+// so : https://www.iana.org/domains/root/db/so.html
+// see also : http://www.nic.so/
 so
 com.so
 edu.so

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6811,8 +6811,8 @@ school.za
 tm.za
 web.za
 
-// zm : https://zicta.zm/
-// Submitted by registry <info@zicta.zm>
+// zm : https://www.iana.org/domains/root/db/zm.html
+// see also : https://zicta.zm/
 zm
 ac.zm
 biz.zm

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3875,7 +3875,7 @@ pharmaciens.km
 presse.km
 veterinaire.km
 
-// kn : https://www.iana.org/domains/root/db/kn.html
+// kn : https://nic.kn/
 kn
 edu.kn
 gov.kn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1339,9 +1339,11 @@ mil.hn
 net.hn
 org.hn
 
-// hr : http://www.dns.hr/documents/pdf/HRTLD-regulations.pdf
+// hr : https://www.iana.org/domains/root/db/hr.html
+// https://domene.hr/en/portal/faq
 hr
 com.hr
+// From.hr domene : http://from.hr/
 from.hr
 iz.hr
 name.hr

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -750,8 +750,8 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
-// see also: http://registry.gc.ca/en/SubdomainFAQ
+// gc.ca: https://www.cira.ca/en/resources/documents/cybersecurity/overview-domain-name-system-dns/ -> "How are nodes delegated?" 
+// see also: https://design.canada.ca/specifications/mandatory-elements/domains-urls.html
 gc.ca
 
 // cat : https://www.iana.org/domains/root/db/cat.html

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1225,7 +1225,7 @@ edu.gl
 net.gl
 org.gl
 
-// gm : http://www.nic.gm/htmlpages%5Cgm-policy.htm
+// gm : https://www.nic.gm/NIC2/policies.html
 gm
 
 // gn : http://psg.com/dns/gn/gn.txt

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5594,8 +5594,7 @@ org.sa
 pub.sa
 sch.sa
 
-// sb : http://www.sbnic.net.sb/
-// Submitted by registry <lee.humphries@telekom.com.sb>
+// sb : http://www.nic.net.sb/
 sb
 com.sb
 edu.sb

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5163,7 +5163,7 @@ onion
 org
 
 // pa : https://www.iana.org/domains/root/db/pa.html
-// see also : http://www.nic.pa/
+// see also : http://www.nic.pa/en/terms-service
 // Some additional second level "domains" resolve directly as hostnames, such as
 // pannet.pa, so we add a rule for "pa".
 pa

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6779,7 +6779,7 @@ yt
 // xn--mgb2ddes ("AlYemen", Arabic) : YE
 اليمن
 
-// xxx : http://icmregistry.com
+// xxx : https://icmregistry.biz/
 xxx
 
 // ye : http://www.y.net.ye/services/domain_name.htm

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5459,7 +5459,8 @@ org.pn
 // post : https://www.iana.org/domains/root/db/post.html
 post
 
-// pr : http://www.nic.pr/index.asp?f=1
+// pr : https://www.iana.org/domains/root/db/pr.html
+// see also : https://www.domains.pr/
 pr
 biz.pr
 com.pr

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6392,8 +6392,7 @@ k12.vi
 net.vi
 org.vi
 
-// vn : https://www.vnnic.vn/en/domain/cctld-vn
-// https://vnnic.vn/sites/default/files/tailieu/vn.cctld.domains.txt
+// vn : https://vnnic.vn/en/domain-name-vn/domain-name/cctldvn
 vn
 ac.vn
 ai.vn

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5162,7 +5162,8 @@ onion
 // org : https://www.iana.org/domains/root/db/org.html
 org
 
-// pa : http://www.nic.pa/
+// pa : https://www.iana.org/domains/root/db/pa.html
+// see also : http://www.nic.pa/
 // Some additional second level "domains" resolve directly as hostnames, such as
 // pannet.pa, so we add a rule for "pa".
 pa

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6716,7 +6716,7 @@ yt
 рф
 
 // xn--wgbl6a ("Qatar", Arabic) : QA
-// http://www.ict.gov.qa/
+// https://www.cra.gov.qa/
 قطر
 
 // xn--mgberp4a5d4ar ("AlSaudiah", Arabic) : SA

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5210,7 +5210,7 @@ net.ph
 ngo.ph
 org.ph
 
-// pk : https://pk5.pknic.net.pk/pk5/msgNamepk.PK
+// pk : https://www.pknic.net.pk/domain-structure.html
 // Contact Email: staff@pknic.net.pk
 pk
 ac.pk

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5491,7 +5491,7 @@ med.pro
 recht.pro
 
 // ps : https://www.iana.org/domains/root/db/ps.html
-// see also: http://www.nic.ps/registration/policy.html#reg
+// see also: https://www.pnina.ps/registration-policy/
 ps
 com.ps
 edu.ps

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1195,7 +1195,7 @@ net.gg
 org.gg
 
 // gh : https://www.iana.org/domains/root/db/gh.html
-// https://www.nic.gh/
+// http://www.nic.gh/policy.html
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
 gh

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5718,7 +5718,6 @@ org.sn
 univ.sn
 
 // so : https://www.iana.org/domains/root/db/so.html
-// see also : http://www.nic.so/
 // see also : https://sonic.so/policies/
 so
 com.so

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -148,7 +148,7 @@ net.ag
 nom.ag
 org.ag
 
-// ai : http://nic.com.ai/
+// ai : https://www.nic.ai/
 ai
 com.ai
 net.ai

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6782,7 +6782,7 @@ yt
 // xxx : https://icmregistry.biz/
 xxx
 
-// ye : http://www.y.net.ye/services/domain_name.htm
+// ye : https://www.iana.org/domains/root/db/ye.html
 ye
 com.ye
 edu.ye

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -174,7 +174,7 @@ net.am
 org.am
 
 // ao : https://www.iana.org/domains/root/db/ao.html
-// https://www.dns.ao/ao/
+// see also: https://www.dns.ao/ao/
 ao
 co.ao
 ed.ao
@@ -235,7 +235,7 @@ gv.at
 or.at
 
 // au : https://www.iana.org/domains/root/db/au.html
-// https://www.auda.org.au/
+// see also: https://www.auda.org.au/
 // Confirmed by registry <general@auda.org.au> 2025-07-16
 au
 // 2LDs
@@ -357,7 +357,7 @@ bf
 gov.bf
 
 // bg : https://www.iana.org/domains/root/db/bg.html
-// https://www.register.bg/ -> "Terms and Conditions"
+// see also: https://www.register.bg/ -> "Terms and Conditions"
 bg
 0.bg
 1.bg
@@ -405,7 +405,7 @@ net.bh
 org.bh
 
 // bi : https://www.iana.org/domains/root/db/bi.html
-// http://whois.nic.bi/
+// see also: http://whois.nic.bi/
 bi
 co.bi
 com.bi
@@ -702,7 +702,7 @@ org.bt
 bv
 
 // bw : https://www.iana.org/domains/root/db/bw.html
-// https://nic.net.bw/bw-name-structure
+// see also: https://nic.net.bw/bw-name-structure
 bw
 ac.bw
 co.bw
@@ -711,7 +711,7 @@ net.bw
 org.bw
 
 // by : https://www.iana.org/domains/root/db/by.html
-// http://tld.by/rules_2006_en.html
+// see also: http://tld.by/rules_2006_en.html
 // list of other 2nd level tlds ?
 by
 gov.by
@@ -724,7 +724,7 @@ com.by
 of.by
 
 // bz : https://www.iana.org/domains/root/db/bz.html
-// http://www.belizenic.bz/
+// see also: http://www.belizenic.bz/
 bz
 co.bz
 com.bz
@@ -761,7 +761,7 @@ cat
 cc
 
 // cd : https://www.iana.org/domains/root/db/cd.html
-// https://www.nic.cd
+// see also: https://www.nic.cd
 cd
 gov.cd
 
@@ -897,7 +897,7 @@ net.cu
 org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
-// https://ola.cv/
+// see also: https://ola.cv/
 // Confirmed by registry <support@ola.cv> 2024-11-26
 cv
 com.cv
@@ -924,7 +924,7 @@ gov.cx
 
 // cy : http://www.nic.cy/
 // Submitted by Panayiotou Fotia <cydns@ucy.ac.cy>
-// https://nic.cy/wp-content/uploads/2024/01/Create-Request-for-domain-name-registration-1.pdf
+// see also: https://nic.cy/wp-content/uploads/2024/01/Create-Request-for-domain-name-registration-1.pdf
 cy
 ac.cy
 biz.cy
@@ -957,7 +957,7 @@ dj
 dk
 
 // dm : https://www.iana.org/domains/root/db/dm.html
-// https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf
+// see also: https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf
 // Confirmed by registry <admin@dotdm.dm> 2024-11-19
 dm
 co.dm
@@ -1065,7 +1065,7 @@ pri.ee
 riik.ee
 
 // eg : https://www.iana.org/domains/root/db/eg.html
-// https://domain.eg/subdomain-names
+// see also: https://domain.eg/subdomain-names
 eg
 ac.eg
 com.eg
@@ -1195,7 +1195,7 @@ net.gg
 org.gg
 
 // gh : https://www.iana.org/domains/root/db/gh.html
-// http://www.nic.gh/policy.html
+// see also: http://www.nic.gh/policy.html
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
 gh
@@ -1217,7 +1217,7 @@ mod.gi
 org.gi
 
 // gl : https://www.iana.org/domains/root/db/gl.html
-// http://nic.gl
+// see also: http://nic.gl
 gl
 co.gl
 com.gl
@@ -1293,7 +1293,7 @@ web.gu
 gw
 
 // gy : https://www.iana.org/domains/root/db/gy.html
-// http://registry.gy/
+// see also: http://registry.gy/
 gy
 co.gy
 com.gy
@@ -1340,7 +1340,7 @@ net.hn
 org.hn
 
 // hr : https://www.iana.org/domains/root/db/hr.html
-// https://domene.hr/en/portal/faq
+// see also: https://domene.hr/en/portal/faq
 hr
 com.hr
 // From.hr domene : http://from.hr/
@@ -1566,7 +1566,7 @@ sch.ir
 is
 
 // it : https://www.iana.org/domains/root/db/it.html
-// https://www.nic.it/
+// see also: https://www.nic.it/
 it
 edu.it
 gov.it
@@ -3853,7 +3853,7 @@ net.ki
 org.ki
 
 // km : https://www.iana.org/domains/root/db/km.html
-// https://www.domaine.km/
+// see also: https://www.domaine.km/
 km
 ass.km
 com.km
@@ -3883,7 +3883,7 @@ net.kn
 org.kn
 
 // kp : https://www.iana.org/domains/root/db/kp.html
-// http://www.star.co.kp/
+// see also: http://www.star.co.kp/
 kp
 com.kp
 edu.kp
@@ -3942,7 +3942,7 @@ net.kw
 org.kw
 
 // ky : https://www.iana.org/domains/root/db/ky.html
-// https://www.ofreg.ky/ict/kydomain-introduction
+// see also: https://www.ofreg.ky/ict/kydomain-introduction
 ky
 com.ky
 edu.ky
@@ -4066,7 +4066,7 @@ plc.ly
 sch.ly
 
 // ma : https://www.iana.org/domains/root/db/ma.html
-// http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
+// see also: http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
 ma
 ac.ma
 co.ma
@@ -4331,7 +4331,7 @@ org.ni
 web.ni
 
 // nl : https://www.iana.org/domains/root/db/nl.html
-// https://www.sidn.nl/
+// see also: https://www.sidn.nl/
 nl
 
 // no : https://www.norid.no/en/om-domenenavn/regelverk-for-no/
@@ -5488,7 +5488,7 @@ med.pro
 recht.pro
 
 // ps : https://www.iana.org/domains/root/db/ps.html
-// http://www.nic.ps/registration/policy.html#reg
+// see also: http://www.nic.ps/registration/policy.html#reg
 ps
 com.ps
 edu.ps
@@ -5621,7 +5621,7 @@ org.sd
 tv.sd
 
 // se : https://www.iana.org/domains/root/db/se.html
-// https://data.internetstiftelsen.se/barred_domains_list.txt -> Second level domains & Sub-domains
+// see also: https://data.internetstiftelsen.se/barred_domains_list.txt -> Second level domains & Sub-domains
 // Confirmed by Registry Services <registry@internetstiftelsen.se> 2024-11-20
 se
 a.se
@@ -5689,7 +5689,7 @@ si
 sj
 
 // sk : https://www.iana.org/domains/root/db/sk.html
-// https://sk-nic.sk/
+// see also: https://sk-nic.sk/
 sk
 org.sk
 
@@ -5779,7 +5779,7 @@ net.sy
 org.sy
 
 // sz : https://www.iana.org/domains/root/db/sz.html
-// http://www.sispa.org.sz/
+// see also: http://www.sispa.org.sz/
 sz
 ac.sz
 co.sz
@@ -5792,14 +5792,14 @@ tc
 td
 
 // tel : https://www.iana.org/domains/root/db/tel.html
-// http://www.telnic.org/
+// see also: http://www.telnic.org/
 tel
 
 // tf : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf
 tf
 
 // tg : https://www.iana.org/domains/root/db/tg.html
-// http://www.nic.tg/
+// see also: http://www.nic.tg/
 tg
 
 // th : https://www.iana.org/domains/root/db/th.html
@@ -5850,7 +5850,7 @@ nom.tm
 org.tm
 
 // tn : http://www.registre.tn/fr/
-// https://whois.ati.tn/
+// see also: https://whois.ati.tn/
 tn
 com.tn
 ens.tn
@@ -5877,8 +5877,8 @@ net.to
 org.to
 
 // tr : https://nic.tr/
-// https://nic.tr/forms/eng/policies.pdf
-// https://nic.tr/index.php?USRACTN=PRICELST
+// see also: https://nic.tr/forms/eng/policies.pdf
+// see also: https://nic.tr/index.php?USRACTN=PRICELST
 tr
 av.tr
 bbs.tr
@@ -5927,7 +5927,7 @@ pro.tt
 tv
 
 // tw : https://www.iana.org/domains/root/db/tw.html
-// https://twnic.tw/dnservice_catag.php
+// see also: https://twnic.tw/dnservice_catag.php
 // Confirmed by registry <dns@twnic.tw> 2024-11-26
 tw
 club.tw
@@ -5968,7 +5968,7 @@ in.ua
 net.ua
 org.ua
 // ua geographic names
-// https://hostmaster.ua/2ld/
+// see also: https://hostmaster.ua/2ld/
 cherkassy.ua
 cherkasy.ua
 chernigov.ua
@@ -6044,7 +6044,7 @@ zp.ua
 zt.ua
 
 // ug : https://www.registry.co.ug/
-// https://www.registry.co.ug, https://whois.co.ug
+// see also: https://www.registry.co.ug, https://whois.co.ug
 // Confirmed by registry <support@i3c.co.ug> 2025-01-20
 ug
 ac.ug

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5602,7 +5602,8 @@ gov.sb
 net.sb
 org.sb
 
-// sc : https://www.nic.sc/en/policies.html
+// sc : https://www.iana.org/domains/root/db/sc.html
+// see also : https://www.nic.sc/en/policies.html
 sc
 com.sc
 edu.sc

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5719,6 +5719,7 @@ univ.sn
 
 // so : https://www.iana.org/domains/root/db/so.html
 // see also : http://www.nic.so/
+// see also : https://sonic.so/policies/
 so
 com.so
 edu.so

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6659,11 +6659,11 @@ yt
 ລາວ
 
 // xn--fzc2c9e2c ("Lanka", Sinhalese-Sinhala) : LK
-// https://nic.lk
+// http://www.domains.lk/
 ලංකා
 
 // xn--xkc2al3hye2a ("Ilangai", Tamil) : LK
-// https://nic.lk
+// http://www.domains.lk/
 இலங்கை
 
 // xn--mgbc0a9azcg ("Morocco/al-Maghrib", Arabic) : MA

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4034,6 +4034,7 @@ org.ls
 sc.ls
 
 // lt : https://www.iana.org/domains/root/db/lt.html
+// see also : https://www.domreg.lt/
 lt
 // gov.lt : http://www.gov.lt/index_en.php
 gov.lt

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3853,7 +3853,7 @@ net.ki
 org.ki
 
 // km : https://www.iana.org/domains/root/db/km.html
-// http://www.domaine.km/documents/charte.doc
+// https://www.domaine.km/
 km
 ass.km
 com.km
@@ -3865,7 +3865,7 @@ org.km
 prd.km
 tm.km
 // These are only mentioned as proposed suggestions at domaine.km, but
-// https://www.iana.org/domains/root/db/km.html says they're available for registration:
+// https://en.wikipedia.org/wiki/.km says they're available for registration:
 asso.km
 coop.km
 gouv.km

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -4159,8 +4159,8 @@ org.mo
 // mobi : https://www.iana.org/domains/root/db/mobi.html
 mobi
 
-// mp : http://www.dot.mp/
-// Confirmed by registry <dcamacho@saipan.com> 2008-06-17
+// mp : https://www.iana.org/domains/root/db/mp.html
+// see also : http://get.mp/
 mp
 
 // mq : https://www.iana.org/domains/root/db/mq.html

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5189,7 +5189,7 @@ net.pe
 nom.pe
 org.pe
 
-// pf : http://www.gobin.info/domainname/formulaire-pf.pdf
+// pf : https://www.iana.org/domains/root/db/pf.html
 pf
 com.pf
 edu.pf

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -3882,7 +3882,8 @@ gov.kn
 net.kn
 org.kn
 
-// kp : http://www.star.co.kp/
+// kp : https://www.iana.org/domains/root/db/kp.html
+// http://www.star.co.kp/
 kp
 com.kp
 edu.kp

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -155,7 +155,7 @@ net.ai
 off.ai
 org.ai
 
-// al : http://www.ert.gov.al/ert_alb/faq_det.html?Id=31
+// al : https://akep.al/en/domain-e-application/ -> "Regulations and Decisions"
 al
 com.al
 edu.al

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -6352,7 +6352,7 @@ mil.vc
 net.vc
 org.vc
 
-// ve : https://registro.nic.ve/
+// ve : https://nic.ve/
 // https://nic.ve/site/user-agreement -> under "III. Clasificación de Nombres de Dominio"
 // Submitted by registry nic@nic.ve and nicve@conatel.gob.ve
 ve

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5944,8 +5944,7 @@ mil.tw
 net.tw
 org.tw
 
-// tz : http://www.tznic.or.tz/index.php/domains
-// Submitted by registry <manager@tznic.or.tz>
+// tz : https://karibu.tz/regulations
 tz
 ac.tz
 co.tz

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1275,7 +1275,7 @@ mil.gt
 net.gt
 org.gt
 
-// gu : http://gadao.gov.gu/register.html
+// gu : https://give.uog.edu/gu-domain-application-form/
 // University of Guam : https://www.uog.edu
 // Submitted by uognoc@triton.uog.edu
 gu

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -897,7 +897,7 @@ net.cu
 org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
-// https://ola.cv/domain-extensions-under-cv/
+// https://ola.cv/
 // Confirmed by registry <support@ola.cv> 2024-11-26
 cv
 com.cv

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1065,7 +1065,7 @@ pri.ee
 riik.ee
 
 // eg : https://www.iana.org/domains/root/db/eg.html
-// https://domain.eg/en/domain-rules/subdomain-names-types/
+// https://domain.eg/subdomain-names
 eg
 ac.eg
 com.eg

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -5179,7 +5179,7 @@ nom.pa
 org.pa
 sld.pa
 
-// pe : https://www.nic.pe/InformeFinalComision.pdf
+// pe : https://punto.pe/policy.php
 pe
 com.pe
 edu.pe

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -173,8 +173,7 @@ commune.am
 net.am
 org.am
 
-// ao : https://www.iana.org/domains/root/db/ao.html
-// see also: https://www.dns.ao/ao/
+// ao : https://www.dns.ao/ao/
 ao
 co.ao
 ed.ao
@@ -356,8 +355,7 @@ ac.be
 bf
 gov.bf
 
-// bg : https://www.iana.org/domains/root/db/bg.html
-// see also: https://www.register.bg/ -> "Terms and Conditions"
+// bg : https://www.register.bg/ -> "Terms and Conditions"
 bg
 0.bg
 1.bg
@@ -404,8 +402,7 @@ gov.bh
 net.bh
 org.bh
 
-// bi : https://www.iana.org/domains/root/db/bi.html
-// see also: http://whois.nic.bi/
+// bi : http://whois.nic.bi/
 bi
 co.bi
 com.bi
@@ -701,8 +698,7 @@ org.bt
 // Submitted by registry <jarle@uninett.no>
 bv
 
-// bw : https://www.iana.org/domains/root/db/bw.html
-// see also: https://nic.net.bw/bw-name-structure
+// bw : https://nic.net.bw/bw-name-structure
 bw
 ac.bw
 co.bw
@@ -723,8 +719,7 @@ com.by
 // http://hoster.by/
 of.by
 
-// bz : https://www.iana.org/domains/root/db/bz.html
-// see also: http://www.belizenic.bz/
+// bz : http://www.belizenic.bz/
 bz
 co.bz
 com.bz
@@ -760,8 +755,7 @@ cat
 // cc : https://www.iana.org/domains/root/db/cc.html
 cc
 
-// cd : https://www.iana.org/domains/root/db/cd.html
-// see also: https://www.nic.cd
+// cd : https://www.nic.cd
 cd
 gov.cd
 
@@ -1064,8 +1058,7 @@ org.ee
 pri.ee
 riik.ee
 
-// eg : https://www.iana.org/domains/root/db/eg.html
-// see also: https://domain.eg/subdomain-names
+// eg : https://domain.eg/subdomain-names
 eg
 ac.eg
 com.eg
@@ -1216,8 +1209,7 @@ ltd.gi
 mod.gi
 org.gi
 
-// gl : https://www.iana.org/domains/root/db/gl.html
-// see also: http://nic.gl
+// gl : http://nic.gl
 gl
 co.gl
 com.gl
@@ -1292,8 +1284,7 @@ web.gu
 // gw : https://nic.gw/regras/
 gw
 
-// gy : https://www.iana.org/domains/root/db/gy.html
-// see also: http://registry.gy/
+// gy : http://registry.gy/
 gy
 co.gy
 com.gy
@@ -1339,8 +1330,7 @@ mil.hn
 net.hn
 org.hn
 
-// hr : https://www.iana.org/domains/root/db/hr.html
-// see also: https://domene.hr/en/portal/faq
+// hr : https://domene.hr/en/portal/faq
 hr
 com.hr
 // From.hr domene : http://from.hr/
@@ -1565,8 +1555,7 @@ sch.ir
 // Confirmed by registry <marius@isgate.is> 2024-11-17
 is
 
-// it : https://www.iana.org/domains/root/db/it.html
-// see also: https://www.nic.it/
+// it : https://www.nic.it/
 it
 edu.it
 gov.it
@@ -3852,8 +3841,7 @@ info.ki
 net.ki
 org.ki
 
-// km : https://www.iana.org/domains/root/db/km.html
-// see also: https://www.domaine.km/
+// km : https://www.domaine.km/
 km
 ass.km
 com.km
@@ -3882,8 +3870,7 @@ gov.kn
 net.kn
 org.kn
 
-// kp : https://www.iana.org/domains/root/db/kp.html
-// see also: http://www.star.co.kp/
+// kp : http://www.star.co.kp/
 kp
 com.kp
 edu.kp
@@ -3941,8 +3928,7 @@ ind.kw
 net.kw
 org.kw
 
-// ky : https://www.iana.org/domains/root/db/ky.html
-// see also: https://www.ofreg.ky/ict/kydomain-introduction
+// ky : https://www.ofreg.ky/ict/kydomain-introduction
 ky
 com.ky
 edu.ky
@@ -4033,8 +4019,7 @@ net.ls
 org.ls
 sc.ls
 
-// lt : https://www.iana.org/domains/root/db/lt.html
-// see also : https://www.domreg.lt/
+// lt : https://www.domreg.lt/
 lt
 gov.lt
 
@@ -4065,8 +4050,7 @@ org.ly
 plc.ly
 sch.ly
 
-// ma : https://www.iana.org/domains/root/db/ma.html
-// see also: http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
+// ma : http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
 ma
 ac.ma
 co.ma
@@ -4111,8 +4095,7 @@ mh
 // mil : https://www.iana.org/domains/root/db/mil.html
 mil
 
-// mk : https://www.iana.org/domains/root/db/mk.html
-// see also: https://marnet.mk/ -> "ПРАВИЛНИК"
+// mk : https://marnet.mk/ -> "ПРАВИЛНИК"
 mk
 com.mk
 edu.mk
@@ -4159,8 +4142,7 @@ org.mo
 // mobi : https://www.iana.org/domains/root/db/mobi.html
 mobi
 
-// mp : https://www.iana.org/domains/root/db/mp.html
-// see also : http://get.mp/
+// mp : http://get.mp/
 mp
 
 // mq : https://www.iana.org/domains/root/db/mq.html
@@ -4300,8 +4282,7 @@ rec.nf
 store.nf
 web.nf
 
-// ng : https://www.iana.org/domains/root/db/ng.html
-// see also : https://www.nira.org.ng/
+// ng : https://www.nira.org.ng/
 ng
 com.ng
 edu.ng
@@ -4331,8 +4312,7 @@ nom.ni
 org.ni
 web.ni
 
-// nl : https://www.iana.org/domains/root/db/nl.html
-// see also: https://www.sidn.nl/
+// nl : https://www.sidn.nl/
 nl
 
 // no : https://www.norid.no/en/om-domenenavn/regelverk-for-no/
@@ -5106,8 +5086,7 @@ voagat.no
 volda.no
 voss.no
 
-// np : https://www.iana.org/domains/root/db/np.html
-// see also : https://www.mos.com.np/
+// np : https://www.mos.com.np/
 *.np
 
 // nr : http://cenpac.net.nr/dns/index.html
@@ -5459,8 +5438,7 @@ org.pn
 // post : https://www.iana.org/domains/root/db/post.html
 post
 
-// pr : https://www.iana.org/domains/root/db/pr.html
-// see also : https://www.domains.pr/
+// pr : https://www.domains.pr/
 pr
 ac.pr
 biz.pr
@@ -5490,8 +5468,7 @@ law.pro
 med.pro
 recht.pro
 
-// ps : https://www.iana.org/domains/root/db/ps.html
-// see also: https://www.pnina.ps/registration-policy/
+// ps : https://www.pnina.ps/registration-policy/
 ps
 com.ps
 edu.ps
@@ -5602,8 +5579,7 @@ gov.sb
 net.sb
 org.sb
 
-// sc : https://www.iana.org/domains/root/db/sc.html
-// see also : https://www.nic.sc/en/policies.html
+// sc : https://www.nic.sc/en/policies.html
 sc
 com.sc
 edu.sc
@@ -5691,8 +5667,7 @@ si
 // Submitted by registry <jarle@uninett.no>
 sj
 
-// sk : https://www.iana.org/domains/root/db/sk.html
-// see also: https://sk-nic.sk/
+// sk : https://sk-nic.sk/
 sk
 org.sk
 
@@ -5717,8 +5692,7 @@ gouv.sn
 org.sn
 univ.sn
 
-// so : https://www.iana.org/domains/root/db/so.html
-// see also : https://sonic.so/policies/
+// so : https://sonic.so/policies/
 so
 com.so
 edu.so
@@ -5782,8 +5756,7 @@ mil.sy
 net.sy
 org.sy
 
-// sz : https://www.iana.org/domains/root/db/sz.html
-// see also: http://www.sispa.org.sz/
+// sz : http://www.sispa.org.sz/
 sz
 ac.sz
 co.sz
@@ -5795,15 +5768,13 @@ tc
 // td : https://www.iana.org/domains/root/db/td.html
 td
 
-// tel : https://www.iana.org/domains/root/db/tel.html
-// see also: http://www.telnic.org/
+// tel : http://www.telnic.org/
 tel
 
 // tf : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf
 tf
 
-// tg : https://www.iana.org/domains/root/db/tg.html
-// see also: http://www.nic.tg/
+// tg : http://www.nic.tg/
 tg
 
 // th : https://www.iana.org/domains/root/db/th.html
@@ -6811,8 +6782,7 @@ school.za
 tm.za
 web.za
 
-// zm : https://www.iana.org/domains/root/db/zm.html
-// see also : https://zicta.zm/
+// zm : https://zicta.zm/
 zm
 ac.zm
 biz.zm

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -234,7 +234,7 @@ gv.at
 or.at
 
 // au : https://www.iana.org/domains/root/db/au.html
-// see also: https://www.auda.org.au/
+// https://www.auda.org.au/
 // Confirmed by registry <general@auda.org.au> 2025-07-16
 au
 // 2LDs
@@ -707,7 +707,7 @@ net.bw
 org.bw
 
 // by : https://www.iana.org/domains/root/db/by.html
-// see also: http://tld.by/rules_2006_en.html
+// http://tld.by/rules_2006_en.html
 // list of other 2nd level tlds ?
 by
 gov.by
@@ -745,8 +745,8 @@ pe.ca
 qc.ca
 sk.ca
 yk.ca
-// gc.ca: https://www.cira.ca/en/resources/documents/cybersecurity/overview-domain-name-system-dns/ -> "How are nodes delegated?"
-// see also: https://design.canada.ca/specifications/mandatory-elements/domains-urls.html
+// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
+// see also: http://registry.gc.ca/en/SubdomainFAQ
 gc.ca
 
 // cat : https://www.iana.org/domains/root/db/cat.html
@@ -891,7 +891,7 @@ net.cu
 org.cu
 
 // cv : https://www.iana.org/domains/root/db/cv.html
-// see also: https://ola.cv/
+// https://ola.cv/domain-extensions-under-cv/
 // Confirmed by registry <support@ola.cv> 2024-11-26
 cv
 com.cv
@@ -918,7 +918,7 @@ gov.cx
 
 // cy : http://www.nic.cy/
 // Submitted by Panayiotou Fotia <cydns@ucy.ac.cy>
-// see also: https://nic.cy/wp-content/uploads/2024/01/Create-Request-for-domain-name-registration-1.pdf
+// https://nic.cy/wp-content/uploads/2024/01/Create-Request-for-domain-name-registration-1.pdf
 cy
 ac.cy
 biz.cy
@@ -951,7 +951,7 @@ dj
 dk
 
 // dm : https://www.iana.org/domains/root/db/dm.html
-// see also: https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf
+// https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf
 // Confirmed by registry <admin@dotdm.dm> 2024-11-19
 dm
 co.dm
@@ -1188,7 +1188,7 @@ net.gg
 org.gg
 
 // gh : https://www.iana.org/domains/root/db/gh.html
-// see also: http://www.nic.gh/policy.html
+// https://www.nic.gh/
 // Although domains directly at second level are not possible at the moment,
 // they have been possible for some time and may come back.
 gh
@@ -5141,8 +5141,7 @@ onion
 // org : https://www.iana.org/domains/root/db/org.html
 org
 
-// pa : https://www.iana.org/domains/root/db/pa.html
-// see also : http://www.nic.pa/en/terms-service
+// pa : http://www.nic.pa/
 // Some additional second level "domains" resolve directly as hostnames, such as
 // pannet.pa, so we add a rule for "pa".
 pa
@@ -5600,7 +5599,7 @@ org.sd
 tv.sd
 
 // se : https://www.iana.org/domains/root/db/se.html
-// see also: https://data.internetstiftelsen.se/barred_domains_list.txt -> Second level domains & Sub-domains
+// https://data.internetstiftelsen.se/barred_domains_list.txt -> Second level domains & Sub-domains
 // Confirmed by Registry Services <registry@internetstiftelsen.se> 2024-11-20
 se
 a.se
@@ -5825,7 +5824,7 @@ nom.tm
 org.tm
 
 // tn : http://www.registre.tn/fr/
-// see also: https://whois.ati.tn/
+// https://whois.ati.tn/
 tn
 com.tn
 ens.tn
@@ -5851,8 +5850,9 @@ mil.to
 net.to
 org.to
 
-// tr : https://www.trabis.gov.tr/
-// see also: https://www.btk.gov.tr/en/internet-domain-names-legislation
+// tr : https://nic.tr/
+// https://nic.tr/forms/eng/policies.pdf
+// https://nic.tr/index.php?USRACTN=PRICELST
 tr
 av.tr
 bbs.tr
@@ -5901,7 +5901,7 @@ pro.tt
 tv
 
 // tw : https://www.iana.org/domains/root/db/tw.html
-// see also: https://twnic.tw/dnservice_catag.php
+// https://twnic.tw/dnservice_catag.php
 // Confirmed by registry <dns@twnic.tw> 2024-11-26
 tw
 club.tw
@@ -5941,7 +5941,7 @@ in.ua
 net.ua
 org.ua
 // ua geographic names
-// see also: https://hostmaster.ua/2ld/
+// https://hostmaster.ua/2ld/
 cherkassy.ua
 cherkasy.ua
 chernigov.ua
@@ -6017,7 +6017,7 @@ zp.ua
 zt.ua
 
 // ug : https://www.registry.co.ug/
-// see also: https://www.registry.co.ug, https://whois.co.ug
+// https://www.registry.co.ug, https://whois.co.ug
 // Confirmed by registry <support@i3c.co.ug> 2025-01-20
 ug
 ac.ug


### PR DESCRIPTION
Fixed broken links in the ICANN section comments, including links with 404 or DNS resolution errors.

Most of the replacement links were sourced from IANA’s Root Zone Database: https://www.iana.org/domains/root/db