### PR TITLE
Add useleadsite.app (LeadSite)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16155,6 +16155,10 @@ dnsupdate.info
 // Submitted by Gavin Brown <gavin.brown@centralnic.com>
 us.org
 
+// LeadSite : https://useleadsite.com
+// Submitted by Guilherme Bezerra <abuse@useleadsite.com>
+useleadsite.app
+
 // V.UA Domain Registry: https://www.v.ua/
 // Submitted by Serhii Rostilo <admin@v.ua>
 v.ua


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

> **Full disclosure on the two-year requirement:** `useleadsite.app` currently expires on **2028-07-30**, which is 3 days short of a literal two years from the date of this submission. We renewed it specifically for this request and we commit to maintaining it well beyond two years at all times, since every one of our customers' published websites is served from this domain and letting it lapse would take all of them offline. We are stating the exact date here rather than quietly ticking the box, and we will renew again immediately if the maintainers prefer a larger margin.

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook

 None. This request is not about working around any third-party limit. We already issue a single wildcard certificate for `*.useleadsite.app` via DNS-01, so Let's Encrypt issuance limits are not a factor, and we are not seeking to change any Cloudflare behaviour.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:

  https://useleadsite.com/privacidade (section 14, "Denúncia de abuso", listing abuse@useleadsite.com)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

Note that we are deliberately **not** submitting our primary/corporate domain `useleadsite.com`. Only `useleadsite.app`, which exists solely to host customer-generated websites, is included in this request.

## Description of Organization

LeadSite (https://useleadsite.com) is a Brazilian SaaS platform. Our customers are small agencies and freelancers who build and host websites for local businesses (barbershops, dental clinics, pet shops, restaurants). Each customer publishes their client's website on a subdomain of `useleadsite.app`, for example `barbearia-do-joao.useleadsite.app`.

There are currently around 9,000 published websites on the domain, each one belonging to a different, unrelated end business. Our application, dashboard, authentication and billing run on a separate registrable domain, `useleadsite.com`.

## Reason for PSL Inclusion

`useleadsite.app` is a shared subdomain space in which every subdomain is controlled by a different, mutually untrusted party.

Without a PSL entry, any published site can set a cookie scoped to the parent domain `.useleadsite.app`, and every other customer's site on the domain can then read it. That is a cross-tenant data leak between businesses that have no relationship with each other. The site code is generated by an LLM from each end customer's brief, so we cannot assume that the content of any given subdomain is well-behaved, and origin isolation does not cover cookie scoping.

`useleadsite.app` was registered exclusively to host customer sites and serves no other purpose. This is the same arrangement already listed for `netlify.app`, `vercel.app` and `lovable.app`.

## DNS verification

`_psl.useleadsite.app` TXT record will point to this pull request URL and will be added as soon as this PR number is known.
