### PR TITLE
REMOVE: adaptable entries (`adaptable.app`)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11305,10 +11305,6 @@ cpserver.com
 // Submitted by Ofer Kalaora <postmaster@activetrail.com>
 activetrail.biz
 
-// Adaptable.io : https://adaptable.io
-// Submitted by Mark Terrel <support@adaptable.io>
-adaptable.app
-
 // addr.tools : https://addr.tools/
 // Submitted by Brian Shea <publicsuffixlist@addr.tools>
 myaddr.dev


### PR DESCRIPTION
Related: #1824

Adaptable was shut down on March 15, 2025. They've created a farewell page on their GitHub org: https://github.com/adaptable/farewell/commit/1930855ffb845da70d6e648b66017fa87e2b5228

adaptable.app no longer resolves a `_psl` record. A [Google search for adaptable.app](https://www.google.com/search?q=site%253Aadaptable.app) returned no results, and the [submitter](https://github.com/mterrel) of #1824 did not have any GitHub activity since submitting https://github.com/adaptable/farewell/commit/1930855ffb845da70d6e648b66017fa87e2b5228 on March 15, 2025.

Their homepage, https://adaptable.io no longer resolves and their [GitHub org](https://github.com/adaptable) is pretty much dead.

Should be save to merge since it was shut down and have effectively no users on it.

@simon-friedberger 
