### PR TITLE
Remove `leapcell.dev` and `leapcell.online`

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14464,8 +14464,6 @@ lpusercontent.com
 // Leapcell : https://leapcell.io/
 // Submitted by Leapcell Team <support@leapcell.io>
 leapcell.app
-leapcell.dev
-leapcell.online
 
 // Liara : https://liara.ir
 // Submitted by Amirhossein Badinloo <info@liara.ir>


### PR DESCRIPTION
Removes two Leapcell entries that no longer exist in public DNS. The organization's third entry, `leapcell.app`, is still live and is intentionally left in place.

### `leapcell.dev`
- `NXDOMAIN` from both Google (`8.8.8.8`) and Cloudflare (`1.1.1.1`), for `NS`, `SOA` and `A`.
- RDAP status: `pending delete`, `redemption period` — expired `2026-07-08` and not renewed.

### `leapcell.online`
- `NXDOMAIN` from both Google (`8.8.8.8`) and Cloudflare (`1.1.1.1`), for `NS`, `SOA` and `A`.
- RDAP status: `server hold` — withdrawn from the zone by the registry.

### DNS verification

```
$ dig +noall +comments leapcell.dev NS @8.8.8.8
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 14059

$ dig +noall +comments leapcell.online NS @8.8.8.8
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 27420

$ dig +short TXT _psl.leapcell.dev @8.8.8.8
$ dig +short TXT _psl.leapcell.online @8.8.8.8
```

Neither name publishes a `_psl` TXT record.

### Not removed: `leapcell.app`

```
$ dig +short leapcell.app NS @8.8.8.8
colin.ns.cloudflare.com.
jean.ns.cloudflare.com.

$ dig +short TXT _psl.leapcell.app @8.8.8.8
"https://github.com/publicsuffix/list/pull/2609"
```

`leapcell.app` resolves and still publishes its `_psl` record, so it remains listed.

### Notes

- All three entries were added in #2609. The section comment and `leapcell.app` are untouched, so the organization keeps its section and contact address.
- Validated locally: `linter/pslint.py` reports no errors, `psltool fmt -d` produces no diff, and `psltool validate` reports `PSL file is valid`.
- These two names surfaced from a sweep of all 2,116 registrable domains in the PRIVATE section, which found 7 non-resolving entries in total. I'm happy to file the others separately if that's useful.
- On the PR template: it covers new PRIVATE-section submissions, and its attestations (maintaining `_psl` records, two-year registration terms, user counts) are made by the domain owner and don't apply to a third-party removal. This follows the evidence format used by recent removal PRs such as #3093, #3065 and #3066.
