### PR TITLE
Add boomurl.me to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12526,6 +12526,10 @@ bluebite.io
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net
 
+// boomurl : https://boomurl.com
+// Submitted by Doron Grinstein <abuse@boomurl.com>
+boomurl.me
+
 // Boutir : https://www.boutir.com
 // Submitted by Eric Ng Ka Ka <ngkaka@boutir.com>
 boutir.com


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).
  (boomurl.me registry expiry: 2029-07-08.)

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. This request does not seek to work around any third-party limit.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.
  (abuse@boomurl.com, monitored by the operator; used as the contact in the list entry.)

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://boomurl.com/report
  <!-- END FILL IN -->

---

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
  <!-- Note: safe here — the application itself lives on boomurl.com; boomurl.me serves ONLY user-published content on subdomains and sets no shared cookies on the apex. -->
---

## Description of Organization
<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
boomurl (boomurl.com) is a small static-site publishing service: a user drags a folder or an HTML file onto the page, verifies ownership with an email code, and the content is published as a static site. There are no accounts or passwords; sites are identified by a globally unique name. The application and publishing APIs live on boomurl.com, while all user-published content is served from boomurl.me, with each site on its own subdomain (`<name>.boomurl.me`) so user content is origin-isolated from the application and from every other site.

I am Doron Grinstein, the individual operator and developer of the service, and I am submitting this request for the domain I control. boomurl.me is used exclusively as the user-content serving domain; it hosts no first-party application pages (its root redirects to boomurl.com).
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://boomurl.com
<!-- END FILL IN -->

## Reason for PSL Inclusion
<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
boomurl.me hosts third-party user-generated content, with each publisher's site on its own subdomain — the same model as `github.io`, `netlify.app`, and `pages.dev`, which are listed in the PRIVATE section for the same reasons:

1. **Reputation isolation.** Because subdomains of an unlisted domain are treated as one site, abusive content published by one user (despite pre-publish screening, hourly scanning with automatic takedown, and Google Safe Browsing lookups on our side) can cause domain-wide consequences for every innocent publisher. PSL listing scopes reputation systems (e.g. Google Safe Browsing) to the individual subdomain that hosted the abuse.

2. **Cookie isolation.** Listing prevents any published site from setting cookies scoped to `boomurl.me` that would be sent to every other published site.

Registrations of subdomains are free and instant (email-verified), which is precisely the class of service the PRIVATE section exists for. We commit to maintaining at least two years of registration on boomurl.me and to keeping the `_psl` TXT record in place.

Prior submission: #3024 (closed for not using the PR template — this PR replaces it).
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
~0.5 (actual count: 480 distinct verified publisher emails across ~1,000 published sites, as of 2026-09-01; growing). We are aware this is below the 2–3k guideline; we submit early because the domain hosts open user-generated content and subdomain reputation isolation is an abuse-containment need from day one.
<!-- END FILL IN -->

## DNS Verification
<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
$ dig +short TXT _psl.boomurl.me
"https://github.com/publicsuffix/list/pull/3215"
```
(Record TTL is 600s; if a cached resolver still returns the previous PR's URL, the authoritative answer can be confirmed with `dig +short TXT _psl.boomurl.me @aiden.ns.cloudflare.com`.)
<!-- END FILL IN -->
