### PR TITLE
Add Wuvex (c.wuvex.net)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16344,6 +16344,10 @@ weeklylottery.org.uk
 wpenginepowered.com
 js.wpenginepowered.com
 
+// Wuvex : https://wuvex.net
+// Submitted by Floyd <admin@wuvex.net>
+c.wuvex.net
+
 // xAI : https://x.ai/
 // Submitted by Asim Shrestha <security@x.ai>
 grok.me


### PR DESCRIPTION
```
// Wuvex : https://wuvex.net
// Submitted by Floyd <admin@wuvex.net>
c.wuvex.net
```

### What the suffix is used for

Wuvex is a self-hosted media server for home NAS and PCs.

Each user's server generates a **random 32-hex label** at first launch and registers it with
our DNS service, receiving `<hash>.c.wuvex.net`. The server then obtains its own wildcard
certificate for `*.<hash>.c.wuvex.net` via ACME DNS-01 — **the private key is generated on
the user's own machine and never leaves it**; our service only publishes the
`_acme-challenge` TXT record on request.

So every subdomain of `c.wuvex.net` belongs to a **different, mutually untrusted party**
(individual households). This is the same shape as other home-server / dynamic-DNS entries
already in the PRIVATE section, e.g. `synology.me`, `myqnapcloud.com`, `duckdns.org`, `ts.net`.

### Why the entry is needed

1. **Cookie isolation.** Without it, any one user's server can set a `Domain=c.wuvex.net`
   cookie that every other user's server would then receive. These are unrelated
   households and must not share a cookie scope.
2. **Certificate rate limits.** Let's Encrypt uses the PSL to determine the registered
   domain. Today every user shares `wuvex.net`'s single 50-certificates-per-7-days bucket —
   which also contains our own authentication host. That caps the entire fleet at ~50 new
   servers per week and lets user activity interfere with our own infrastructure.

### Expected behaviour

| Name | Result |
|---|---|
| `c.wuvex.net` | public suffix |
| `abc123….c.wuvex.net` | registrable domain |
| `foo.abc123….c.wuvex.net` | subdomain of the above |

### Details

- Only `c.wuvex.net` is delegated to our authoritative nameservers. The rest of `wuvex.net`
  is ordinary company use and is **not** part of this request.
- Registration expires **2029-06-22**; we will keep it renewed with well over a year remaining.
- `linter/pslint.py` passes locally against the modified list.
- The `_psl.c.wuvex.net` TXT record pointing at this PR will be published as soon as this PR
  has a number, and will be left in place afterwards.