### PR TITLE
Add glideos.app (Glide)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13795,6 +13795,10 @@ gitlab.io
 gitapp.si
 gitpage.si
 
+// Glide : https://www.glideapps.com
+// Submitted by Glide Engineering <engineering@heyglide.com>
+glideos.app
+
 // Global NOG Alliance : https://nogalliance.org/
 // Submitted by Sander Steffann <sander@nogalliance.org>
 nog.community


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://www.glideapps.com/support
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Glide is a software platform on which businesses build and publish custom applications (internal tools, portals, customer-facing apps) without traditional development. Customer organizations design applications in our builder and publish them; each published application is served from its own subdomain of `glideos.app` (for example `myapp--acme.glideos.app` or a vanity slug such as `acme-portal.glideos.app`). The subdomains are therefore operated by thousands of mutually-unrelated customer organizations, while the `glideos.app` apex itself hosts no content — it serves only a permanent redirect to our corporate website. Our corporate website and dashboard live on separate domains (`glideapps.com`, `glideapps.dev`), so this request does not affect our own web properties' cookies.

I am Ben Ipsen, Principal Engineer at Glide, submitting on behalf of Glide's engineering organization, which operates the `glideos.app` zone and the platform that serves it. The role address `engineering@heyglide.com` in the list entry is our engineering team's monitored inbox.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://www.glideapps.com
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
`glideos.app` is a multi-tenant hosting suffix: each subdomain is controlled by a different customer organization, and those organizations must not share a browser security context. Our platform already enforces this server-side — every application session cookie is set host-only, and no `Domain=.glideos.app` cookie exists by design — but only PSL inclusion makes browsers enforce the same boundary, preventing any subdomain from ever setting a supercookie readable by other tenants' applications.

Second, we need reputation systems to evaluate each customer subdomain independently. Because the zone is not currently a recognized public suffix, domain-reputation systems score all tenants collectively at the registrable-domain level; this has already caused ISP-level DNS filtering of the entire zone, taking every customer's application offline for those ISPs' subscribers, in response to activity attributable to at most a single tenant. PSL inclusion is the established mechanism by which multi-tenant platforms (e.g. `github.io`, `netlify.app`, `pages.dev`) scope such evaluation to the individual subdomain.

We are not seeking to work around any third-party limit (Let's Encrypt is not in use — TLS is via our CDN provider's wildcard certificate — and no Cloudflare zone-count, iOS/Facebook, or similar limit is implicated). `glideos.app` is registered through 2031-05-26 (more than two years remaining, verifiable via RDAP) and we shall maintain more than one year of registration term to remain listed, as well as keep the `_psl` TXT record in place.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Tens of thousands (estimate). This is the count of distinct customer organizations building on Glide, whose published applications this domain serves; thousands of distinct organizations publish on `glideos.app` today and it is the default published-application domain for the platform going forward.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.glideos.app
"https://github.com/publicsuffix/list/pull/3200"
```
<!-- END FILL IN -->
