### PR TITLE
Add sitey.com.br (private section)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15731,6 +15731,10 @@ vipsinaapp.com
 // Submitted by Skylar Challand <support@siteleaf.com>
 siteleaf.net
 
+// Sitey : https://sitey.com.br
+// Submitted by Andre <aspandre88@gmail.com>
+sitey.com.br
+
 // Small Technology Foundation : https://small-tech.org
 // Submitted by Aral Balkan <aral@small-tech.org>
 small-web.org


### PR DESCRIPTION
**Organization**: Sitey — https://sitey.com.br

**Reason for request**: Sitey is a website builder for small businesses in Brazil. Each customer receives a website on a subdomain of sitey.com.br (e.g. julioqueiroz.sitey.com.br). We request inclusion in the PRIVATE domains section so that customer sites are treated as independent origins (cookie isolation, Safe Browsing / reputation isolation between customer sites).

**DNS validation**: The `_psl.sitey.com.br` TXT record pointing to this pull request URL will be added right after this PR is opened.

We have read the submission guidelines (https://github.com/publicsuffix/list/wiki/Guidelines) and understand that rollbacks are slow and disruptive; this is a long-term production use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)