### PR TITLE
Add jeanai-site.cz (JeanAI customer-site preview domain)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14266,6 +14266,10 @@ iserv.host
 // Submitted by Ispmanager infrastructure team <infrastructure@ispmanager.com>
 ispmanager.name
 
+// JeanAI : https://jeanai.cz
+// Submitted by Lukáš Klimeš <support@jeanai.cz>
+jeanai-site.cz
+
 // Jelastic, Inc. : https://jelastic.com/
 // Submitted by Ihor Kolodyuk <ik@jelastic.com>
 mel.cloudlets.com.au


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/) — disclosed for transparency: listing changes which rate-limit bucket each customer subdomain falls into. This is a side effect of the correct security boundary rather than the submission's objective; details in the rationale below.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://jeanai.cz/contact (support@jeanai.cz — the same monitored role address used in the list entry)
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
JeanAI (jeanai.cz) is a Czech website-building and business-automation platform: small businesses describe what they need in chat, and the platform generates and publishes a website for them, then keeps operating it (updates, e-mail, AI agents). The submitter is the platform's owner and operator, a sole proprietor registered in the Czech Republic (IČO 11894547), acting directly on behalf of the organization. The domain being submitted, `jeanai-site.cz`, is dedicated platform infrastructure: it exists solely to hand out preview addresses for customers' published sites, hosts no content at its apex, and is deliberately a separate registration from the application's own domain (`jeanai.cz`) precisely so it can be listed here.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://jeanai.cz
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Every website published through the platform automatically receives a free preview address as a subdomain of `jeanai-site.cz` (for example `sklep-kafe.jeanai-site.cz`), each served from that customer's own hosting account. The subdomains therefore belong to mutually untrusting parties — different businesses that have no relationship with each other — which is the textbook case for a PRIVATE-section entry: without listing, any customer site can set cookies scoped to the shared apex and have them sent to every other customer's site. Cookie and storage isolation between these parties is the purpose of this submission.

For transparency: listing also changes how Let's Encrypt's per-registered-domain rate limit applies (each subdomain would get its own bucket instead of all customers sharing one). We state this openly rather than as an objective — the isolation boundary this submission draws (one customer = one private domain) is the same boundary the certificate limits follow, and at our current volume the shared bucket is not yet a practical constraint, so this request is not motivated by hitting a limit nor by working around one.

The domain's registration is maintained long-term (auto-renewal configured for 9 years; the registration term itself is kept at two-plus years remaining, as affirmed in the checklist), the `_psl` record will be kept in place for as long as the entry exists, and the entry will be maintained (updated or removed) as the platform evolves.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Fewer than 0.1 at the time of submission — this is the actual current count, stated honestly: the platform is in its first-customers phase. We are submitting early and deliberately, because the parties on these subdomains are mutually untrusting from the second customer onward, and because propagation takes months — by the time the count is in the thousands, starting the process would be far too late. We fully understand if the maintainers prefer to defer this request until the user count meets the guideline threshold.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.jeanai-site.cz
"https://github.com/publicsuffix/list/pull/3182"
```
<!-- END FILL IN -->
