### PR TITLE
Add deployzy.app to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12911,6 +12911,10 @@ deployagent.com
 piebox.site
 deployagent.space
 
+// Deployzy : https://deployzy.com
+// Submitted by Deployzy <support@deployzy.com>
+deployzy.app
+
 // deSEC : https://desec.io/
 // Submitted by Peter Thomassen <peter@desec.io>
 dedyn.io


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook

 We are **not** seeking to work around any third-party rate limits. This request is solely about correct cookie/certificate origin boundaries and abuse isolation (see rationale).

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://deployzy.com/report (abuse email: abuse@deployzy.com)

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

## Description of Organization

Deployzy (https://deployzy.com) is a self-hosted, Railway-style platform-as-a-service and localhost-tunneling provider. Users deploy web applications, databases, and expose local development servers to the internet, each of which is served on its own subdomain of `deployzy.app`. The brand, dashboard, API, and account system live on `deployzy.com`; all customer-controlled content is deliberately served from a separate registrable domain, `deployzy.app`, so that untrusted user content never shares an origin boundary with the operator's brand domain.

I am the founder and operating engineer of Deployzy and I am submitting this request on behalf of the organization. My role covers the platform's infrastructure, DNS, and TLS provisioning, so I am directly responsible for maintaining the domains and the `_psl` records referenced below.

## Reason for PSL Inclusion

Every customer application and tunnel receives a distinct hostname of the form `<name>.deployzy.app`. Because these subdomains are controlled by independent, mutually untrusting users, they must be treated as separate registrable sites: supercookies must not be settable across the shared parent (`deployzy.app`), and TLS certificate issuance and browser `Set-Cookie` domain scoping must stop at each individual subdomain rather than the shared suffix. Listing `deployzy.app` in the PRIVATE section is exactly the mechanism that enforces this, protecting users from cross-subdomain cookie leakage and one tenant scoping a cookie to the whole platform.

The second reason is safety isolation. As a hosting/tunnel provider we occasionally receive abuse (phishing or malware) on an individual tenant subdomain. Without a PSL boundary, a Safe-Browsing or reputation flag against one `*.deployzy.app` subdomain risks tainting the entire parent domain and every other tenant. A PRIVATE-section listing ensures each subdomain is evaluated as its own site, which both limits collateral damage to innocent tenants and lets abuse tooling correctly attribute a bad subdomain.

We confirm that `deployzy.app` is registered with more than two years remaining on its term and will be maintained well beyond a one-year horizon while listed. This request is not an attempt to work around any third-party rate limit.

**Number of THOUSANDS of distinct users this request is being made to serve:** ~2 (estimate; distinct users operating subdomains under `deployzy.app`).

## DNS Verification

```
dig +short TXT _psl.deployzy.app
"https://github.com/publicsuffix/list/pull/3124"
```
