### PR TITLE
Add VIBSL (vibsl.app, vibsl.io)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16177,7 +16177,7 @@ now.sh
 // Submitted by Danko Aleksejevs <danko@very.lv>
 2038.io
 
-// VIBSL : https://vibsl.com/
+// Vibsl Labs Inc : https://vibsl.com/
 // Submitted by Swetha Gudala <security@vibsl.com>
 vibsl.app
 vibsl.io

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16177,6 +16177,11 @@ now.sh
 // Submitted by Danko Aleksejevs <danko@very.lv>
 2038.io
 
+// VIBSL : https://vibsl.com/
+// Submitted by Swetha Gudala <security@vibsl.com>
+vibsl.app
+vibsl.io
+
 // Virtual-Info : https://www.virtual-info.info/
 // Submitted by Adnan RIHAN <hostmaster@v-info.info>
 v-info.info


### PR DESCRIPTION
## Submission

```
// VIBSL : https://vibsl.com/
// Submitted by Swetha Gudala <security@vibsl.com>
vibsl.app
vibsl.io
```

Placed alphabetically by company name, between **VeryPositive SIA** and **Virtual-Info**.

## Why these entries are needed

VIBSL is a deployment platform. Each customer application is served on its own subdomain — `acme-shop.vibsl.app`, `other-tenant.vibsl.app` — and those subdomains belong to **different, mutually untrusting customers**.

Without a PSL entry, a browser permits an application on one subdomain to set a cookie scoped to `Domain=.vibsl.app`. That cookie is then sent to every other customer's application on the platform. Customers run their own authentication inside their apps, so this is cross-tenant session exposure by default, not a theoretical edge case.

`vibsl.io` serves the same role for team-tier customers and is included so the boundary is consistent as customers move between tiers.

This is the same rationale under which `vercel.app`, `netlify.app` and `workers.dev` are listed.

## Expected behaviour

| input | before | after |
|---|---|---|
| `getPublicSuffix("acme-shop.vibsl.app")` | `app` | `vibsl.app` |
| `Set-Cookie: Domain=.vibsl.app` from `acme-shop.vibsl.app` | accepted, sent to all tenants | **rejected by the browser** |
| `getPublicSuffix("tenant.vibsl.io")` | `io` | `vibsl.io` |

## Rollout

- Both domains are registered with more than 2 years remaining (`vibsl.io` to 2030-07-03, verifiable via whois; `vibsl.app` to 2029, Google's registry restricts public whois for `.app`).
- `_psl` TXT records will be added to both zones pointing at this PR, and left in place after validation.
- `security@vibsl.com` is a monitored mailbox controlled by VIBSL.