### PR TITLE
Add australis.id and learn.australis.id (Australis)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12446,6 +12446,11 @@ myasustor.com
 *.atlassian-isolated-3p.com
 cdn.prod.atlassian-dev.net
 
+// Australis : https://australis.io
+// Submitted by Omar Fareda <admin@australis.io>
+australis.id
+learn.australis.id
+
 // AVM : https://avm.de
 // Submitted by Andreas Weise <a.weise@avm.de>
 myfritz.link


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None — this request works around no third-party limits.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://australis.io/abuse
  <!-- END FILL IN -->

---

**Description of Organization**

Australis (https://australis.io) is an AI application builder: users describe an app in plain language and the product generates, verifies, and can publish it as a real website. We also run Australis Academy, a structured course in which learners build and ship their own sites.

**Reason for PSL Inclusion**

- `australis.id` hosts user-published sites at `{name}.australis.id`. Each subdomain is an independent site operated by a different registered user.
- `learn.australis.id` hosts Academy learners' published sites at `{name}.learn.australis.id` — a second, distinct population of user content one level down, which is why it is listed separately (the parent entry alone would not isolate learner sites from one another).

Both populations are arbitrary user-generated static sites, so we request PSL entries to give each subdomain its own cookie/storage boundary and its own reputation in browser security systems, per the standard practice for user-content hosts (github.io, vercel.app, netlify.app). Our product's own application and API run on a different registrable domain (australis.io) and are unaffected.

The service is live today; publishing requires a signed-in account, is rate-limited, and abuse handling (takedown + account closure) is in place, with the abuse contact published at https://australis.io/abuse.

**DNS verification**

`_psl.australis.id` and `_psl.learn.australis.id` TXT records pointing at this PR are in place (added immediately after opening, since the record value carries the PR URL) — verifiable with:

    dig +short TXT _psl.australis.id
    dig +short TXT _psl.learn.australis.id
