### PR TITLE
Add spacesheep.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15817,7 +15817,7 @@ my.de
 *.nxa.eu
 nx.gw
 
-// Spacesheep : https://spacesheep.dev
+// Spacesheep : https://spacesheep.app
 // Submitted by Misha Makarov <abuse@spacesheep.app>
 spacesheep.app
 

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15817,6 +15817,10 @@ my.de
 *.nxa.eu
 nx.gw
 
+// Spacesheep : https://spacesheep.dev
+// Submitted by Misha Makarov <abuse@spacesheep.app>
+spacesheep.app
+
 // Spawnbase : https://spawnbase.ai
 // Submitted by Alexander Zuev <security@spawnbase.ai>
 spawnbase.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 None. We are not seeking to work around any third-party limit. TLS for `*.spacesheep.app` is issued by Cloudflare Universal SSL, which is unaffected by this request; we do not use Let's Encrypt.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://spacesheep.app/ (the bare suffix domain itself shows the abuse contact) and https://spacesheep.dev/abuse
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding.

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Spacesheep is an application for users' microapps. A user, or an AI coding agent acting for them, builds a small self-contained web app (a dashboard, a calculator, a booking page, an interactive report, a game) and publishes it through our API; we host it and let the owner share it publicly, with a member list, or privately. Every microapp is arbitrary user-authored HTML and JavaScript, written by someone we do not control and that no other user has reason to trust.

Our own site (dashboard, sign-in, documentation) lives on **spacesheep.dev**. Users' microapps are deliberately served from a separate domain, **spacesheep.app**, and each microapp gets its own hostname there: `https://<uuid>.spacesheep.app`. The bare `spacesheep.app` apex hosts nothing except a page that explains this and shows the abuse contact. This is the same shape as `github.io`, `pages.dev`, or `vercel.app`: one operator, many unrelated authors, one hostname each.

I am Misha Makarov, the founder and engineer who runs the service and administers both domains; I am submitting on behalf of Spacesheep as its owner. The service runs on Cloudflare (Workers, R2, D1); both domains are registered with Cloudflare Registrar under the same account.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://spacesheep.dev
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
**Cookie and site isolation between unrelated authors.** Each `<uuid>.spacesheep.app` host serves a microapp written by a different person, and that content is untrusted by us and by every other author. Without a PSL entry, a script on one space can set a cookie with `Domain=spacesheep.app` that is then sent to every other space and to the apex, and browsers treat all spaces as one "site" for site isolation, storage partitioning, and related-website heuristics. Listing `spacesheep.app` makes each space its own registrable domain, so cookies cannot cross between spaces, Chrome puts each in its own process, and one author cannot interfere with another's storage.

**Abuse containment.** Because anyone can publish, some microapps will eventually be used for phishing or malware. With the entry in place, Safe Browsing and similar reputation systems can flag the offending `<uuid>.spacesheep.app` without flagging every other author's microapp or the apex. We have abuse handling in place (progressive trust for new accounts, content screening, a takedown path, and the abuse contact linked from the suffix domain itself), and this entry lets third-party reputation systems act at the same granularity we do.

**Our own cookies are unaffected.** Our session cookies live on `spacesheep.dev`, which is not part of this request. The only cookie set on the suffix domain is a per-space, host-only viewer session set on `<uuid>.spacesheep.app` without a `Domain` attribute, which continues to work after listing. Nothing is set on the bare `spacesheep.app`, and we have read and accept the propagation and rollback expectations.

**Registration term.** `spacesheep.app` was renewed on 2 September 2026 and now expires on **5 July 2029**, more than two years from this PR. Auto-renew is enabled. We commit to keeping the registration at more than one year of remaining term for as long as the entry is listed, to keeping the `_psl` TXT record in place, and to monitoring `abuse@spacesheep.app`.

**Not a limit workaround.** We are not trying to work around any third-party rate limit. TLS for the wildcard is handled by Cloudflare Universal SSL and does not depend on this entry.

This is a first submission; there are no prior issues or PRs for this section.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
Spacesheep is in private preview ahead of public launch, so the figure below is the preview cohort, not the launched product.

Current actual count, not an estimate: 23 registered accounts, of which 6 have published; 208 microapps are live on `<uuid>.spacesheep.app` today, i.e. under 0.1 thousand users. Published microapps already receive roughly 1.7k unique visitors per week, but we understand that audience does not count as users under the guidelines.

We are submitting before launch on purpose: once the product is public, every new user's microapp lands on `<uuid>.spacesheep.app` immediately, and the isolation the PSL provides has to be in place before that traffic arrives rather than months after, given propagation lead time. If the maintainers prefer that we return once the user count is higher, we understand, and we will keep the `_psl` record and abuse contact in place regardless.
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.spacesheep.app
"https://github.com/publicsuffix/list/pull/3220"
```
<!-- END FILL IN -->
