### PR TITLE
Add makopages.com (Ma-ko Pages)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14606,6 +14606,10 @@ magicpatternsapp.com
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru
 
+// Ma-ko Pages : https://ma-ko.io
+// Submitted by Adán Alpízar <adan1984@gmail.com>
+makopages.com
+
 // MathWorks : https://www.mathworks.com/
 // Submitted by Emily Reed <psl-maintainers@groups.mathworks.com>
 matlab.cloud


### PR DESCRIPTION
## Description

Adding `makopages.com` to the **PRIVATE** section.

Ma-ko Pages (https://ma-ko.io) is a landing-page builder that hosts each tenant's published landing pages on its own subdomain, `{tenant}.makopages.com`. Adding `makopages.com` to the PSL ensures each tenant subdomain is treated as a separate site, giving proper cookie/origin isolation between tenants — the same rationale as `github.io`, `pages.dev`, `vercel.app`, etc.

- **Domain:** `makopages.com`
- **Section:** PRIVATE (placed alphabetically, between Mail.Ru Group and MathWorks)
- **Submitter:** Adán Alpízar <adan1984@gmail.com>

## Ownership / verification
- We control `makopages.com`.
- A `_psl.makopages.com` DNS TXT record pointing to this PR URL will be added right after opening (per the submission process).

## Rationale
Multi-tenant subdomain hosting: each tenant publishes at `{tenant}.makopages.com`. Without the PSL entry, all tenant subdomains are treated as the same site (same registrable domain), which weakens cross-tenant cookie/site isolation. This entry makes each tenant subdomain a separate site.