### PR TITLE
Add wavehouse.app (Wave RF) to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16214,6 +16214,10 @@ wal.app
 // Submitted by Lorentz Kinde <security@wasmer.io>
 wasmer.app
 
+// Wave RF : https://wavehouse.cloud/
+// Submitted by Eric Andrechek <security@wavehouse.cloud>
+wavehouse.app
+
 // Webflow, Inc. : https://www.webflow.com
 // Submitted by Webflow Security Team <security@webflow.com>
 webflow.io


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission doesn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/2835, although 
the organization and description were not as substantial 
as desired, which required maintainers' time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace because extra cycles are not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. We are not seeking to work around any third-party limit.

 For completeness, since the two most commonly cited limits are named in this template: we
 do not rely on Let's Encrypt rate limits being altered — every tenant hostname is covered by
 a single wildcard ACM certificate (`*.wavehouse.app`), so our certificate issuance volume is
 one certificate regardless of tenant count and does not scale with subdomains. We do not use
 Cloudflare for SaaS or custom hostnames on this domain; the zone holds one wildcard record.
 <!-- END FILL IN -->

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail regarding the effort that was made to work directly 
with the third party or parties in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry in, the 
order of commented organization placement, and the order of sorting of entries. 
(Hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically, both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- Provide the URL where an Internet user can access the abuse contact information -->
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://wavehouse.cloud/security

  The page carries an "Abuse" section for reporting a customer endpoint on `wavehouse.app`
  (phishing, malware, or other malicious content), reachable at the monitored role address
  `abuse@wavehouse.cloud`, alongside our vulnerability disclosure contact. That address is also
  published machine-readably per RFC 9116 at
  https://wavehouse.cloud/.well-known/security.txt — it is live today; the abuse-specific
  wording is deploying alongside this submission.

  Note on where that page lives: `wavehouse.app` hosts no content of its own. Its apex serves
  exactly one thing — a `301` to `https://wavehouse.cloud`, with the path preserved — so a
  reporter who trims a customer endpoint back to the domain lands on our site rather than a DNS
  error, and `https://wavehouse.app/.well-known/security.txt` resolves to the real document
  (RFC 9116 requires clients to follow redirects). Our corporate site, documentation and
  console all remain on `wavehouse.cloud`.

  We mention this because it is the one exception to keeping the apex inert, and it is
  deliberately compatible with the listing: a redirect sets no cookie of ours, and we
  understand that once listed, browsers will reject any cookie scoped to this apex. Nothing
  stateful will ever be served here.
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Wave RF operates WaveHouse Cloud, a managed database hosting service. Customers create
"projects", and each project is provisioned as an isolated single-tenant analytics engine
(WaveHouse, backed by ClickHouse) running in our Kubernetes cluster. Every project is reached
over HTTPS at its own randomly generated subdomain — `<ref>.wavehouse.app`, where `<ref>` is a
20-character random string — routed by an HAProxy edge that maps the Host header to that
tenant's backend. This is the same shape as other hosting providers already in the PRIVATE
section: we allocate subdomains to customers who are mutually untrusting, and we do not
control what those customers serve from them.

The subdomains are not user-chosen vanity names; they are opaque identifiers we mint. But the
CONTENT served under them is entirely customer-defined. A customer defines queries and API
endpoints on their project, and our data plane returns the resulting bytes. The response media
type is passed through from the underlying database engine's output format on the raw-query
endpoint today, and our roadmap extends that format selection to the customer's named endpoints,
so a customer can cause a response of a type we did not choose. That makes each
`<ref>.wavehouse.app` an origin under the customer's control, not ours.

I am Eric Andrechek, an engineer at Wave RF and the person responsible for the platform's
infrastructure and security posture. I administer the DNS for both `wavehouse.cloud` and
`wavehouse.app` and can create the `_psl` verification record. The contact in the list entry,
`security@wavehouse.cloud`, is a monitored role address rather than a personal one, as is the
separate `abuse@wavehouse.cloud`; both are published in our security.txt.
<!-- END FILL IN -->

**Organization Website:**
<!-- Provide the website address of the org as a full URL (i.e. https://example.com) -->
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://wavehouse.cloud
<!-- END FILL IN -->

## Reason for PSL Inclusion
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, iOS/Facebook, 
Cloudflare, etc.) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also reference any past issues or PRs 
specifically related to this submission or section.

Provide three or more sentences here that describe the purpose 
for which your PR should be included in the PSL. There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
**Cookie security — specifically, cookie isolation between mutually untrusting tenants.**

`wavehouse.app` exists only to host customer project endpoints. Because customers control the
bytes served from their subdomain, script running on `a.wavehouse.app` can set a cookie scoped
`Domain=.wavehouse.app`, and the browser will then send that cookie to `b.wavehouse.app`. The
`Cookie` request header carries no domain or path metadata, so the receiving party cannot
distinguish a cookie planted by a sibling from one it set itself. Without a PSL entry there is
no mechanism available to us that prevents this: `SameSite` does not help, because sibling
subdomains are same-site with each other by definition, and host-only cookies only govern where
*our* cookies are sent, not whether a sibling can *set* one. Listing `wavehouse.app` makes each
tenant subdomain a distinct site rather than merely a distinct origin, which is the only control
that closes tenant-to-tenant cookie planting.

We have already done the part of this that does not require you. Our console, REST API and
marketing site live on a **separate registrable domain**, `wavehouse.cloud`, and the tenant data
plane is being moved off it onto `wavehouse.app` specifically so that a customer subdomain
cannot reach our own session cookies. That domain separation fixes tenant-to-operator. It does
nothing for tenant-to-tenant, which is what this request is for. We are not asking the PSL to
substitute for an isolation boundary we could have built ourselves.

Nothing of ours is or will be served at the `wavehouse.app` apex, and we understand that a
listing permanently forecloses setting a cookie there. We designed for that constraint before
registering the domain rather than discovering it afterwards: the apex is empty by policy, and
every asset that needs cookies — console, API, docs, blog — stays on `wavehouse.cloud`, which
is not part of this request and must not be listed.

**Registration term.** `wavehouse.app` was registered 2026-08-10 and expires **2029-08-10** — a
three-year term, comfortably beyond the two-year requirement. We commit to maintaining more than
one year of remaining term for as long as the entry is listed, and to keeping the `_psl` TXT
record published permanently rather than removing it after verification.

**On timing, and on scale.** We are pre-launch: the platform is in closed testing and every
tenant today is one of our own. We are applying now, before we have external customers, and we
want to be transparent that this is deliberate rather than an oversight of the guidelines'
expectation around project scale. The reason is that PSL propagation is slow by nature —
volunteer review, then the list ships inside browser releases and reaches users over subsequent
months. If we wait until we have thousands of users, we would be asking those users to depend on
a boundary that does not yet exist in their browsers, and the hostnames would by then be baked
into customer code, making any correction a migration rather than a configuration change. We
would rather have the boundary land before the customers do. We fully accept that this means our
request may sit until we can demonstrate real usage, and we are happy to keep it open, provide
updated user counts as they materialise, or resubmit later if you would prefer we come back once
launched — please just tell us which you prefer and we will follow it. In the interim we are not
treating this listing as an active control: our edge serves every tenant response with
`Content-Security-Policy: sandbox` and `X-Content-Type-Options: nosniff`, and forces any response
media type outside a strict allowlist to `application/octet-stream` with
`Content-Disposition: attachment`, so a tenant response cannot execute script at all while this
is pending.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- 
The guidelines state that PSL inclusion is considered only for 
projects that have achieved a minimum of 2000 - 3000 distinct 
users or more. 

To be clear, 'users' is the number of distinct individuals 
working directly with a relationship with the requestor in 
using subnames of the requested space, and is not measured 
as the count of the audience of users that would visit to 
or interact with the namespace(s).

Please provide us this count, and identify if this is current 
actual count or an estimate. -->
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
**0 thousand — current actual count, not an estimate.** The platform is in closed testing and
has no external customers holding subdomains today; the only tenants are our own. We are stating
this plainly rather than projecting a number we cannot evidence. Please see the "On timing, and
on scale" paragraph above for why we are applying at this stage anyway, and for our offer to
either hold this open until we can show real usage or withdraw and resubmit post-launch,
whichever the maintainers prefer.
<!-- END FILL IN -->

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
The record is live:

```
$ dig +short TXT _psl.wavehouse.app
"https://github.com/publicsuffix/list/pull/3136"
```

It is managed as code in our infrastructure repository (Terraform, Cloudflare zone) and is
configured to remain in place permanently, not to be removed after verification.

The apex resolves too, so a reporter who trims a customer endpoint back to the domain reaches
our site rather than a DNS error:

```
$ curl -sI https://wavehouse.app | head -2
HTTP/2 301
location: https://wavehouse.cloud/

$ curl -sL https://wavehouse.app/.well-known/security.txt | head -2
Contact: mailto:security@wavehouse.cloud
Contact: mailto:abuse@wavehouse.cloud
```

Syntax checked locally with the repository linter before submitting:

```
$ cd linter && ./pslint.py ../public_suffix_list.dat
$ echo $?
0
```
<!-- END FILL IN -->
