### PR TITLE
Add nautacloud.net

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14783,6 +14783,10 @@ cust.retrosnub.co.uk
 // Submitted by Paulus Schoutsen <infra@nabucasa.com>
 ui.nabu.casa
 
+// nautacloud : https://nautacloud.net
+// Submitted by Alejandro Santana <santanarobainaa@gmail.com>
+nautacloud.net
+
 // Needle Tools GmbH : https://needle.tools
 // Submitted by Felix Herbst <security@needle.tools>
 needle.run


### PR DESCRIPTION
### What is this domain used for?

[nautacloud](https://nautacloud.net) is a free static-site hosting service aimed at developers in Cuba, who generally cannot open accounts with the usual providers because those require an international credit card. Every user is given a subdomain of `nautacloud.net` (`<their-site>.nautacloud.net`) and publishes arbitrary HTML, CSS and JavaScript to it.

### Why does it need to be on the list?

The content on those subdomains is written by members of the public and is not controlled by us, so each one should be treated by browsers as its own site. Without an entry here, one user's site can set a cookie scoped to `.nautacloud.net` that is then sent to the parent domain and to every other user's site, and all of them share one origin's worth of browser-level grouping.

The service's dashboard is served from the apex, and it deliberately uses no cookies at all — session tokens are kept in `sessionStorage` — so listing the apex as a public suffix does not break anything on our side. This is the same arrangement as other hosting providers already in this section.

### Details

- **Organisation:** nautacloud
- **Website:** https://nautacloud.net
- **Contact:** santanarobainaa@gmail.com
- **Entry:** `nautacloud.net`
- **Section:** PRIVATE

The `_psl` TXT record pointing at this pull request will be added as soon as it has a number, per the submission guidelines.