### PR TITLE
Add nyapp.no (NYSKY AS)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15023,6 +15023,10 @@ freeddns.us
 nsupdate.info
 nerdpol.ovh
 
+// NYSKY AS : https://nysky.no
+// Submitted by Christoffer Nyborg <kontakt@nysky.no>
+nyapp.no
+
 // O3O.Foundation : https://o3o.foundation/
 // Submitted by the prvcy.page Registry Team <info@o3o.foundation>
 prvcy.page


### PR DESCRIPTION
**Organization:** NYSKY AS (Norwegian org. no. 838 139 892) — https://nysky.no — a Norwegian PaaS where all compute, data and logging reside physically in Norway.

**Domain:** `nyapp.no` (PRIVATE section)

**Reason for the entry:**
`nyapp.no` is the dedicated apex for customer-deployed applications on the nysky platform. Each customer application is served as its own subdomain (`<app>.nyapp.no`), following the same model as `github.io` / `workers.dev`. The subdomains belong to mutually untrusting parties, so we need:

1. **Cookie isolation** — a customer application must not be able to set cookies scoped to `nyapp.no` that affect sibling applications.
2. **Per-subdomain site isolation** for SameSite/CSRF purposes.
3. **Correct rate-limit bucketing** for ACME certificate issuance.

The platform itself (website, API, auth) lives on separate domains (`nysky.no`, `nysky.app`); `nyapp.no` will only ever host end-customer applications.

**DNS validation:** the `_psl.nyapp.no` TXT record pointing to this PR will be published immediately after this PR is opened (the domain was registered with Norid today; the zone is served by our own authoritative nameservers `ns1.nysky.no`/`ns2.nysky.no`). I will comment here once the record is live.

**Sorting:** inserted in the PRIVATE section in alphabetical order (between nsupdate.info and O3O.Foundation).

**Acknowledgements:** I am authorized to submit this on behalf of NYSKY AS (I am the founder/registrant contact). I understand that inclusion and removal both propagate slowly through downstream consumers, and that the entry should be treated as long-lived.