### PR TITLE
Add cloudqube.app (CloudQube sandbox subdomains)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12731,6 +12731,10 @@ cdn.cloudflareanycast.net
 cdn.cloudflarecn.net
 cdn.cloudflareglobal.net
 
+// CloudQube : https://cloudqube.eu
+// Submitted by Zac Clery <security@cloudqube.eu>
+cloudqube.app
+
 // cloudscale.ch AG : https://www.cloudscale.ch/
 // Submitted by Gaudenz Steinlin <support@cloudscale.ch>
 cust.cloudscale.ch


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Description of Organization

CloudQube (https://cloudqube.eu), operated by Clery Development (KvK 87060396, Netherlands), is an EU-based platform that provisions and manages web hosting, DNS, and related services on behalf of its users. Free-tier users publish static websites at `<label>.cloudqube.app`, one delegated subdomain per user site, comparable to `github.io`, `netlify.app`, `vercel.app`, and `pages.dev`.

### Reason for PSL Inclusion

`cloudqube.app` hosts independent, user-controlled content on per-user subdomains. Each `<label>.cloudqube.app` is a distinct site operated by a different, unrelated party. We are requesting inclusion in the PRIVATE section so that:

- **Cookie isolation**: user agents treat each `<label>.cloudqube.app` as its own registrable site, so one user's site cannot set or read cookies scoped to `cloudqube.app` (and therefore cannot reach another user's subdomain). This is the primary, specified purpose of PSL inclusion and the main reason we are applying.
- **Correct site boundaries**: tooling that relies on the PSL (browsers, and systems that consult it) treats each subdomain as an independent site rather than as parts of a single `cloudqube.app` site.

`cloudqube.app` is deliberately a separate registrable domain from our corporate/product domain `cloudqube.eu`; user content is never served from the domain that runs our application or email.

### Third-party limits

This request is **not** submitted to work around any third-party rate limits or restrictions (e.g. Let's Encrypt, iOS/Facebook, or any other). We do not seek to overcome any such limit through PSL inclusion.

### DNS verification (dig)

`cloudqube.app` is registered and delegated to our DNS provider:

```
$ dig NS cloudqube.app +short
ns1.openprovider.nl.
ns2.openprovider.be.
ns3.openprovider.eu.
```

Per RFC 8553, a `_psl.cloudqube.app` TXT record pointing to this PR will be added once the PR number is assigned, and left in place for as long as the entry remains in the PSL.

### Abuse contact

Abuse reporting form: **https://cloudqube.eu/abuse**
Abuse email: **abuse@cloudqube.eu**

Both are publicly accessible without an account and are actively monitored.

### Checklist

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via dig
- [x] Each domain in the PRIVATE section has and shall maintain at least two years remaining on registration (`cloudqube.app` is registered through 2029-03-10), and we will keep the `_psl` TXT record in place in the zone.
- [x] We are listing any third-party limits we seek to work around (none apply).
- [x] This request was not submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges responsibility for maintaining the domains within their section (removing unused names, retaining the `_psl` record, responding to emails).
- [x] The Guidelines were read and understood, and this request conforms to them.
- [x] The submission follows the formatting and sorting guidelines (entry placed alphabetically by organization name in the PRIVATE section, between "Cloudflare, Inc." and "cloudscale.ch AG").
- [x] A role-based email address (security@cloudqube.eu) has been used and this inbox is actively monitored with a response time of no more than 30 days.
- [x] Abuse contact information is available and easily accessible.

**Abuse Contact URL:** https://cloudqube.eu/abuse
