### PR TITLE
Add dbctel.eu (Double Clic SARL)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13016,6 +13016,10 @@ co.scot
 me.scot
 org.scot
 
+// Double Clic SARL : https://www.double-clic.eu/
+// Submitted by Guillaume Ludger <guillaume.ludger@double-clic.eu>
+dbctel.eu
+
 // DrayTek Corp. : https://www.draytek.com/
 // Submitted by Paul Fang <mis@draytek.com>
 drayddns.com


### PR DESCRIPTION
## What is being added

```
// Double Clic SARL : https://www.double-clic.eu/
// Submitted by Guillaume Ludger <guillaume.ludger@double-clic.eu>
dbctel.eu
```

## Who we are

Double Clic SARL (France) publishes **DBC Tel**, an on-premise IP telephony system (PBX) sold as an appliance through a reseller channel. We operate the `dbctel.eu` zone.

## Why this belongs in the private section

Each `<customer>.dbctel.eu` is a **separate PBX appliance, running on hardware belonging to a different end customer, administered by that customer**. We provide only the DNS name and the software; we do not host the machines and the customers have no relationship with one another.

Concretely, this means:

* **Cookie isolation.** Each appliance serves a web administration console and an end-user portal on its own subdomain. Without a public suffix entry, a page served by `customer-a.dbctel.eu` can set a cookie on `.dbctel.eu` that the browser will then send to `customer-b.dbctel.eu`. These are unrelated companies; a flaw at one must not reach another.
* **Certificate rate limits.** Every appliance obtains its own Let's Encrypt certificate. Today they all count against the single registered domain `dbctel.eu`, so beyond the weekly limit no appliance can obtain or replace a certificate — including one that has lost its own.

This is the same shape as other appliance and per-customer-deployment entries already in the private section.

## Validation

The `_psl` TXT record pointing at this pull request will be added on `dbctel.eu` as soon as this PR has a number, per the submission guidelines.

## Contact

Guillaume Ludger — guillaume.ludger@double-clic.eu