### PR TITLE
Add py3.ru

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15279,6 +15279,10 @@ puter.app
 puter.site
 puter.work
 
+// py3.ru : https://py3.ru
+// Submitted by Andrei Ilinskii <info@py3.ru>
+py3.ru
+
 // PythonAnywhere LLP : https://www.pythonanywhere.com
 // Submitted by Giles Thomas <giles@pythonanywhere.com>
 pythonanywhere.com


### PR DESCRIPTION
### What is py3.ru

py3.ru is a free subdomain registry for students of HSE University (National
Research University Higher School of Economics, Moscow — ~50,000 students).
Any student with an `hse.ru` / `*.hse.ru` mailbox can register up to five
subdomains of the form `NAME.py3.ru` and either manage DNS records
(A/AAAA/CNAME/MX/TXT/SRV/CAA) on our authoritative servers or delegate the
name to external nameservers of their choice. Subdomain holders are mutually
untrusting private individuals; the operator only runs the registry and DNS —
no content hosting.

Each registered subdomain is a separate delegated DNS zone with its own
SOA/NS (`dig SOA NAME.py3.ru` answers with the child zone's SOA), i.e. the
service behaves like a conventional domain registry one level down.

### Why the PSL entry is needed

* **Cookie / origin isolation.** `alice.py3.ru` and `bob.py3.ru` belong to
  unrelated people, and the registry portal itself lives at the apex
  `https://py3.ru`. Without a PSL entry a site on one student's subdomain can
  set `Domain=py3.ru` supercookies affecting every other student and the
  portal, and all subdomains are same-site to each other.
* **Let's Encrypt rate limits.** With the entry, each `NAME.py3.ru` becomes
  its own registered domain for CA rate-limiting purposes instead of all
  students sharing the limits of `py3.ru`.

### Expected behaviour (input/output)

With the single rule `py3.ru`:

| Input | registrable domain (eTLD+1) |
|---|---|
| `alice.py3.ru` | `alice.py3.ru` |
| `www.alice.py3.ru` | `alice.py3.ru` |
| `py3.ru` | none (public suffix itself; the portal uses only `__Host-`/host-only cookies and needs no registrable domain) |

A cookie set from `alice.py3.ru` with `Domain=py3.ru` should be rejected;
`alice.py3.ru` and `bob.py3.ru` should be cross-site to each other and to the
portal. No wildcard rule is requested: sub-subdomains belong to the same
student as their parent `NAME.py3.ru`.

### Statements

* Registration term note (ccTLD policy): the .RU registry (Coordination
  Center for TLD RU) registers domains for exactly one year and only allows
  renewal within a window near expiry — multi-year expiration dates are
  impossible for ANY .ru domain, so the "2 years beyond submission" guideline
  cannot be met literally (the same applies to every existing .ru entry in
  the PRIVATE section). Auto-renewal is enabled at the registrar and we
  commit to renewing every cycle as soon as the registry window opens;
  current `paid-till` is verifiable via `whois py3.ru`.
* A `_psl.py3.ru` TXT record containing this PR's URL will be published
  within minutes of opening the PR and will remain in place permanently.
* We understand that PSL changes propagate to browsers and libraries slowly
  and are effectively long-term; the service is operated as a long-term
  institutional resource for the university's students.
* Submitter is the operator/administrator of py3.ru; the email in the entry
  comment (`info@py3.ru`) is the operator contact mailbox on the domain
  itself and is listed in the service's legal documents.
