### PR TITLE
Add gptrf.site and stage.gptrf.site (GPTRF hosting platform)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13960,6 +13960,11 @@ pymnt.uk
 // Submitted by <domeinnaam@minaz.nl>
 gov.nl
 
+// GPTRF : https://gptrf.ru/
+// Submitted by Karlen Danielyan <support@gptrf.ru>
+gptrf.site
+stage.gptrf.site
+
 // Grafana Labs : https://grafana.com/
 // Submitted by Platform Engineering <info@grafana.com>
 grafana-dev.net


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://gptrf.ru/legal/hosting — the hosting terms page names the abuse / complaint contact (support@gptrf.ru) and the takedown procedure for content hosted under gptrf.site; the same address is listed in the site footer of https://gptrf.ru/.
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
GPTRF («ГПТ Россия», https://gptrf.ru/) is a Russian AI content platform operated by sole proprietor Karlen Danielyan (ИП Даниелян К.М.). Besides text, image and video generation, the platform has a "Studio" that builds complete websites for its users and hosts them. The domain `gptrf.site` exists solely as the hosting apex for those user websites: every site a customer publishes is served at its own hostname `<name>.gptrf.site` (production) or `<name>.stage.gptrf.site` (our staging environment). The customers are unrelated third parties (individuals and small businesses) who each control the content of their own hostname; the apex `gptrf.site` itself serves no content and only redirects to `gptrf.ru`. Our organization's own website stays on `gptrf.ru`, which is not part of this request.

The submitter is the owner and operator of the platform (the registrant of both `gptrf.ru` and `gptrf.site`), submitting on behalf of the organization; the entry is maintained by the same engineering team that runs the hosting service, and the role-based contact `support@gptrf.ru` is monitored by that team.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://gptrf.ru/
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
`gptrf.site` and `stage.gptrf.site` are multi-tenant hosting suffixes in the same sense as `github.io`, `vercel.app` or `netlify.app`: each label directly under them belongs to a different, mutually untrusted customer. We request inclusion for cookie and origin security:

1. Browsers must treat `foo.gptrf.site` and `bar.gptrf.site` as separate registrable domains — a customer site must not be able to set or read cookies scoped to `gptrf.site` and thereby affect other customers' sites (cookie isolation, site-scoped storage partitioning, SameSite behaviour).
2. Search engines and other consumers of the list should treat each customer site as an independent site rather than as pages of one `gptrf.site` property.
3. Origin-isolation features that key on the registrable domain (document.domain restrictions, Related Website Sets logic, password managers) should behave correctly for each customer site.

We are not attempting to work around any third-party limits (Let's Encrypt, Cloudflare or otherwise): TLS for `*.gptrf.site` is a single wildcard certificate we already hold, and customers' own domains, when used, are validated and certified individually and do not depend on this listing.

Registration term: `gptrf.site` was registered on 2026-06-03 and its registration is paid through 2029-06-03 (RDAP, verified on the day of this PR) — more than two years beyond the submission date. We commit to keeping the registration in good standing with more than one year remaining at all times, to keeping the `_psl` TXT records in place, and to keeping `support@gptrf.ru` reachable. There are no past issues or PRs related to this section.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Estimate. The hosting feature is launching to the platform's existing user base in September 2026, so the count of customers with a live `<name>.gptrf.site` hostname is 0 at the time of this PR; the parent platform gptrf.ru has about 306 thousand registered accounts (actual count on the day of this PR), and the hosting is offered to all of them. We would rather have the suffix listed before the first customer sites go live than migrate cookies afterwards; if the maintainers prefer to wait for an actual usage figure, we will report it here when available.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
$ dig +short TXT _psl.gptrf.site
"https://github.com/publicsuffix/list/pull/3203"

$ dig +short TXT _psl.stage.gptrf.site
"https://github.com/publicsuffix/list/pull/3203"
```

Both records are published in the authoritative zone (Yandex Cloud DNS, `ns1/ns2.yandexcloud.net`) and will remain in place after validation.
<!-- END FILL IN -->
