### PR TITLE
Add Fluctly.com private domain

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13654,9 +13654,12 @@ firebaseapp.com
 // Submitted by Eric Chan <support@flashdrive.io>
 fldrv.com
 
-// Fleek Labs Inc : https://fleek.xyz
 // Submitted by Parsa Ghadimi <dev@fleek.xyz>
 on-fleek.app
+
+// Fluctly : https://fluctly.com/
+// Submitted by Kashi Ahmer <admin@fluctly.com>
+fluctly.com
 
 // FlutterFlow : https://flutterflow.io
 // Submitted by Anton Emelyanov <anton@flutterflow.io>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13654,6 +13654,7 @@ firebaseapp.com
 // Submitted by Eric Chan <support@flashdrive.io>
 fldrv.com
 
+// Fleek Labs Inc : https://fleek.xyz
 // Submitted by Parsa Ghadimi <dev@fleek.xyz>
 on-fleek.app
 


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->

 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://fluctly.com/contact
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->

Fluctly.com is a free subdomain and hosting service that I run. Users sign
up, pick a subdomain like name.fluctly.com, and each subdomain comes with
its own hosting panel with PHP, file manager and database tools. I am Kashi
Ahmer. I built the platform, I run it, I handle the user support, and I am
also the registrant of the fluctly.com domain. I am making this request on
behalf of the service.

<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://fluctly.com/
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Fluctly issues subdomains under fluctly.com to mutually-untrusting, independent third parties, where each subdomain is owned and controlled by a different person. We are requesting inclusion in the PRIVATE section so that browsers and other PSL consumers treat each user's subdomain as a separate registrable site. This provides cookie and local-storage isolation between tenants, prevents one user from setting "super-cookies" scoped to fluctly.com that could affect all other users, and establishes correct per-subdomain security boundaries. The fluctly.com domain is registered for 5 years and holds well over two years remaining on registration; we will maintain more than one year of registration term at all times and keep the `_psl` TXT record in place for as long as we remain listed. This request is purely about establishing correct security boundaries between untrusting tenants and is not intended to work around any third-party limits or restrictions.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
3127 distinct active user subdomains at present (actual current count from our admin panel), each belonging to a separate independent owner, and the number is growing.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.fluctly.com
"https://github.com/publicsuffix/list/pull/3210"
```
<!-- END FILL IN -->
