### PR TITLE
Remove non-wildcard `aivencloud.com`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11344,7 +11344,6 @@ beep.pl
 // Aiven : https://aiven.io/
 // Submitted by Aiven Security Team <security+appdomains@aiven.io>
 aiven.app
-aivencloud.com
 *.aivencloud.com
 
 // Akamai : https://www.akamai.com/


### PR DESCRIPTION
Related: https://github.com/publicsuffix/list/pull/3019

This PR was submitted to fix a merge error where a `*.aivencloud.com` was merged into the PSL with the existing `aivencloud.com` entry still in place causing downstream confusion.

See also: https://github.com/publicsuffix/list/pull/2771#issuecomment-5297727061 (Comment by @dnsguru)
> We typically are fairly binary about one or the other (with or without) the wildcard - because outside of the algorythm (which different downstream interpret differently), different interpretations happen, and having both typically is problematic due to how it behaves in the wild as result.

@simon-friedberger 