### PR TITLE
Add pabbly.app to the private section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15157,6 +15157,10 @@ ox.rs
 // Submitted by Charly Coste <changaco@changaco.oy.lc>
 oy.lc
 
+// Pabbly : https://www.pabbly.com
+// Submitted by Pabbly Studio Team <admin@pabbly.com>
+pabbly.app
+
 // Pagefog : https://pagefog.com/
 // Submitted by Derek Myers <derek@pagefog.com>
 pgfog.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail regarding the effort that was made to work directly 
with the third party or parties in attempting to address this within their 
rationale response below.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://www.pabbly.com/report-abuse/
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->

Pabbly is a software company that builds business automation and marketing products. One of these is Pabbly Studio, an AI application builder at studio.pabbly.com, where a customer describes the application they want and the builder generates and deploys it for them.

Every generated application is served on its own subdomain of pabbly.app. The applications belong to our customers, not to us — we provide the hosting, the runtime and the subdomain. Each one runs in an isolated VM with its own database, and the customers are unrelated to one another. This is the same hosting model as vercel.app, netlify.app, lovable.app and onrender.com, all of which are already listed.

pabbly.app carries only these customer applications. Our own product and marketing sites are on pabbly.com, and the pabbly.app root redirects to studio.pabbly.com.

The builder itself is behind sign-in, so studio.pabbly.com will show a login page rather than the product. The deployed applications are public, and we are happy to share example subdomains if you would like to see the model in practice.

I am a software engineer at Pabbly working on Pabbly Studio, and I am submitting this on behalf of the company. The role mailbox in the .dat section header is admin@pabbly.com, which is actively monitored.

<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://www.pabbly.com
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->

Cookie and storage isolation between customer applications.

Pabbly Studio hosts customer applications, each deployed on its own subdomain of pabbly.app. The customers are unrelated businesses and individuals and are mutually untrusted. A significant share of these applications implement their own authentication and set their own session cookies.

Because every application shares pabbly.app as its registrable domain, browsers currently treat them all as one site. Any application can set a cookie scoped to the parent domain, and that cookie would then be sent to every other customer's application on the domain. The same applies to storage partitioning and other same-site boundaries. Nothing at the browser level prevents this today.

Application code on our platform is generated from customer prompts, so we do not control the cookie attributes each application writes. We can give guidance but cannot guarantee every application scopes its cookies correctly. A PSL entry moves that boundary from each application's own code to the browser, where it is enforced regardless of what the application does. Secondarily, it would also mean one customer's subdomain cannot affect the standing of the others.

pabbly.app expires on 2029-08-04. We will renew it while more than one year of term remains, and will keep the _psl TXT record in place for as long as the entry is listed.

We are not aware of any prior issues or pull requests relating to this domain or section.

<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Pabbly serves a large user base across its products, with over 190,000 monthly active users. Pabbly Studio is the newest of these products, and its customers are the individuals who hold subdomains under pabbly.app — a growing subset of that wider base. We are happy to share precise current figures with the maintainers if that would help the review.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
$ dig +short TXT _psl.pabbly.app
"https://github.com/publicsuffix/list/pull/3175"
```
<!-- END FILL IN -->
