### PR TITLE
Remove KnightPoint and Perspecta

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14425,10 +14425,6 @@ kiloapps.io
 kinghost.net
 uni5.net
 
-// KnightPoint Systems, LLC : http://www.knightpoint.com/
-// Submitted by Roy Keene <rkeene@knightpoint.com>
-knightpoint.systems
-
 // KoobinEvent, SL : https://www.koobin.com
 // Submitted by Iván Oliva <ivan.oliva@koobin.com>
 koobin.events
@@ -15192,10 +15188,6 @@ mypep.link
 // Perplexity AI : https://www.perplexity.ai/
 // Submitted by Alec Xiang <security@perplexity.ai>
 pplx.app
-
-// Perspecta : https://perspecta.com/
-// Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
-perspecta.cloud
 
 // Ping Identity : https://www.pingidentity.com
 // Submitted by Ping Identity <security@pingidentity.com>


### PR DESCRIPTION
- See relevant comment from the original requestor: https://github.com/publicsuffix/list/pull/898#issuecomment-2333034721
- Originally added in #898
- Email # 1 bounced `<rkeene@knightpoint.com>: Host or domain name not found. Name service error for
    name=knightpoint.com type=A: Host found but no data record of requested
    type`
- Email # 2 bounced `<[kvanalstyne@perspecta.com](mailto:kvanalstyne@perspecta.com)>
    (reason: 550 5.4.1 Recipient address rejected: Access denied. AS(201806281) [BN3USG02FT014.eop-usg02.itar.protection.office365.us 2026-07-25T01:28:23.808Z 08DEE99B413E0BD9])`
- Perspecta and Knight Point Systems no longer appear to operate as independent organizations or public-facing services. Knight Point Systems was acquired by Perspecta in 2019, and Perspecta was subsequently acquired and integrated into Peraton in 2021.
