### PR TITLE
Add namynotsites.com (NAMYNOT Inc.)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14783,6 +14783,10 @@ cust.retrosnub.co.uk
 // Submitted by Paulus Schoutsen <infra@nabucasa.com>
 ui.nabu.casa
 
+// NAMYNOT Inc. : https://namynot.com
+// Submitted by Antonio Wells <hostmaster@namynot.com>
+namynotsites.com
+
 // Needle Tools GmbH : https://needle.tools
 // Submitted by Felix Herbst <security@needle.tools>
 needle.run


### PR DESCRIPTION
### Submission type
Addition to the **PRIVATE** section.

### Domain
`namynotsites.com`

### Organisation
NAMYNOT Inc. — https://namynot.com

### Role contact
hostmaster@namynot.com

### Rationale

NAMYNOT Inc. builds and hosts websites for independent small businesses. Every customer receives their own subdomain of `namynotsites.com` (for example `coreya-investments-llc.namynotsites.com`), and each of those subdomains belongs to a different, unrelated company.

Without a public suffix entry, browsers treat `namynotsites.com` as a single site. A script running on one customer's subdomain can set a cookie scoped to `.namynotsites.com`, which every other customer's site will then send, and same-site protections do not apply between them. These are independent businesses that have no relationship with one another, so that boundary needs to be real rather than assumed.

This is the case the private section exists for: a single organisation delegating subdomains to mutually untrusting third parties.

### Ownership / validation

The domain is registered to and controlled by NAMYNOT Inc. A `_psl.namynotsites.com` TXT record pointing to this pull request will be added immediately after it is opened, and I will comment here once it has propagated.

### Checklist

- [x] The addition is in the PRIVATE section
- [x] Entry is placed in alphabetical order within the section
- [x] A comment line identifies the organisation and a role contact address
- [x] The domain is under our control
- [ ] `_psl` DNS TXT record added (will be added and confirmed in a comment below)