### PR TITLE
Remove `*.on-acorn.io`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11301,10 +11301,6 @@ ltd.ua
 a2hosted.com
 cpserver.com
 
-// Acorn Labs : https://acorn.io
-// Submitted by Craig Jellick <domains@acorn.io>
-*.on-acorn.io
-
 // ActiveTrail : https://www.activetrail.biz/
 // Submitted by Ofer Kalaora <postmaster@activetrail.com>
 activetrail.biz


### PR DESCRIPTION
- Removal confirmed by the original requestor: https://github.com/publicsuffix/list/pull/1578#issuecomment-5061963581
- Domain pointing to domain parking. 
- Organization website (Acorn Labs) domain acorn.io was listed on dan.com domain market.
