### PR TITLE
Add sahabti.app to PSL (Sahabti)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15492,6 +15492,10 @@ io.noc.ruhr-uni-bochum.de
 // Submitted by Tech Support <support@rasnet.ru>
 ras.ru
 
+// Sahabti : https://sahabti.com
+// Submitted by Mohammad Shehadeh <support@sahabti.com>
+sahabti.app
+
 // Sakura Frp : https://www.natfrp.com
 // Submitted by Bobo Liu <support@natfrp.cloud>
 nyat.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. This request does not seek to work around any third-party limit. TLS for `*.sahabti.app` is a single first-level wildcard certificate issued by Cloudflare Universal SSL, so no Let's Encrypt rate limit is involved, and no Cloudflare limit is being circumvented.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://sahabti.com/legal/security (section "Abuse controls on public tenant endpoints" — reports to support@sahabti.com with "Abuse" in the subject). The suffix apex `https://sahabti.app` redirects to that page.
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Sahabti is a cloud hosting platform. Customers create managed database instances (PostgreSQL, MySQL, MariaDB, Redis-compatible and others) and deploy their own web applications from GitHub repositories onto infrastructure that we own and operate. Each deployed application runs in its own container and is served at its own first-level subdomain of `sahabti.app`, in the form `<name>-<random>.sahabti.app` (for example `shop-k4f9x2.sahabti.app`). These subdomains are allocated automatically by the platform and belong to different, mutually untrusted customers who run code we do not author or review.

Our own company website, customer dashboard, identity service and API are deliberately kept on a separate registrable domain, `sahabti.com`. `sahabti.app` exists solely to host customer workloads and serves no first-party site of ours; its apex only redirects to our security page.

I am Mohammad Shehadeh, founder of Sahabti and the engineer responsible for its infrastructure, including the `sahabti.app` DNS zone and the routing layer that serves these subdomains. Sahabti is the registrant of `sahabti.app` (registered through Namecheap; the registration is kept at least two years out for as long as the domain is listed).
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://sahabti.com
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Cookie and origin isolation between customers. Every first-level subdomain of `sahabti.app` is a distinct customer's application running code we do not control. Without a PSL entry, browsers treat `sahabti.app` as one registrable domain: an application at `a-k4f9x2.sahabti.app` can set a cookie with `Domain=.sahabti.app`, which the browser then sends to `b-p7m3qd.sahabti.app` and to every other customer's application (cookie tossing and cross-tenant session fixation). The same grouping also makes unrelated customers' sites "same-site" to one another for SameSite cookie purposes. This is the standard multi-tenant hosting case for which `vercel.app`, `netlify.app`, `herokuapp.com` and `github.io` are listed, and the same remedy applies: treating `sahabti.app` as a public suffix makes each customer subdomain its own registrable domain.

This is not a request to obtain certificates or to raise any third-party limit: TLS is one Cloudflare Universal SSL wildcard for `*.sahabti.app`, and the platform issues nothing per customer. Nor does it affect any first-party property of ours, since everything we operate ourselves is on `sahabti.com`. We understand that after inclusion no cookie can be set on `sahabti.app` itself, and that is the intended outcome.

Registration of `sahabti.app` will be kept at more than two years remaining while listed. The `_psl.sahabti.app` TXT record will remain in place for the lifetime of the listing, and `support@sahabti.com` is a monitored role address.

Expected behaviour after inclusion:

```
registrable domain of  shop-k4f9x2.sahabti.app  ->  shop-k4f9x2.sahabti.app   (today: sahabti.app)
cookie Domain=.sahabti.app set by any customer site  ->  rejected by the browser
```
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Estimate, not a current count: the platform is in pre-launch and is onboarding its first customers now. We are submitting ahead of scale because the isolation this provides has to be in place before unrelated customers share the suffix, not after, and because browser propagation takes months. If the maintainers prefer to defer until the 2–3k distinct-customer threshold is reached, we are happy to keep this PR open or to reopen it at that point.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.sahabti.app
"https://github.com/publicsuffix/list/pull/3173"
```
<!-- END FILL IN -->
