### PR TITLE
Add vx-build.app (VX Build)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16202,6 +16202,10 @@ voorloper.cloud
 // Submitted by Niels Maumenee <storage@vultr.com>
 *.vultrobjects.com
 
+// VX Build : https://vx-build.ai/
+// Submitted by Fernando Oliveira <contact@vx-build.ai>
+vx-build.app
+
 // Waffle Computer Inc., Ltd. : https://docs.waffleinfo.com
 // Submitted by Masayuki Note <masa@blade.wafflecell.com>
 wafflecell.com


### PR DESCRIPTION
### Submission

```
// VX Build : https://vx-build.ai/
// Submitted by Fernando Oliveira <contact@vx-build.ai>
vx-build.app
```

### Rationale

`vx-build.app` is an application-hosting platform. Customer-deployed applications are served on
per-customer subdomains (`<app>.vx-build.app`), and customers may also point their own domains at
the platform via CNAME.

Each subdomain is delegated to an **independent third party** and runs untrusted, customer-authored
code. They should therefore be treated as separate sites so that cookies, origin-based storage and
other same-site boundaries do not leak between unrelated tenants.

This is the same delegation boundary as other application-hosting entries already in the private
section (e.g. `pages.dev`, `workers.dev`, `vercel.app`, `netlify.app`).

No platform/first-party session cookies are served from `vx-build.app` — the platform's own console
runs on a separate registrable domain (`vx-build.ai`), specifically so that tenant content and
platform authentication never share a cookie scope.

### Checklist

- [x] Entry added to the **PRIVATE** section, sorted alphabetically by company name (after
      `Vultr Objects`, before `Waffle Computer Inc., Ltd.`)
- [x] Comment header includes company URL and submitter contact
- [x] Submitted by an authorised representative of the domain holder
- [x] Domain registration extends more than 2 years beyond submission (expires **2029-07-30**)
- [x] `linter/pslint.py` passes
- [ ] `_psl` DNS TXT record — adding immediately, referencing this PR URL