### PR TITLE
Add redwheelbarrow.dev (RedWheelbarrow AI, PRIVATE)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15388,6 +15388,10 @@ instances.spawn.cc
 *.clusters.rdpa.co
 *.srvrless.rdpa.co
 
+// redwheelbarrow.dev : https://redwheelbarrow.ai
+// Submitted by Reza Nehzati <reza@heydonto.com>
+redwheelbarrow.dev
+
 // Render : https://render.com
 // Submitted by Anurag Goel <dev@render.com>
 onrender.com


### PR DESCRIPTION
## Submission

- **Section:** PRIVATE domains
- **Entity:** RedWheelbarrow AI — https://redwheelbarrow.ai
- **Domain:** `redwheelbarrow.dev`
- **Placement:** alphabetical, between `Redpanda Data` and `Render`.

## Rationale

`redwheelbarrow.dev` hosts on-demand, per-branch **preview environments** — one per
subdomain (`<preview>.redwheelbarrow.dev`), each running isolated, untrusted
application code. Listing `redwheelbarrow.dev` as a public suffix makes every
`*.redwheelbarrow.dev` its own registrable site, so cookies and other
origin-scoped state cannot leak between previews or to the parent domain. This is
the same rationale as other preview/hosting providers already in the PRIVATE
section (e.g. Render, Repl.it, Redpanda).

## Control / validation

- The domain is operated by RedWheelbarrow AI; DNS is managed via Cloudflare.
- A `_psl.redwheelbarrow.dev` TXT record pointing at this PR is being added per the
  submission guidelines.
