### PR TITLE
Add sophengine.com to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15776,6 +15776,10 @@ sol.site
 // Submitted by David Coles <david.coles@sony.com>
 playstation-cloud.com
 
+// Sophistication : https://sophistication.io
+// Submitted by Dominik Schimpf <support@sophistication.io>
+sophengine.com
+
 // SourceHut : https://sourcehut.org
 // Submitted by Drew DeVault <sir@cmpwn.com>
 srht.site


### PR DESCRIPTION
## Why is this PR being requested?

Sophistication is a multi-tenant landing-page platform. Every customer's published page is served on its own subdomain of `sophengine.com` (`<slug>.sophengine.com`), issued automatically to customers who have no relationship with one another and do not trust one another.

We are requesting inclusion in the PRIVATE section so that each customer subdomain is treated as its own registrable domain. Two concrete outcomes:

1. **Cookie isolation.** No tenant can set a cookie at the shared parent that another tenant reads.
2. **Independent reputation.** One tenant's subdomain does not attach its reputation to the parent domain or to sibling tenants.

## Example subdomains and desired outcome

`acme-sommer.sophengine.com` and `beispiel-shop.sophengine.com` belong to unrelated customers. After this change, neither can set a cookie readable by the other, and consumers of the list treat them as separate sites rather than as subdomains of a common owner.

No wildcards and no exception (`!`) rules are requested. The apex `sophengine.com` remains under our own control and is not issued to customers.

## How many domains are being requested?

One: `sophengine.com`.

## Internal or general utility?

General utility. This is the production domain that customer-facing pages are served from, not an internal or staging-only domain.

## Registration term

Registered through Cloudflare Registrar, expiring **2029-06-29** (more than two years remaining), with auto-renew enabled.

## DNS validation

An RFC 8553 `_psl` TXT record pointing at this PR will be added to `sophengine.com` immediately after this PR is opened, once the PR number is known. I will comment here to confirm once it is in place and resolving.