### PR TITLE
Add eth.limo and eth.link gateways

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14449,6 +14449,12 @@ laravel.cloud
 on-forge.com
 on-vapor.com
 
+// Last Mile Labs, Inc : https://eth.limo
+// Submitted by eth.limo team <security@eth.limo>
+*.eth.limo
+*.gno.limo
+*.eth.link
+
 // LCube - Professional hosting e.K. : https://www.lcube-webhosting.de
 // Submitted by Lars Laehn <info@lcube.de>
 git-repos.de

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14452,7 +14452,6 @@ on-vapor.com
 // Last Mile Labs, Inc : https://eth.limo
 // Submitted by eth.limo team <security@eth.limo>
 *.eth.limo
-*.gno.limo
 *.eth.link
 
 // LCube - Professional hosting e.K. : https://www.lcube-webhosting.de


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

<!--
Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter. This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.
-->

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when their submission doesn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/2835, although 
the organization and description were not as substantial 
as desired, which required maintainers' time to visit the 
requestor's website to further research.
Having more robust org/desc improves the PR processing 
pace because extra cycles are not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Implemented [RFC9116](https://datatracker.ietf.org/doc/html/rfc9116) for all submitted entries 

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 - None. This request does not seek to work around any third-party limit.
 <!-- END FILL IN -->

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail regarding the effort that was made to work directly 
with the third party or parties in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

<!--
Submitter will maintain domains in good standing or may lose section.

The ongoing trust of the PSL requires it to be free of outdated or problematic entries. In making this pull request, there is a commitment by the submitter that they are going to review and maintain their relevant section. By submitting an entry, the requestor acknowledges that their entry and section may be removed if the domain does not maintain the respective _psl entries in DNS, any domain(s) within their section fail to resolve in DNS, the domain does not get renewed, expires or is otherwise unreachable. The submitter further identifies that it is their responsibility to review their submitted section within the PSL, submitting updates or removals as their domain(s) may change over time. It is also the responsibility of the submitter to provide (and keep up to date) a reachable email address within the section, and to maintain that address as it may change over time, so that they receive notices.
-->

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

<!--
The guidelines describe which section to place the entry in, the 
order of commented organization placement, and the order of sorting of entries. 
(Hint: TLD then SLD, ascending sorting) Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly. Typically, both are solved or
neither.
-->

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed. Mislocated entries and trailing spaces should be avoided.
-->

<!--
In your submission, please include a role-based email address (e.g. security@example.com) rather than a personal email address (e.g. jane.doe@example.com) under your organization name, so that we can maintain contact with your organization, independent of personnel changes.
This email address will be used for any required verification or inquiries regarding your PSL listing. This inbox must be actively maintained and monitored for future communications from the PSL project for as long as the domain remains in the PSL. Any PSL inquiries sent to this address must receive a response within 30 days, as maintaining timely communication is required for continued inclusion in the PSL.
-->

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

<!--
Please confirm that you have accessible abuse contact information on your website. 

At a minimum, you must provide an abuse contact either in the form of an email address or a web form that can be used to report abuse. This contact should be easily accessible to allow concerned parties to notify the registry or subdomain operator directly when malicious activities such as phishing, malware, or abuse are detected. For example, if you provide subdomains at example.com, where users may register subdomains such as clientname.example.com, then in case of abuse, reporters should be able to visit example.com and easily find the relevant abuse contact information.
-->

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- Provide the URL where an Internet user can access the abuse contact information -->
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://eth.limo — the "Report abuse" link on the homepage opens the abuse reporting form (https://forms.gle/n85iLgSuim9mmP6EA). Abuse reports are also accepted by email at abuse@eth.limo. All domains included in this request perform apex redirection to the eth.limo homepage, so the abuse contact is reachable for all of them.
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollbacks are really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that. 

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

<!--
As you complete each item in the checklist please mark it with an X.

For example:
* [x] Description of Organization
-->

## Description of Organization
<!--
Provide at least 3 sentences (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business, etc.) 
and what you do (i.e. DynDNS, hosting, etc.), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Last Mile Labs, Inc operates the eth.limo and eth.link, ENS (Ethereum Name Service) gateways as a public good. The gateways provide connectivity to decentralized websites (dWebsites) built with ENS and various decentralized storage protocols (IPFS, Arweave, Swarm, etc.). Each ENS name (`foo.eth`) is served at `foo.eth.limo` (and `foo.eth.link`), and ENS subdomains (some subdomain providers, such as `base.eth`, issue thousands of names to users) are served at deeper labels (`foo.base.eth.limo`). A name owner only needs to configure the `contenthash` record for their ENS domain and append `.limo`/`.link`. The gateway resolution service then handles the on-chain lookup, retrieves the content from the referenced storage network and returns it to the requesting client.

Names appearing under `eth.limo`/ `eth.link` are controlled by their respective ENS owners, who are unrelated to one another. The gateway does not register, allocate or approve these names as they originate on-chain and become servable the moment an owner sets a `contenthash` record, without any prior configuration with the gateway.

This request is submitted by the eth.limo engineering team (security@eth.limo), at Last Mile Labs, Inc, which is the registrant of `eth.limo` and which operates `eth.link` (registered to a separate entity), including its DNS, as the registrant's authorized representative. We are authorized representatives for all three domains and are responsible for operating the gateways, keeping the registrations and `_psl` records in good standing, and maintaining this PSL section.
<!-- END FILL IN -->

**Organization Website:**
<!-- Provide the website address of the org as a full URL (i.e. https://example.com) -->
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://eth.limo
<!-- END FILL IN -->

## Reason for PSL Inclusion
<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, iOS/Facebook, 
Cloudflare, etc.) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also reference any past issues or PRs 
specifically related to this submission or section.

Provide three or more sentences here that describe the purpose 
for which your PR should be included in the PSL. There is no 
upper limit, but six paragraphs seems like a rational stop.
-->

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
**Origin isolation between unrelated tenants.** Given the dynamic nature and scale of the ENS domains served through the gateway, strong origin enforcement is required. ENS names originate as on-chain domains and are configurable by their owners without prior registration or setup with the gateway service, so every third-level name under `eth.limo` (and `eth.link`) is effectively a separate, mutually untrusted site.

**Requested entries and expected input/output.** We request the wildcard entries `*.eth.limo` and `*.eth.link`.


**Registration term and maintenance.** Per RDAP at the time of submission, `eth.limo` is registered through 2028-06-08 and `eth.link` through 2033-07-26.

**Related issues/PRs.** None. This is the first submission for this section.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- 
The guidelines state that PSL inclusion is considered only for 
projects that have achieved a minimum of 2000 - 3000 distinct 
users or more. 

To be clear, 'users' is the number of distinct individuals 
working directly with a relationship with the requestor in 
using subnames of the requested space, and is not measured 
as the count of the audience of users that would visit to 
or interact with the namespace(s).

Please provide us this count, and identify if this is current 
actual count or an estimate. -->
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
145,400. This is the current actual count of distinct hostnames (ENS names and subnames, each controlled by its on-chain owner) served through the eth.limo gateway (eth.link serves the same ENS namespace), not the visitor audience.
<!-- END FILL IN -->

## DNS Verification
<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"

dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want
your entry to remain in the PSL, so that future (TBD)
automation can remove entries where the record is not present.
-->
<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
dig +short TXT _psl.eth.limo
"https://github.com/publicsuffix/list/pull/3199"

dig +short TXT _psl.eth.link
"https://github.com/publicsuffix/list/pull/3199"
<!-- END FILL IN -->

## Addendum

> Please provide current exact user counts on the submitted entries at a per entry basis (instead of an aggregated number across various entries). Per our requirements, Users' is the number of distinct individuals working directly with a relationship with the requestor in using subnames of the requested space, and is not measured as the count of the audience of users that would visit to or interact with the namespace(s). Please provide the number in your reply and in the PR Template, with supporting materials in a manner that can be publicly verified.

https://dune.com/queries/8532051

| Total ENS Domains with `contenthash` set | "distinct individuals" (on-chain addresses) |
| ------------------------------------------ | ------------------------------------- |
| 36194 | 15868 | 

The Dune Analytics query above lists all currently known ENS domains across multiple chains that have the `contenthash` record defined as of block `25848773`. That means that every one of those domains is directly retrievable through the `eth.limo`/`eth.link` gateways. The 145k number referenced in initial PR comment above denotes distinct subdomains served by the gateway service over 30d, which includes the population in the table.

> Please provide a more detailed technical explanation on how these domains are distributed and used, and include working examples that we can verify. Please also put this in the PR template.

Users never "register" or otherwise configure domains through `eth.limo` or `eth.link`. 

ENS domains can be registered by users through a number of means. The primary point of registration and configuration takes place on https://app.ens.domains. A user registers an ENS domain, i.e. `ens.eth`, their wallet represents the key pair that "owns" and exercises control over the domain on the Ethereum blockchain, or other supported blockchain networks. The user is directly interacting with the blockchain network for all domain operations. The domain holder specifies the identifier of their static site content in the `contenthash` record in the resolver contract configured for that domain, in the case of `ens.eth` that is currently set to `/ipfs/bafybeifnx3u22ngv4ygpnj32qkwzrpgizw4i7e3swp4v6am5piiih3ude4`. At this point the domain is now eligible for resolution and retrieval via the `eth.limo` or `eth.link` gateways: https://ens.eth.limo.

The records for `ens.eth` can be inspected with different tools:

https://dns.eth.limo/dns-query?name=ens.eth
https://app.ens.domains/ens.eth 

Comprehensive documentation is available:

https://docs.ens.domains/dweb/intro/
https://eth-limo.gitbook.io/documentation/beginner/configuring-your-ens-name/updating-your-ens-content-records