### PR TITLE
Add iqhs.pl (IQHost) to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14231,6 +14231,10 @@ home64.de
 ipv64.de
 ipv64.net
 
+// IQHost / IQ Group : https://iqhost.pl/
+// Submitted by Adam Buhl <admin@iqhost.pl>
+iqhs.pl
+
 // ir.md : https://nic.ir.md
 // Submitted by Ali Soizi <info@nic.ir.md>
 ir.md


### PR DESCRIPTION
### Submission type

Addition to the PRIVATE section.

### Domain

`iqhs.pl`

### Who we are

IQHost (https://iqhost.pl) is a Polish shared hosting provider. Every hosting account we provision receives a technical subdomain under `iqhs.pl` in the form `hostNNNNN.iqhs.pl`, used as the account's default hostname before the customer connects their own domain.

We are the owner and operator of `iqhs.pl`. The zone is served by our own nameservers (`ns1.iqhs.pl`, `ns2.iqhs.pl`, `ns3.iqhs.eu`).

### Why this belongs in the PRIVATE section

These subdomains are delegated to mutually-untrusting parties. As of today we operate **1945 subdomains of `iqhs.pl` across 1830 separate customer accounts**, each under the control of a different customer.

Because `iqhs.pl` is currently treated as a registrable domain, any one of those customers can set a cookie scoped to `.iqhs.pl`, which is then sent to every other customer's site under the same suffix. The same boundary problem applies to other origin-derived scoping that relies on the public suffix.

Adding `iqhs.pl` to the PRIVATE section gives each customer subdomain its own registrable-domain boundary and removes that cross-customer leak.

This is a long-running production service, not an experimental or short-term project.

### DNS validation

The `_psl` TXT record pointing to this PR will be published at `_psl.iqhs.pl` immediately after this PR is opened, per RFC 8553:

```
_psl.iqhs.pl. IN TXT "https://github.com/publicsuffix/list/pull/<this PR>"
```

### Contact

Adam Buhl <admin@iqhost.pl>
