### PR TITLE
Add opendesk.page

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15080,6 +15080,10 @@ chatgpt.site
 // Submitted by Sven Marnach <sven@opencraft.com>
 opencraft.hosting
 
+// OpenDesk : https://opendesk.ai.kr
+// Submitted by Seungmoon Choi <seungmoonchoi71@gmail.com>
+opendesk.page
+
 // OpenHost : https://registry.openhost.uk
 // Submitted by OpenHost Registry Team <support@openhost.uk>
 16-b.it


### PR DESCRIPTION
OpenDesk (https://opendesk.ai.kr) is a desktop app where non-developer users create AI agent colleagues; those colleagues build and publish static homepages for small businesses. Each user site is served on its own subdomain under opendesk.page (e.g. https://test-bakery-0817.opendesk.page — live). Sites are user-generated content, so we request inclusion in the PRIVATE section to prevent domain-wide cookies and ensure browsers treat each user site as a separate site.

- Registrant/operator: OpenDesk (Nerdevs)
- Domain: opendesk.page (Cloudflare Registrar)
- DNS `_psl.opendesk.page` TXT record pointing to this PR will be added right after submission.
- Serving: Cloudflare Workers + R2, wildcard `*.opendesk.page`