### PR TITLE
Add upload.tf content-hosting domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16243,6 +16243,12 @@ rs.ba
 // Submitted by Marcin <dns@ath.bielsko.pl>
 bielsko.pl
 
+// upload.tf : https://uploadthefile.com
+// Submitted by Mulham <abuse@uploadthefile.com>
+upltf.com
+upl.tf
+upload.tf
+
 // urown.net : https://urown.net
 // Submitted by Hostmaster <hostmaster@urown.net>
 urown.cloud


### PR DESCRIPTION
## Why is the PR being requested?

upload.tf is a file-sharing and static-site hosting service. Every uploaded page is published on **its own subdomain** of the three domains below, and that content is authored by **mutually untrusting members of the public** — including arbitrary HTML and JavaScript, which executes in the visitor's browser.

Without these entries, sibling subdomains are same-site. A page published by one user can set a `Domain=`-scoped cookie that every other user's page then sends, and can exhaust the per-domain cookie jar to evict other users' legitimate cookies. Storage partitioning does not help here, since same-site siblings share a top-level-site key.

This is the same isolation model already used by `github.io`, `netlify.app`, `vercel.app`, `pages.dev` and `gitlab.io`.

## What are the example domains' use scenarios?

| Domain | Role |
|---|---|
| `upltf.com` | Sandbox host — guest HTML/JS is rendered and executed here, one label per published page (`abc123.upltf.com`) |
| `upload.tf` | Page shells, download landing pages and content byte routes (`abc123.upload.tf`) |
| `upl.tf` | Internal preview host serving the same guest bytes to moderators (`abc123.upl.tf`) |

Desired outcome: `abc123` and `def456` under each of these are different users' content and should be **cross-site to one another and to the apex**, so that no published page can set or read cookies belonging to another.

The application itself (accounts, sessions, billing) is served from a **separate registrable domain, `uploadthefile.com`, which is deliberately not included in this request** — it needs ordinary cookie behaviour.

## Contact

abuse@uploadthefile.com — a monitored mailbox, also published in our `/.well-known/security.txt` and on our legal pages as the Digital Services Act Article 11/12 point of contact.

## Requirements checklist

- [x] All three domains are registered until **2030-06** (3 years 9 months remaining, comfortably over the 2-year minimum).
- [x] `linter/pslint.py` passes clean against the modified list.
- [x] Entry placed in the PRIVATE section, sorted by company name (between "University of Bielsko-Biala" and "urown.net").
- [ ] `_psl` TXT records — will be published on all three zones pointing at this PR immediately after it is opened, and left in place permanently.