### PR TITLE
Add makeautonomous.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14618,6 +14618,11 @@ magicpatternsapp.com
 // Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
 hb.cldmail.ru
 
+// Make Autonomous : https://makeautonomous.com
+// Submitted by Simon Janin <s.janin@x80security.com>
+// https://github.com/publicsuffix/list/pull/3192
+makeautonomous.com
+
 // MathWorks : https://www.mathworks.com/
 // Submitted by Emily Reed <psl-maintainers@groups.mathworks.com>
 matlab.cloud


### PR DESCRIPTION
**Domain name:** makeautonomous.com

**Owner / operator:** X80 Security GmbH (MyAPI HQ platform)

**Contact email:** s.janin@x80security.com

**Service description:**
MyAPI HQ operates a multi-tenant funnel-hosting platform. Customers register their own subdomains under makeautonomous.com and publish independent HTML/CSS/JS content served from those subdomains. Tenants are mutually untrusted — they are independent third parties.

Without public-suffix status, browsers treat sibling subdomains as part of one registrable domain. That allows a malicious tenant to set cookies scoped `Domain=.makeautonomous.com` that flow to every other tenant's subdomain, breaking the platform's tenant-isolation model. PSL inclusion is the standard fix and the precedent (github.io, vercel.app, workers.dev, herokuapp.com, pages.dev, etc).

**Ownership proof:**
A `_psl.makeautonomous.com` TXT record has been added pointing at this PR URL:

    $ dig +short TXT _psl.makeautonomous.com
    "https://github.com/publicsuffix/list/pull/3192"

(Being updated to this PR's URL immediately after the number is assigned.)

**Precedents we modelled on:**
- github.io (GitHub Pages)
- vercel.app (Vercel)
- workers.dev (Cloudflare Workers)
- pages.dev (Cloudflare Pages)
- herokuapp.com (Heroku)
- netlify.app (Netlify)

All same shape: a parent domain hosting independent customer subdomains, where cross-subdomain cookie / Service-Worker / document.domain leakage would violate tenant isolation.

By submitting this PR I confirm I have authority to make this submission on behalf of the domain owner and have read the guidelines at https://github.com/publicsuffix/list/wiki/Guidelines.
