### PR TITLE
Add mosas.host

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14761,6 +14761,10 @@ mocha-sandbox.dev
 // Submitted by Elizabeth Southwell <elizabeth@modx.com>
 modx.dev
 
+// Mosas : https://mosas.host/
+// Submitted by Dion Ren <me@dionren.com>
+mosas.host
+
 // Mozilla Foundation : https://mozilla.org/
 // Submitted by glob <glob@mozilla.com>
 bmoattachments.org

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14761,7 +14761,7 @@ mocha-sandbox.dev
 // Submitted by Elizabeth Southwell <elizabeth@modx.com>
 modx.dev
 
-// Mosas : https://mosas.host/
+// Mosas : https://mosas.ai/
 // Submitted by Dion Ren <me@dionren.com>
 mosas.host
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14762,7 +14762,7 @@ mocha-sandbox.dev
 modx.dev
 
 // Mosas : https://mosas.ai/
-// Submitted by Dion Ren <me@dionren.com>
+// Submitted by Dion Ren <security@mosas.ai>
 mosas.host
 
 // Mozilla Foundation : https://mozilla.org/


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://mosas.ai/abuse
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Mosas (https://mosas.ai) is an upcoming, permanently free, self-hosted AIGC creation platform. Users deploy the software on macOS, Windows, or Linux and connect it either to cloud large-language-model APIs or to model services they run themselves.

Because the creation platform is used by a team on a private network and/or a public network, each deployment needs a stable hostname. We therefore let operators apply for a second-level name under mosas.host (for example studio.mosas.host). That name is pointed at the instance's private-network IP, or at a public IP they have mapped, so teammates can reach the instance without sharing cookies or login state with other operators.

I am Dion Ren (GitHub: dionren), the domain owner and operator of mosas.host / mosas.ai, submitting this as the authorized representative, using the role inbox security@mosas.ai.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://mosas.ai
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Each *.mosas.host name is issued to a separate, mutually untrusting operator of a self-hosted Mosas instance. Those operators must not be able to set or read cookies for one another, or for the product site at mosas.ai.

Expected behaviour after inclusion:
- a cookie set on studio-a.mosas.host is sent only to studio-a.mosas.host
- that cookie is not sent to studio-b.mosas.host
- that cookie is not sent to mosas.host or mosas.ai

The same boundary matters for SameSite. Browsers decide same-site by registrable domain, so today studio-a.mosas.host and studio-b.mosas.host are treated as the same site, and one operator's page counts as a same-site context for another operator's instance. Listing mosas.host makes each operator's name its own site, which is the behaviour these deployments need.

The names are ordinary per-operator hostnames (A/AAAA or similar) targeting the operator's LAN IP or a publicly mapped IP. This is not an IP-encoded wildcard scheme, and it is not a request to work around any third-party rate limit or product restriction.

mosas.host has more than two years remaining on registration. We will keep the _psl TXT record in place for as long as the entry should remain in the list.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
The product is about to launch. We are not citing a fabricated user count. We are requesting inclusion now so that cookie isolation is in place before operators are issued *.mosas.host names.
<!-- END FILL IN -->

## DNS Verification
<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.mosas.host
"https://github.com/publicsuffix/list/pull/3172"
```

This TXT record is live at _psl.mosas.host and will be left in place.
<!-- END FILL IN -->