### PR TITLE
Add swipebuild.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15933,6 +15933,10 @@ storage.supabase.co
 supabase.in
 supabase.net
 
+// SwipeBuild : https://swipebuild.app
+// Submitted by Long Tang <swipebuild@outlook.com>
+swipebuild.app
+
 // Syncloud : https://syncloud.org
 // Submitted by Boris Rybalkin <syncloud@syncloud.it>
 syncloud.it


### PR DESCRIPTION
Add SwipeBuild entry to the PRIVATE section.

# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. This request is not intended to work around any third-party limits.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://swipebuild.app/ (abuse contact e-mail is shown on the page: swipebuild@outlook.com)
  <!-- END FILL IN -->

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
SwipeBuild is an AI app builder that lets small service businesses in Japan (independent salons, personal trainers, coaches and instructors) create and publish small web apps - diagnostic quizzes, pre-booking intake forms and price simulators - without writing code. Each published app is customer-authored content and is served on its own subdomain of swipebuild.app (for example https://sw5szkna.swipebuild.app/), while our own application and marketing pages live on a separate domain, so swipebuild.app is dedicated exclusively to end-customer content. I am the founder and developer of SwipeBuild, the registrant of the swipebuild.app domain, and I operate the serving infrastructure for it; I am submitting this request on behalf of the service.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://swipebuild.app
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Cookie security between mutually untrusting tenants. Content under each subdomain of swipebuild.app is authored by a different customer. Without a PSL entry, a page on one customer's subdomain could set a cookie with `domain=swipebuild.app` that browsers would then send to every other customer's visitors (cookie injection / supercookie risk). Listing swipebuild.app in the PRIVATE section makes browsers treat each customer subdomain as a separate site, which is the correct boundary for this multi-tenant, user-content platform - the same reason other per-customer subdomain platforms in the PRIVATE section are listed.

The domain is dedicated to customer content only; we do not need first-party cookies on the apex, and the page at the apex only describes the service and provides the abuse contact. The serving stack is Amazon S3 + CloudFront with a wildcard certificate for `*.swipebuild.app`, and each tenant page is static HTML with a strict Content-Security-Policy.

Registration term: swipebuild.app is registered until 2031 (a 5-year registration made in 2026), which is more than two years beyond this submission, with auto-renew and transfer lock enabled. We commit to maintaining more than one year of remaining term and to keeping the `_psl` TXT record in place for as long as we wish to remain listed.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Fewer than 0.01 thousand today (actual count: single-digit businesses in our first onboarding wave; the service has just launched its delivery infrastructure). Our 12-month target is on the order of 1-2 thousand distinct businesses (estimate). We are submitting early because the security boundary matters from the first published tenant, and we understand that inclusion is at the maintainers' discretion given the current scale.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.swipebuild.app
"https://github.com/publicsuffix/list/pull/3185"
```
(The TXT record is in place.)
<!-- END FILL IN -->
