### PR TITLE
Add flareapps.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13648,7 +13648,7 @@ filegear.me
 firebaseapp.com
 
 // FlareApps : https://flareapps.io
-// Submitted by Apiwat Jarruwattanachai <apiwatja@flare.agency>
+// Submitted by Apiwat Jarruwattanachai <psl@flare.agency>
 flareapps.site
 
 // FlashDrive : https://flashdrive.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13647,6 +13647,10 @@ filegear.me
 // Submitted by Chris Raynor <chris@firebase.com>
 firebaseapp.com
 
+// FlareApps : https://flareapps.io
+// Submitted by Apiwat Jarruwattanachai <apiwatja@flare.agency>
+flareapps.site
+
 // FlashDrive : https://flashdrive.io
 // Submitted by Eric Chan <support@flashdrive.io>
 fldrv.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None — this request does not seek to work around any third-party limit.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
   — The entry now uses **`psl@flare.agency`**, a role-based address delivering to the organization's actively-monitored operations inbox (response well under 30 days). Updated in this PR after initial submission.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  Every published site under `*.flareapps.site` carries a platform-injected footer link "Report this site" opening an anonymous abuse-report form (server-side, cannot be removed by the site owner) — live example: https://kind-bronze-raccoon-nvlj.flareapps.site/ (footer). Reports land in the platform's moderation/takedown queue. Abuse email: psl@flare.agency.
  <!-- END FILL IN -->

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

Flare Agency Co., Ltd. is a software company registered in Bangkok, Thailand (operating since 2015), building web platforms for Thai small businesses. Our product FlareApps (https://flareapps.io) is a multi-tenant SaaS website builder and business-operations platform aimed at Thai SMBs and creators (restaurants, guesthouses, tour operators, freelancers, community organizations). Each customer designs a website in the FlareApps studio and publishes it; published customer sites are served exclusively on the dedicated render domain `flareapps.site`, one customer site per one-deep subdomain (`<slug>.flareapps.site`) — the same isolation model as `github.io` / `vercel.app`. The application, marketing, and API surfaces live on the separate brand domain `flareapps.io`, which is deliberately NOT part of this request. I am Apiwat Jarruwattanachai, director and engineer at Flare Agency, the registrant of `flareapps.site`, and the operator of the platform's infrastructure; I am submitting on behalf of the organization.

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://flareapps.io
<!-- END FILL IN -->

## Reason for PSL Inclusion

Cookie security and tenant isolation for user-generated content. `flareapps.site` exists solely to host end-user-authored websites on one-deep subdomains; no first-party application cookies live on it. Without PSL listing, any tenant's site can set cookies scoped to the registrable domain (`Domain=flareapps.site`), which would be sent to every other tenant's site — a cross-tenant supercookie/session-fixation surface. The platform's viewer-session architecture was designed for PSL semantics from the start: all authentication cookies on the render domain are host-only per site, and the codebase forbids widening any cookie's `Domain` on `flareapps.site`. PSL listing makes each customer site its own site/origin boundary for cookies, SAB/storage partitioning, SEO treatment, and abuse/reputation scoring, so one tenant's behavior cannot bleed into another's.

The domain is registered through **June 2029** (renewed to hold more than two years of remaining term for this submission) with auto-renew enabled, and we shall maintain more than one year of remaining term while listed. The `_psl` TXT record will be kept in place for the lifetime of the listing.

No third-party limits are being worked around; this is purely the standard multi-tenant user-content isolation case (github.io model).

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Honest current actual count: fewer than 1 thousand distinct site-operating users today — the platform is in the final pre-public-launch phase (real customer sites are live on the domain now; public launch is imminent). We are filing at launch-preparation deliberately and transparently because derivative propagation of PSL changes lags acceptance by months, and retrofitting PSL semantics after tenants have accumulated cookies is precisely the breakage the guidelines warn about. The subdomain space is end-user-registered by design, and each new customer adds a distinct subdomain. If the maintainers prefer to defer on user-count grounds we understand; we would then re-open referencing this PR once past the threshold.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.flareapps.site
"https://github.com/publicsuffix/list/pull/3095"
```
(Record created in Route 53 immediately after PR creation, TTL 300; verified against the authoritative nameservers. It will be kept in place for the lifetime of the listing.)
<!-- END FILL IN -->
