### PR TITLE
Add damnsite.page

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12842,6 +12842,10 @@ cfolks.pl
 cyon.link
 cyon.site
 
+// DamnSite : https://damnsite.com
+// Submitted by DamnSite Operations <hello@damnsite.com>
+damnsite.page
+
 // Dansk.net : http://www.dansk.net/
 // Submitted by Anani Voule <digital@digital.co.dk>
 biz.dk


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Description of Organization:**

DamnSite (damnsite.com), operated by SIGNAL9 LLC, is a website service for small businesses (barbershops, plumbers, bakeries and similar local businesses). Each customer receives a generated static website hosted on their own subdomain of `damnsite.page` (for example `tonys-barbershop.damnsite.page`). Customers manage their sites conversationally via SMS/chat; the product itself lives on the separate domain damnsite.com.

**Reason for PSL Inclusion:**

`damnsite.page` exclusively hosts third-party customer content, one independent small business per subdomain, with no first-party content at the apex (which 301-redirects to the product site). We request inclusion in the PRIVATE section so browsers treat each customer's subdomain as an independent site: preventing any customer's site from setting supercookies scoped to `*.damnsite.page` readable by other customers, and ensuring cookie/storage/SameSite isolation between unrelated businesses that happen to share our suffix. This is the same isolation model as other website-builder platforms already listed in the PRIVATE section.

**DNS verification:**

```
dig +short TXT _psl.damnsite.page
; will contain the URL of this pull request
```

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://damnsite.com/terms
  <!-- END FILL IN -->