### PR TITLE
Add patientos.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15154,6 +15154,10 @@ pgfog.com
 gotpantheon.com
 pantheonsite.io
 
+// PatientOS : https://patientos.com.au/
+// Submitted by Tim O'Connell <psl@patientos.site>
+patientos.site
+
 // Paywhirl, Inc : https://paywhirl.com/
 // Submitted by Daniel Netzer <dan@paywhirl.com>
 *.paywhirl.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 - None. This request is motivated by cookie isolation between customer subdomains (detailed below). For transparency: inclusion will incidentally change how Let's Encrypt accounts per-registered-domain rate limits for our customer subdomains, but we are nowhere near those limits, have not requested increases, and are not submitting to alter them.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://patientos.site/ (the index page names abuse@patientos.site)
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
PatientOS is an Australian clinic-management platform (practice management system) for medical clinics, operated from Australia. Each clinic customer gets a marketing website they publish through our website builder; every published site is served on its own subdomain of `patientos.site` (for example `pocketdoc-demo.patientos.site`) — one subdomain per customer clinic, the same shared-hosting model as `pantheonsite.io` or `pages.dev`. The organization's primary product domain is `patientos.com.au`; `patientos.site` exists solely as the shared hosting domain for these customer-published sites and serves no first-party content of its own beyond an index/abuse-contact page.

I am Tim O'Connell, the engineer/operator of PatientOS and the registrant of `patientos.site`; I administer the domain's DNS zone directly and am submitting on the organization's own behalf (not a third party). The section's role-based contact is `psl@patientos.site` (actively monitored).
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://patientos.com.au
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Cookie security between mutually-untrusting customers. Each subdomain of `patientos.site` is operated by a different clinic customer, and these sites include signed-in patient functionality (a patient portal session cookie scoped to the customer's subdomain). Without PSL listing, browsers treat all customer subdomains as one site: any customer's subdomain can set a `Domain=patientos.site` cookie that shadows or fixates another customer's session cookie, and SameSite protections do not apply between the subdomains. Listing `patientos.site` in the PRIVATE section gives each customer subdomain its own registrable domain, isolating cookies between customers — the same rationale as the existing entries for multi-tenant hosting platforms.

The `patientos.site` registration runs to 2029-06-26 (more than two years remaining); we commit to maintaining more than one year of remaining term for as long as the entry is listed, and to keeping the `_psl` TXT record in place. No prior issues or PRs relate to this domain.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Fewer than 1 thousand today — this is an actual count, stated plainly: the platform is newly launching, and the subdomains currently serve early clinic customers and their patients. Each subdomain is a distinct clinic organization whose patients sign in on that subdomain; we estimate exceeding 2 thousand distinct signed-in patient users across customer subdomains within the first year as clinics onboard. We are submitting ahead of that scale because the entries protect patient session cookies (medical-context accounts), and because browser propagation lags list inclusion by months — waiting until the threshold is crossed would leave real patient sessions on a shared registrable domain for the interim. If the maintainers prefer that we return once the user threshold is met, we will do so.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
$ dig +short TXT _psl.patientos.site
"https://github.com/publicsuffix/list/pull/3102"
```
The record is live and permanent.
<!-- END FILL IN -->
