### PR TITLE
Add cin.ufpe.br to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14194,6 +14194,10 @@ se.leg.br
 sp.leg.br
 to.leg.br
 
+// Centro de Informática da Universidade Federal de Pernambuco (CIn-UFPE) : https://www.cin.ufpe.br/
+// Submitted by Nadja Maria Soares Lins <seu_email@cin.ufpe.br>
+cin.ufpe.br
+
 // intermetrics GmbH : https://pixolino.com/
 // Submitted by Wolfgang Schwarz <admin@intermetrics.de>
 pixolino.com


### PR DESCRIPTION
**Motivation:** 
The Centro de Informática (CIn) at the Federal University of Pernambuco (UFPE) provisions independent subdomains under `cin.ufpe.br` for our students, faculty, and research laboratories. 

Currently, our users are unable to verify and host their academic projects on PaaS providers like Vercel or Netlify. Because `cin.ufpe.br` is not on the PSL, these platforms automatically request apex domain (`ufpe.br`) verification. As the CIn network administration team, we hold administrative authority over `cin.ufpe.br`, but not over the university's apex domain.

### Checklist of required steps

- [x] Description of Organization
- [x] Robust Reason for PSL Inclusion
- [x] DNS verification via `dig`
- [x] Each domain listed in the `PRIVATE` section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

### Submitter affirms the following:

- [x] We are listing any third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see Issue #1245 as a well-documented example)
  - Vercel
  - Netlify
- [ ] This request was not submitted with the objective of working around other third-party limits.
- [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the `_psl` DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
- [x] The Guidelines were carefully read and understood, and this request conforms to them.
- [x] The submission follows the Guidelines on formatting and sorting.
- [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

### Abuse Contact:

- [x] Abuse contact information (email or web form) is available and easily accessible.
URL where abuse contact or abuse reporting form can be found:
https://www.cin.ufpe.br/

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.
To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.
PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.
(Link: https://github.com/publicsuffix/list/wiki/Guidelines#affectation-and-propagation-expectations)

- [x] Yes, I understand. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. Proceed anyway.