### PR TITLE
Add official social ccTLD subdomain ia.bo for Bolivia (.BO)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -457,7 +457,7 @@ net.bn
 org.bn
 
 // bo : https://nic.bo
-// Confirmed by registry <soporte@nic.bo> 2024-11-19
+// Confirmed by registry <soporte@nic.bo> 2026-09-01
 bo
 com.bo
 edu.bo
@@ -501,6 +501,7 @@ tecnologia.bo
 tksat.bo
 transporte.bo
 wiki.bo
+ia.bo
 
 // br : http://registro.br/dominio/categoria.html
 // Submitted by registry <fneves@registro.br>

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -481,6 +481,7 @@ deporte.bo
 ecologia.bo
 economia.bo
 empresa.bo
+ia.bo
 indigena.bo
 industria.bo
 info.bo
@@ -501,7 +502,6 @@ tecnologia.bo
 tksat.bo
 transporte.bo
 wiki.bo
-ia.bo
 
 // br : http://registro.br/dominio/categoria.html
 // Submitted by registry <fneves@registro.br>


### PR DESCRIPTION
### Public Suffix List (PSL) Submission - ICANN Section Update

**Description of Organization:**
AGETIC ( Agencia de Gobierno Electrónico y Tecnologías de Información y Comunicación) is the official government agency and registry operator responsible for managing the `.bo` ccTLD (Bolivia).

**Reason for PSL Inclusion:**
We have officially introduced `ia.bo` as a new social second-level domain under our national registry registry interface (https://nic.bo) for artificial intelligence projects and entities. We need to add it to the ICANN section to ensure proper cookie separation and security scoping for our users.

**DNS Verification:**
The domain `ia.bo` is fully operated and delegated by NIC Bolivia. Validation can be confirmed by inspecting our official IANA root zone database registry or via our official contact channels at `soporte@nic.bo`.
