### PR TITLE
Add contentive.site

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12798,6 +12798,10 @@ hosting-cluster.nl
 // Submitted by Contentful Developer Experience Team <prd-ecosystem-dx@contentful.com>
 ctfcloud.net
 
+// Contentive : https://contentive.io
+// Submitted by Zac Huddart <zhuddart@gmail.com>
+contentive.site
+
 // Convex : https://convex.dev/
 // Submitted by James Cowling <security@convex.dev>
 convex.app

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12799,7 +12799,7 @@ hosting-cluster.nl
 ctfcloud.net
 
 // Contentive : https://contentive.io
-// Submitted by Zac Huddart <zhuddart@gmail.com>
+// Submitted by Contentive <hello@contentive.io>
 contentive.site
 
 // Convex : https://convex.dev/


### PR DESCRIPTION
Contentive (https://contentive.io) is a multi-tenant hosting platform: each customer workspace serves a website on its own subdomain of contentive.site (e.g. customer-name.contentive.site), with customer-authored client-side code. We are requesting inclusion in the PRIVATE domains section so browsers treat each tenant subdomain as a separate site (cookie isolation between tenants, per-subdomain reputation) — the same usage pattern as pages.dev, github.io and netlify.app.

The parent product (API/dashboard) lives on the separate domain contentive.io; contentive.site exists solely to host customer sites.

The _psl TXT validation record is live at _psl.contentive.site, pointing at this PR.

Organisation: Contentive — https://contentive.io
Contact: hello@contentive.io