### PR TITLE
Add shiped.site to PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15796,6 +15796,10 @@ zicp.fun
 // Submitted by Nyoom <admin@sheezy.art>
 sheezy.games
 
+// Shiped : https://shiped.app
+// Submitted by Abhi Kandivalikar <abhishek.kandivalikar@gmail.com>
+shiped.site
+
 // Shopblocks : http://www.shopblocks.com/
 // Submitted by Alex Bowers <alex@shopblocks.com>
 myshopblocks.com


### PR DESCRIPTION
## Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig
* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the _PSL txt record in place

**Description of Organization**

Shiped (https://shiped.app) is a hosting platform that lets users deploy AI-generated sites and apps. I am submitting this as the operator of the platform.

**Reason for PSL Inclusion**

User-deployed projects are served on individual third-level subdomains of shiped.site (e.g. `my-app.shiped.site`), operated by mutually-untrusting tenants. Including `shiped.site` in the PSL makes each project subdomain a separate site for cookie scope (no cross-tenant cookie setting/reading), same-site boundaries, and other browser security partitioning. The platform itself (dashboard, API, auth) runs on a completely different domain (shiped.app), so shiped.site serves exclusively untrusted user content — the same model as github.io / pages.dev.

**DNS verification**

`dig TXT _psl.shiped.site` returns `https://github.com/publicsuffix/list/pull/3233`. The record will remain in place.

**Registration term**: domain registered through 2027+ and will be renewed.