### PR TITLE
Add pickz.gg to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15179,6 +15179,10 @@ pplx.app
 // Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
 perspecta.cloud
 
+// Pickz : https://pickz.gg
+// Submitted by Siddhant Varyambat <security@pickz.gg>
+pickz.gg
+
 // Ping Identity : https://www.pingidentity.com
 // Submitted by Ping Identity <security@pingidentity.com>
 forgeblocks.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission doesn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/2835, although 
the organization and description were not as substantial 
as desired, which required maintainers' time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace because extra cycles are not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 - None. This request does not seek to work around any third-party limit. We are not
   requesting inclusion for Let's Encrypt rate limits (we terminate TLS at Cloudflare
   using a single wildcard certificate for `*.pickz.gg`, so we issue no per-subdomain
   certificates), nor for Cloudflare for SaaS / custom hostname limits, nor for any
   iOS/Facebook-style restriction. The sole motivation is cookie and origin isolation
   between mutually untrusted user-controlled subdomains.
 <!-- END FILL IN -->

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail regarding the effort that was made to work directly 
with the third party or parties in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry in, the 
order of commented organization placement, and the order of sorting of entries. 
(Hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically, both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [ ] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- Provide the URL where an Internet user can access the abuse contact information -->
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->

  https://pickz.gg/abuse (not yet published — see "Abuse contact" in the rationale above)

 <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->

Pickz is a small, independent (single-founder, self-funded) software project operated
by me, Siddhant Varyambat. I am the founder, the sole engineer, and the registrant of
`pickz.gg`; I am submitting this request on my own behalf rather than for an employer.

Pickz is a link-and-landing-page product for affiliate marketers. Each person who signs
up claims a handle and is given their own subdomain, `{handle}.pickz.gg`, which serves
that person's public landing page and their tracked outbound links
(`{handle}.pickz.gg/l/{token}`). The content on those subdomains is authored and
controlled by the individual account holder, not by Pickz — the relationship is the same
shape as a hosting or page-builder provider: we operate the infrastructure, our users
control what is published under their own name.

The subdomain namespace is therefore a multi-tenant space of mutually untrusted parties.
Pickz itself runs on `pickz.gg` (marketing) and `app.pickz.gg` (the signed-in
application); the entire remainder of the `*.pickz.gg` namespace is delegated to users.

 <!-- END FILL IN -->

**Organization Website:**
<!-- Provide the website address of the org as a full URL (i.e. https://example.com) -->
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->

https://pickz.gg

 <!-- END FILL IN -->

## Reason for PSL Inclusion
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, iOS/Facebook, 
Cloudflare, etc.) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also reference any past issues or PRs 
specifically related to this submission or section.

Provide three or more sentences here that describe the purpose 
for which your PR should be included in the PSL. There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->

**Please note: this pull request is intentionally opened as a DRAFT and is not yet ready
for maintainer review.** Two of the checklist requirements are not met today and I have
deliberately left those boxes unchecked rather than affirm something untrue — details at
the end of this section. I will convert this to a ready-for-review pull request once both
are resolved. I would rather hold a slot honestly than consume volunteer review cycles on
a submission I know to be incomplete.

**Cookie isolation (primary reason).** Every account on Pickz publishes under its own
subdomain of `pickz.gg`, and those account holders do not trust one another. Without a
PSL entry, `pickz.gg` is the registrable domain for the whole namespace, which means any
one user's page can set a cookie with `Domain=pickz.gg` that is then transmitted to every
other user's subdomain and to our own application origin at `app.pickz.gg`. That is a
straightforward cross-tenant session-fixation and tracking vector. Listing `pickz.gg` in
the PRIVATE section makes each `{handle}.pickz.gg` its own registrable domain, so a
cookie set by one tenant cannot be scoped to, or read by, any other tenant.

**Origin/permission isolation (secondary).** Several browser mechanisms use the
registrable domain rather than the origin as their unit of separation — "same-site"
cookie treatment, storage-partitioning heuristics, and various privacy and permission
groupings. A PSL entry aligns those boundaries with the trust boundary that actually
exists in our system, which is per-account, not per-domain.

**Per-tenant reputation containment (secondary).** We chose subdomains over paths
(`pickz.gg/{handle}`) specifically so that a single abusive account is actionable in
isolation: blocklists and platform anti-spam systems operate per hostname, so one bad
actor gets `badactor.pickz.gg` flagged rather than tainting every other account's links.
A PSL entry makes that hostname boundary the same boundary the browser enforces.

**Deliberate acceptance of the apex impact.** I understand and specifically intend that
listing `pickz.gg` makes the apex a public suffix, and that as a result `pickz.gg` itself
can no longer set cookies, and that this is slow or impossible to roll back. Our
architecture already accounts for this: the apex serves only static marketing content
with no session state, and all authenticated application traffic lives on
`app.pickz.gg`, which remains a normal cookie-setting registrable domain under this
entry.

**Registration term.** I have left the two-year registration checkbox unchecked, and I
would appreciate maintainer guidance on how it should be interpreted for `.gg`. Nominet
(the `.gg` registry) does not sell multi-year terms in the usual sense: registry WHOIS
reports `Registration status: Registered until cancelled` with a `Registry fee due on
28th May each year`, so the registration does not expire on a fixed multi-year horizon
the way a `.com` does. My registrar shows a paid-through date of 2027-05-28 with
auto-renew enabled, which is the closest analogue to an expiry date and is less than two
years out.

I did not want to check a box asserting "at least two years remaining" when the honest
answer is "this TLD does not express registration that way, and the nearest equivalent
figure is under two years." If maintainers would like a paid-through date beyond
2028-08, I will arrange it and confirm here before requesting review. Either way I commit
to maintaining the registration in good standing, and to more than one year of remaining
term, for as long as the entry is listed.

**User count.** Pickz is pre-launch and has zero live tenants today, which is below the
2000-3000 distinct-user threshold in the guidelines. I am raising this request early
because the guidelines note the review is long-lead and because the subdomain-per-tenant
URL shape is already committed and is the irreversible part of the design — pasted
affiliate links cannot be relocated later. I fully accept that maintainers may prefer to
hold this until the user threshold is met, and I am not asking for an exception.

**Abuse contact.** The abuse-reporting page described below is not yet published, because
the production site is still a pre-launch skeleton. This is the second unchecked box. It
will be live at the URL given before I request review.

No prior issues or pull requests relate to this domain or section.

 <!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- 
The guidelines state that PSL inclusion is considered only for 
projects that have achieved a minimum of 2000 - 3000 distinct 
users or more. 

To be clear, 'users' is the number of distinct individuals 
working directly with a relationship with the requestor in 
using subnames of the requested space, and is not measured 
as the count of the audience of users that would visit to 
or interact with the namespace(s).

Please provide us this count, and identify if this is current 
actual count or an estimate. -->
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->

0 (actual). Pickz is pre-launch; there are no live tenants yet. Projected first-year
figure is well under one thousand distinct account holders. This count is stated honestly
and is below the guideline threshold — see the "User count" paragraph above.

 <!-- END FILL IN -->

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/3150"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/3150"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.
-->
<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->

The `_psl` TXT record is published and will be kept in place for as long as the entry
remains listed:

```
dig +short TXT _psl.pickz.gg
"https://github.com/publicsuffix/list/pull/3150"
```

 <!-- END FILL IN -->
