### PR TITLE
Add teable.app to private domains (Teable)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15995,6 +15995,10 @@ p.tawkto.email
 // Submitted by Bruno Lorensi <suporte@tche.br>
 tche.br
 
+// Teable : https://teable.ai
+// Submitted by Teable Engineering <dev@teable.io>
+teable.app
+
 // team.blue : https://team.blue
 // Submitted by Cedric Dubois <psl-sh@team.blue>
 site.tb-hosting.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://teable.ai (site footer contact) — abuse reports are handled via support@teable.io
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Teable is a no-code database and AI app-builder platform. Users build database-backed applications with an AI agent and publish them as standalone web apps. Each published app is served on its own subdomain of `teable.app` (for example `quran.teable.app`, `se.teable.app`); the subdomains host user-generated content that is authored and controlled by independent, mutually-untrusting customers, while our own product and marketing sites live on separate domains (`teable.ai`, `teable.io`). The `teable.app` apex hosts no first-party content (it only redirects to our main site), so the zone functions purely as a namespace for customer deployments.

I am an engineer at Teable responsible for the app-publishing infrastructure, submitting on behalf of the company.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://teable.ai
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Subdomains of `teable.app` are operated by independent customers who deploy their own applications, including applications with their own login systems and cookies. We are requesting inclusion in the PRIVATE section for cookie security: one customer's app must not be able to set or read cookies scoped to `.teable.app` that would affect other customers' apps. These are mutually-untrusting tenants on sibling subdomains, each running its own authentication, so supercookie-style scoping to the shared parent domain is a real cross-tenant risk.

We are not seeking to work around any third-party rate limits. The domain is registered through Vercel's registrar with auto-renewal enabled, and we commit to maintaining registration and the `_psl` TXT record for as long as the entry remains listed.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
~5 thousand (actual count: 4,947 distinct registered users have created apps in the app builder, each of which receives a `teable.app` subdomain on publish; the platform has ~134,000 registered users overall and publishing is growing).
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.teable.app
"https://github.com/publicsuffix/list/pull/3168"
```
(The `_psl` TXT record is in place.)
<!-- END FILL IN -->
