### PR TITLE
Add viclix.app (PRIVATE section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15736,6 +15736,10 @@ vipsinaapp.com
 // Submitted by Skylar Challand <support@siteleaf.com>
 siteleaf.net
 
+// Sizth, LLC : https://www.sizth.com/
+// Submitted by JP <jp@sizth.com>
+viclix.app
+
 // Small Technology Foundation : https://small-tech.org
 // Submitted by Aral Balkan <aral@small-tech.org>
 small-web.org


### PR DESCRIPTION
Adding `viclix.app` to the PRIVATE DOMAINS section.

**Organization:** Sizth, LLC — https://www.sizth.com
**Product:** Viclix (https://viclix.com), a PaaS operated by Sizth, LLC
**Submitted by:** JP <jp@sizth.com>

**What the domain is used for:**
viclix.app is a dedicated domain on which the Viclix PaaS serves
customer-deployed applications, one per subdomain: `{customer}.viclix.app`.
Each subdomain hosts an independent, mutually-untrusted customer app. We request
inclusion so browsers treat each customer subdomain as its own registrable site,
preventing cross-subdomain cookie leakage and cookie-tossing between customers.
(The Viclix control plane — dashboard/admin/www — lives on a separate registrable
domain, viclix.com, and is intentionally not part of this request.)

**DNS validation:** the `_psl.viclix.app` TXT record contains the URL of this PR.

**Registration commitment:**
- viclix.app has more than 2 years of registration remaining as of this PR's
  submission date (expires 2029-07-21).
- We commit to keeping the registration in good standing with more than one year
  remaining in its term at all times.
