### PR TITLE
Add partner.franchisemethode.de to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11341,6 +11341,10 @@ africa.com
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl
 
+// AI Consulting UG (haftungsbeschränkt) : https://www.franchisemethode.de/
+// Submitted by Paul Roth <paul@sascha-mende.com>
+partner.franchisemethode.de
+
 // Aiven : https://aiven.io/
 // Submitted by Aiven Security Team <security+appdomains@aiven.io>
 aiven.app


### PR DESCRIPTION
### What is being requested
Add `partner.franchisemethode.de` to the PRIVATE section.

### Company / operator
AI Consulting UG (haftungsbeschränkt), Lange Str. 23, 29378 Wittingen, Germany — https://www.franchisemethode.de/
Submitter: Paul Roth <paul@sascha-mende.com> (I control this address and the DNS zone for franchisemethode.de; domain control is demonstrated via the `_psl` TXT record below).

### Rationale
We operate a multi-tenant funnel platform. Each independent partner ("franchisee") is provisioned a subdomain of the form `<partner>.partner.franchisemethode.de`, which that partner operates independently (their own marketing, their own third-party ad/analytics accounts, their own Meta Business Manager and tracking pixel). We need each partner's subdomain to be treated as a separate registrable domain so that:
- cookies and web-origin state are isolated between partners (no partner can read another's cookies), and
- third-party services that key on the registrable domain (eTLD+1) — notably Meta's domain verification, which collapses subdomains to the eTLD+1 and allows only one owner per registrable domain — treat each partner's subdomain as independently ownable/verifiable.

This is the same pattern as e.g. `myshopify.com`, `vercel.app`, `herokuapp.com`.

### Who does this benefit
Primarily our own tenants (a private-platform use case), which is why this belongs in the PRIVATE section.

### Domain registration
`franchisemethode.de` is registered and will be kept in good standing with more than 2 years of registration remaining beyond this submission. We commit to maintaining it.

### Validation — expected input/output
Using the PSL algorithm (getPublicSuffix / getRegistrableDomain):

```
BEFORE this change (public suffix = de):
  getRegistrableDomain("maria.partner.franchisemethode.de")  => "franchisemethode.de"
  getRegistrableDomain("tom.partner.franchisemethode.de")    => "franchisemethode.de"
  -> maria and tom collapse to the SAME registrable domain (cannot be independently owned).

AFTER this change (public suffix = partner.franchisemethode.de):
  getPublicSuffix("maria.partner.franchisemethode.de")       => "partner.franchisemethode.de"
  getRegistrableDomain("maria.partner.franchisemethode.de")  => "maria.partner.franchisemethode.de"
  getRegistrableDomain("tom.partner.franchisemethode.de")    => "tom.partner.franchisemethode.de"
  -> each partner subdomain is its own registrable domain (independently ownable + cookie-isolated).

The apex franchisemethode.de and www.franchisemethode.de are unaffected (not under partner.).
```

### DNS validation
`_psl.partner.franchisemethode.de` TXT = this PR's URL (added immediately after opening the PR; it will remain in place permanently to signal continued inclusion is desired).
