### PR TITLE
Add statyapps.io

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15872,6 +15872,10 @@ novecore.site
 // Submitted by Eric Selin <admin@statichost.eu>
 statichost.page
 
+// Staty : https://staty.io
+// Submitted by Staty <info@staty.io>
+statyapps.io
+
 // stereosense GmbH : https://www.involve.me
 // Submitted by Florian Burmann <publicsuffix@involve.me>
 feedback.ac


### PR DESCRIPTION
**Organization:** Staty (https://staty.io) — a multi-tenant sports-league management platform.

**What/why:** Each customer organization gets its own public site at `<org>.statyapps.io` (e.g. https://elite-sports-club.statyapps.io), serving league schedules, standings, and registration. The subdomains are operated by mutually-untrusting third parties (our customers), so we are requesting private-section inclusion to prevent any tenant from setting cookies scoped to the registrable root that would affect other tenants. Platform surfaces (dashboard, API, docs) live on a separate domain (staty.io) and are not affected.

Our application already uses host-only session cookies; this entry adds the browser-enforced boundary.

**Expected input/output:**
- `getRegistrableDomain("elite-sports-club.statyapps.io")` → `elite-sports-club.statyapps.io"`
- `getPublicSuffix("foo.statyapps.io")` → `statyapps.io`
- Cookies with `Domain=.statyapps.io` are rejected.

**Validation:** `_psl.statyapps.io` TXT record pointing at this PR will be added immediately after opening (DNS is on Cloudflare, propagation is fast). Domain registration runs through 2028-08-24.

`linter/pslint.py` passes on the modified list. Sorted under "Staty" between statichost.eu and stereosense GmbH in the private domains section.