### PR TITLE
Add avi.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12444,6 +12444,10 @@ myasustor.com
 *.atlassian-isolated-3p.com
 cdn.prod.atlassian-dev.net
 
+// Avi : https://avi.run
+// Submitted by Austen Collins <support@avi.run>
+avi.site
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.link


### PR DESCRIPTION
**Organization:** Avi (https://avi.run) — avi.site is the multi-tenant hosting domain for user-published websites on the Avi platform, one site per subdomain.

**Reason for listing:** cookie/storage isolation between independently-controlled tenant subdomains, per standard practice for such services (vercel.app, github.io, netlify.app precedents).

- [x] I am authorized to represent the registrant of avi.site
- [x] DNS validation: `_psl.avi.site` TXT → this PR's URL (in place)
- [x] We understand rollout takes months, removal is discouraged, and the domain's purpose (public multi-tenant hosting) is permanent