### PR TITLE
Add bizosapps.com (BizOS)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12504,6 +12504,10 @@ bnr.la
 // Submitted by Andy Ortlieb <aortlieb@atlassian.com>
 bitbucket.io
 
+// BizOS : https://bizos.cc/
+// Submitted by BizOS <contact@bizos.lol>
+bizosapps.com
+
 // Blackbaud, Inc. : https://www.blackbaud.com
 // Submitted by Paul Crowder <paul.crowder@blackbaud.com>
 blackbaudcdn.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

* [x] We are listing *any* third-party limits that we seek to work around in our rationale
 - None. This request is not motivated by any third-party limit.

* [x] This request was _not_ submitted with the objective of working around other third-party limits.
* [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
* [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  https://bizos.cc/terms — role-based contact `contact@bizos.lol`, published on our public terms page. Our privacy page (https://bizos.cc/privacy, `privacy@bizos.lol`) states a 30-day response commitment.

---

### Description of Organization

BizOS (https://bizos.cc/) is a French SaaS platform that gives small businesses an autonomous
software agent to run their day-to-day operations. Part of that product builds and hosts a small
web application **on behalf of each customer**.

Note on naming: our corporate and product site is `bizos.cc`; role-based mailboxes are on
`bizos.lol` (a domain we also operate). `bizosapps.com` is a **separate registrable domain used
exclusively for customer-controlled content** — nothing of ours is served from it.

### Reason for PSL Inclusion

Each customer receives a subdomain of `bizosapps.com` — `customer-a.bizosapps.com`,
`customer-b.bizosapps.com` — serving an application whose code is generated for that customer.
These subdomains are **mutually untrusted**: they belong to different, unrelated businesses.

Without a PSL entry, an application on `customer-a.bizosapps.com` can set
`Set-Cookie: …; Domain=bizosapps.com`, which browsers will then send to
`customer-b.bizosapps.com`. One customer could read or influence another customer's visitors.
The subdomains are also treated as same-site with respect to each other, which weakens
`SameSite`-based CSRF protections between unrelated tenants.

This is the same tenant-isolation need that `vercel.app`, `myshopify.com`, `netlify.app` and
`pages.dev` are listed for. We deliberately registered a **separate** domain for customer content
rather than using a subdomain of our own site, precisely so that this boundary is at the
registrable-domain level.

We are submitting **before** hosting multiple customers on it, so that the boundary exists from
the start rather than being retrofitted.

### DNS verification

`bizosapps.com` is registered until **2028-08-03** (two years remaining, and we commit to
maintaining it beyond that). Its zone is under our control (Vercel DNS):

```
$ dig +short NS bizosapps.com
ns1.vercel-dns.com.
ns2.vercel-dns.com.
```

The `_psl` TXT record pointing at this PR will be added as soon as the PR number is assigned,
and a comment will confirm it here. It will remain in place permanently.
