### PR TITLE
Add apexnet.bond to private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16403,4 +16403,8 @@ nett.to
 // Submitted by ZoneABC Team <support@zoneabc.net>
 zabc.net
 
+// ApexNet : https://apexnet.bond
+// Submitted by Wahid Parsa <info@apexnet.bond>
+apexnet.bond
+
 // ===END PRIVATE DOMAINS===


### PR DESCRIPTION
### PSL Pull Request Checklist

* [x] Description of Organization / Service provided
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

Third-party Limits are used elsewhere, such as at Cloudflare, Let's Encrypt, Apple, GitLab or others, and having an entry in the PSL alters the manner in which those third-party systems or products treat a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact your domain(s) directly with that third-party, and it is inappropriate to submit entries to the PSL as a means to work around those limits or restrictions.

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see Issue #1245)

### Domain Information

* **Domain Name:** apexnet.bond
* **Website:** https://apexnet.bond
* **Policy / Terms:** https://apexnet.bond/terms
* **Abuse Contact:** abuse@apexnet.bond

### Rationale & Service Description
ApexNet provides free custom subdomains under `apexnet.bond` for users' web projects and tools. Adding `apexnet.bond` to the PSL ensures proper cookie isolation and security boundaries between subdomains.

Submitter asserts that all statements above are true to the best of their knowledge.
