### PR TITLE
Add dispensary.shop (Flowhub) to PRIVATE domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13658,6 +13658,10 @@ fldrv.com
 // Submitted by Parsa Ghadimi <dev@fleek.xyz>
 on-fleek.app
 
+// Flowhub : https://www.flowhub.com
+// Submitted by Hugh Hunter <hugh.hunter@flowhub.com>
+dispensary.shop
+
 // FlutterFlow : https://flutterflow.io
 // Submitted by Anton Emelyanov <anton@flutterflow.io>
 flutterflow.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Note on registration term:** RDAP now shows `dispensary.shop` expiring **2029-09-09** (renewed 2026-08-24; last changed 2026-08-24T22:54:37Z). More than two years remaining. We will keep `_psl.dispensary.shop` in place and maintain the registration in good standing with more than one year left.

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. Let's Encrypt per-registrable-domain rate limits would improve as a side effect of PSL inclusion; that is **not** the reason for this request (we already issue per-store certificates via Cloudflare for SaaS for vanity hosts, and a wildcard for `*.dispensary.shop`).
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Submitter contact:** hugh.hunter@flowhub.com (Hugh Hunter, software engineer at Flowhub, authorized representative of the domain registrant). Public company contact: hello@flowhub.com.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://www.flowhub.com/contact and mailto:hello@flowhub.com (also listed on https://flowhub.com/privacy-policy)
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization
<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Flowhub is a cannabis retail software company. We operate a point-of-sale system and a hosted ecommerce storefront product. Each merchant (an independent dispensary, unaffiliated with other merchants on the platform) is issued one or more hostnames on `dispensary.shop` of the form `{store}.dispensary.shop` (example: `stiiizy.dispensary.shop`). Those merchants are mutually untrusting third parties: they do not share customers, sessions, or marketing pixels, and they must not be able to set cookies that other merchants' storefronts would receive.

I am Hugh Hunter, a software engineer at Flowhub. I am submitting this as an authorized representative of the domain owner. `dispensary.shop` has been the production ecommerce hostname space since 2016 (RDAP registration 2024-09-09 reflects a registrar change/re-registration; the name has been in continuous use for storefronts for years). Live examples include `stiiizy.dispensary.shop` and many other `{merchant}.dispensary.shop` storefronts.

This is the same operating model as `myshopify.com` (already listed): a commerce platform that issues subdomains to independent merchants.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://www.flowhub.com
<!-- END FILL IN -->

## Reason for PSL Inclusion
<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
**Cookie isolation between mutually untrusting merchant storefronts.**

Browsers currently treat `foo.dispensary.shop` and `bar.dispensary.shop` as the same site (eTLD+1 = `dispensary.shop`). Third-party marketing scripts that we and our merchants load — Meta's `fbevents.js` in particular — walk up the hostname and set first-party identity cookies (`_fbp`) with `Domain=.dispensary.shop`. That cookie is then sent to every other merchant on the suffix.

We have verified this two ways:

1. Source inspection of production `fbevents.js`: the cookie writer unconditionally emits `domain=.<suffix>` and stops at the first suffix the browser will accept. `.shop` is already a public suffix, so the loop accepts `.dispensary.shop`.
2. A live Chromium experiment on `stiiizy.dispensary.shop` registered `_fbp` with `Domain: .dispensary.shop` (value `fb.1.…`, subdomain index 1).

Consequence: one `_fbp` identity is shared across all tenants; attribution and consent leak between unrelated businesses. The same class of bug exists for GA/GTM tags that default cookie_domain to the registrable domain.

Listing `dispensary.shop` in the PRIVATE section makes each `{store}.dispensary.shop` its own site, matching `myshopify.com`, `github.io`, `herokuapp.com`, `netlify.app`, and `vercel.app`. After inclusion, `document.cookie = "…; domain=.dispensary.shop"` is rejected and Meta's walk-up falls through to the tenant host.

This request is **not** to circumvent Let's Encrypt, Cloudflare, iOS, or Facebook product limits. Those are not the goal. Cookie isolation for mutually untrusting merchants is.

**Expected input / output**

| Input | Today | After PSL |
| --- | --- | --- |
| Cookie `Domain=.dispensary.shop` from `stiiizy.dispensary.shop` | accepted | rejected |
| Cookie host-only on `stiiizy.dispensary.shop` | accepted | accepted |
| Same-site for `a.dispensary.shop` vs `b.dispensary.shop` | same site | different sites |

We are **not** listing environment suffixes (`dev.dispensary.shop`, `uat.dispensary.shop`). Those are internal. Listing the parent suffix is sufficient.

**Registration term:** `dispensary.shop` now expires **2029-09-09** (>2 years remaining). We will keep `_psl.dispensary.shop` in place and maintain the registration in good standing with more than one year left.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
On the order of **hundreds** of distinct merchant organizations currently issued a unique `{store}.dispensary.shop` hostname (each serving public ecommerce). That is below the informal 2–3k-tenant guideline. We are requesting inclusion because the security property (cookie isolation between mutually untrusting merchants) cannot be enforced by browsers without a PSL entry — the same reason `myshopify.com` is listed — not because we need a rate-limit workaround. Happy to provide a representative list of active 3LDs if useful.
<!-- END FILL IN -->

## DNS Verification
<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
$ dig +short TXT _psl.dispensary.shop
"https://github.com/publicsuffix/list/pull/3186"
```
This `_psl` TXT will be left in place for as long as we want `dispensary.shop` listed.
<!-- END FILL IN -->
