### PR TITLE
Remove XnBay Technology entries from suffix list

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16343,12 +16343,6 @@ grok.me
 *.xenonconnect.de
 half.host
 
-// XnBay Technology : http://www.xnbay.com/
-// Submitted by XnBay Developer <developer.xncloud@gmail.com>
-xnbay.com
-u2.xnbay.com
-u2-local.xnbay.com
-
 // XS4ALL Internet bv : https://www.xs4all.nl/
 // Submitted by Daniel Mostertman <unixbeheer+publicsuffix@xs4all.net>
 cistron.nl


### PR DESCRIPTION
The latest WHOIS data shows that the xnbay.com domain name has expired, been deleted, and then re-registered by a domain name registration platform.

