### PR TITLE
Add algago.com to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11372,9 +11372,11 @@ barsy.ca
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate
 *.alces.network
+
 // AlgaGo : https://algago.com/
 // Submitted by Aayat Zahara <abuse@algago.com>
 algago.com
+
 // Alibaba Cloud API Gateway
 // Submitted by Alibaba Cloud Security <cloud_product_security_team@alibaba-inc.com>
 alibabacloudcs.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11372,7 +11372,9 @@ barsy.ca
 // Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
 *.compute.estate
 *.alces.network
-
+// AlgaGo : https://algago.com/
+// Submitted by Aayat Zahara <abuse@algago.com>
+algago.com
 // Alibaba Cloud API Gateway
 // Submitted by Alibaba Cloud Security <cloud_product_security_team@alibaba-inc.com>
 alibabacloudcs.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://algago.com/contact.php
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
AlgaGo is a free subdomain hosting platform that lets individuals and organizations claim their own subdomain (for example, yourname.algago.com) with free SSL and a simple dashboard where they publish their own posts and pages. The platform serves students, freelancers, small businesses, and content creators who need an online presence without purchasing a domain. Each subdomain is operated independently by its own user, and these users are unrelated, mutually-untrusting parties. I, Aayat Zahara, am the owner and operator of AlgaGo, and I am submitting this request as the authorized representative of the organization. The role-based contact admin@algago.com is actively monitored.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://algago.com
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
AlgaGo issues subdomains under algago.com to mutually-untrusting third parties. Each user receives an isolated subdomain where they publish their own content, and these users do not trust one another.

Without algago.com listed in the PRIVATE section, browsers treat algago.com as the registrable eTLD+1, so cookies set without an explicit Domain attribute, as well as browser storage, can be shared across completely independent customer subdomains. This creates cross-tenant security risks including cookie and session leakage, weakened SameSite/CSRF protections, and broken storage partitioning between untrusted tenants.

Listing algago.com establishes the correct public-suffix boundary so that each user subdomain is treated as a separate site, enabling proper cookie isolation, SameSite/CSRF protection, and storage partitioning between tenants. This request is made purely for cookie and storage security and is not intended to work around any third-party limits. The domain registration is maintained in good standing with a term longer than two years, and we shall keep the `_psl` TXT verification record in place for as long as the entry remains in the list.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Approximately 3.2 thousand distinct users (current actual count), each issued their own subdomain under algago.com.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.algago.com
"https://github.com/publicsuffix/list/pull/3187"
```
<!-- END FILL IN -->