### PR TITLE
Add proginter.app and proginter.dev

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15238,6 +15238,11 @@ xen.prgmr.com
 // Submitted by registry <lendl@nic.at>
 priv.at
 
+// Proginter : https://proginter.com
+// Submitted by Proginter <accounts@proginter.com>
+proginter.app
+proginter.dev
+
 // PROJECT ELIV : https://eliv.kr/
 // Submitted by PROJECT ELIV DomainName Team <team@eliv.kr>
 c01.kr


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

(Status update 2026-07-23: the registration extension is DONE - registry RDAP now shows expiration 2029-08-14 for both proginter.app and proginter.dev, over three years remaining. The `_psl` TXT records are in place and will be maintained.)

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. This request does not seek to work around any third-party limit. TLS for both namespaces is served from our own wildcard certificates (no per-subdomain issuance), and we have no rate-limit, Cloudflare, or platform-limit motivation.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://proginter.com/contact
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

(Our primary organization website is proginter.com, which is NOT part of this request. The two submitted apexes serve only a redirect to proginter.com and set no cookies of their own.)

---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Proginter is a web hosting provider operating its own server fleet and control panel, serving managed WordPress/PHP hosting, VPS servers, and staging environments for business customers. Customer staging environments are provisioned as per-customer subdomains of proginter.dev (in production use today), and proginter.app is our free-hosting tier domain on which each customer website is provisioned as its own subdomain. The submitter is the operator of Proginter's infrastructure, acting for the organization; accounts@proginter.com is the organization's monitored role address.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://proginter.com
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Both namespaces host content controlled by different, mutually-untrusting customers: each subdomain of proginter.app is a different customer's website (free hosting tier, open signup) and each subdomain of proginter.dev is a different customer's staging environment. We request private-section listing for the standard user-content reasons: (1) cookie isolation, so one customer's site can never set or read cookies scoped to the shared parent and affect sibling customers; (2) reputation scoping, so security tooling (e.g. Safe Browsing) can treat each customer's subdomain independently rather than penalizing every customer for one bad actor - we run daily malware/phishing scanning with takedown, and this listing complements that; (3) correct origin-boundary treatment by the many products that consume the PSL. This is the same pattern as other hosting providers' user-content domains in the private section. We confirm the intent is not to work around any third-party limit; TLS is already served from our own wildcard certificates.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Current actual count: below 0.1 thousand (dozens of business customers use proginter.dev staging subdomains today; proginter.app is our free-tier domain whose public launch is this month, with open signup including AI-agent-driven signup). We are providing the honest current figure rather than a projection: this is a pre-launch submission made early because the free tier's open signup makes the cookie-isolation and reputation-scoping protections most valuable from day one, before abuse can affect existing customers. If the maintainers prefer to hold this request until the namespace crosses the distinct-user threshold, we will keep the `_psl` records in place and update this PR with actual counts as the tier grows.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.proginter.app
"https://github.com/publicsuffix/list/pull/3078"
```

```
dig +short TXT _psl.proginter.dev
"https://github.com/publicsuffix/list/pull/3078"
```
<!-- END FILL IN -->
