### PR TITLE
Add smartestsites.com (Smartest Websites)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15749,6 +15749,10 @@ pharmacien.fr
 port.fr
 veterinaire.fr
 
+// Smartest Websites : https://smartestwebsites.com
+// Submitted by Brandon Rangel <hello@smartestwebsites.com>
+smartestsites.com
+
 // Smoove.io : https://www.smoove.io/
 // Submitted by Dan Kozak <dan@smoove.io>
 vp4.me


### PR DESCRIPTION
Adding smartestsites.com to the PRIVATE DOMAINS section.

Smartest Websites is a website builder that hosts each customer's published site on
its own subdomain of smartestsites.com (customer-site.smartestsites.com). Sites are
authored by customers and served as static files; subdomains are allocated
automatically per site.

Requesting the PSL entry so that each customer subdomain is treated as its own
cookie and origin boundary. Without it, one customer's site can set a cookie scoped
to .smartestsites.com that every other customer's site can read, which is a
cross-customer isolation problem rather than a cosmetic one.

The apex smartestsites.com serves no customer content - the marketing site is on a
separate domain (smartestwebsites.com), and no authenticated or session-bearing
application is served from smartestsites.com or any of its subdomains.

Rationale matches existing entries for comparable hosting platforms
(github.io, vercel.app, netlify.app, pages.dev).

Validation: _psl TXT record added per the submission guidelines.
Contact: hello@smartestwebsites.com