### PR TITLE
Add leoplaza.com and leohungry.com (Asaleo)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12409,6 +12409,11 @@ appwrite.network
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
+// Asaleo : https://asaleo.com
+// Submitted by William Nguyen <tien.405@gmail.com>
+leoplaza.com
+leohungry.com
+
 // Aquapal : https://aquapal.net/
 // Submitted by Aki Ueno <admin@aquapal.net>
 f5.si

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12409,11 +12409,6 @@ appwrite.network
 // Submitted by Thomas Orozco <thomas@aptible.com>
 on-aptible.com
 
-// Asaleo : https://asaleo.com
-// Submitted by William Nguyen <tien.405@gmail.com>
-leoplaza.com
-leohungry.com
-
 // Aquapal : https://aquapal.net/
 // Submitted by Aki Ueno <admin@aquapal.net>
 f5.si
@@ -12427,6 +12422,11 @@ arvanedge.ir
 user.aseinet.ne.jp
 gv.vc
 d.gv.vc
+
+// Asaleo : https://asaleo.com
+// Submitted by William Nguyen <tien.405@gmail.com>
+leoplaza.com
+leohungry.com
 
 // Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
 // Submitted by Hector Martin <marcan@euskalencounter.org>


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig — `_psl` records are being published now that this PR has a number; see below.
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

### Description of Organization

Asaleo (https://asaleo.com) is enterprise resource planning software for small and medium manufacturers and retailers. Each customer business runs its own instance, and those that sell online are given a storefront on a marketplace domain we operate, one shop per subdomain.

### Reason for PSL Inclusion

Two marketplace domains host storefronts belonging to unrelated merchants:

- `leoplaza.com` — general marketplace; each merchant's storefront is served at `<merchant>.leoplaza.com`
- `leohungry.com` — food and drink marketplace; same structure

Every subdomain is operated by a different, unrelated business, and shoppers sign in and check out on them. Without a PRIVATE section entry a browser treats all of these as one site, so a cookie set by one merchant's storefront is readable by every other merchant's storefront. These entries make each storefront an independent origin for cookie and storage purposes, which is the same boundary the merchants would have if each ran on its own domain.

We are filing before the marketplaces open rather than after, because adding the entries once shoppers already hold sessions would change cookie behaviour underneath them.

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook

 None. This request is not made to work around any third-party limit. We hold no rate limit, certificate limit or platform restriction that this entry would relieve, and have not approached any third party about one.

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.
 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.
 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.
 * [ ] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

 Not yet. The address in the submitted block is currently a personal one. A role-based address on `asaleo.com` is being provisioned and this PR will be updated with it before it is ready for review.

**Abuse Contact:**

* [ ] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:

  Not yet published. The marketplaces are not open to shoppers and the abuse reporting page is being put in place; this PR will be updated with the URL before it is ready for review.

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.

---

**Note to maintainers:** three items above are honestly unticked rather than claimed — the `_psl` records, the role-based address and the abuse contact page. All three are in progress and this PR will be updated when each is in place. Please treat it as not yet ready for review until then.
