### PR TITLE
Add nysky.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15023,6 +15023,10 @@ freeddns.us
 nsupdate.info
 nerdpol.ovh
 
+// nysky : https://nysky.no
+// Submitted by Christoffer Nyborg <kontakt@nysky.no>
+nysky.app
+
 // O3O.Foundation : https://o3o.foundation/
 // Submitted by the prvcy.page Registry Team <info@o3o.foundation>
 prvcy.page


### PR DESCRIPTION
nysky.app hosts third-party customer applications on subdomains (`<app>.nysky.app`), similar to vercel.app/netlify.app which are already listed. Each subdomain belongs to a different customer of the nysky platform (https://nysky.no), a Norwegian PaaS. Listing prevents cross-customer cookie injection (`Domain=nysky.app`) and gives each customer app its own cookie/origin boundary.

The apex serves our own marketing site and uses host-only cookies only, so the listing is safe for first-party use.

Requirements:
- Sorted alphabetically in the PRIVATE DOMAINS section (between nsupdate.info and O3O.Foundation)
- `_psl.nysky.app` TXT record pointing to this PR will be published immediately after opening (DNS is operated on our own authoritative servers, ns1/ns2.nysky.no)

Contact: kontakt@nysky.no