### PR TITLE
Add dreampia.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13020,6 +13020,10 @@ shoparena.pl
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
 dreamhosters.com
 
+// Dreampia : https://dreampia.ai
+// Submitted by Dreampia <cube@eonofpixel.com>
+dreampia.app
+
 // Dreamyoungs, Inc. : https://durumis.com
 // Submitted by Infra Team <infra@durumis.com>
 durumis.com


### PR DESCRIPTION
Dreampia (https://dreampia.ai) is a Korean-first AI website builder.
User-published sites are served on individual subdomains of
dreampia.app (e.g. mybakery.dreampia.app), one subdomain per user
site, while the application itself lives on a separate registered
domain (dreampia.ai). dreampia.app is used exclusively for
user-published content.

We are requesting inclusion in the PRIVATE section so that browsers
scope cookies per user site: without PSL listing, a site on one
subdomain can set a domain=.dreampia.app cookie that is sent to every
other user's site (cookie tossing). This is the same arrangement as
github.io, netlify.app and vercel.app.

The _psl.dreampia.app TXT record pointing to this pull request will be
in place shortly after this PR is opened.

Contact: cube@eonofpixel.com