### PR TITLE
Add luvasilk.com to private domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14606,6 +14606,10 @@ barsyonline.co.uk
 // Submitted by Joshua Newman <public-suffix-list@lutra.ai>
 *.lutrausercontent.com
 
+// Luvasilk : https://luvasilk.com
+// Submitted by Dominik Jasaitis <dominik.jasaitis@gmail.com>
+luvasilk.com
+
 // Luyani Inc. : https://luyani.com/
 // Submitted by Umut Gumeli <public-suffix-list@luyani.com>
 luyani.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission — luvasilk.com

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig (record will be set immediately after this PR number is assigned; I will comment with the dig output)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

**Submitter affirms the following:**

* [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
  - [Cloudflare](https://developers.cloudflare.com/learning-paths/get-started/add-domain-to-cf/add-site/) — luvasilk.com is hosted on Cloudflare; without PSL inclusion, a malicious artifact upload can exhaust per-domain Cloudflare rate limits shared across all customers.
  - [Let's Encrypt](https://letsencrypt.org/docs/rate-limits/) — without PSL inclusion, rate limits apply per registrable domain rather than per subdomain, affecting all customers on the platform.

* [x] The submitter acknowledges that it is their responsibility to maintain the domains within the PSL.

* [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully *read* and *understood*, and this request conforms to them.
* [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: https://luvasilk.com

---

### Description of Organization

**Luvasilk** is a client-delivery platform for interactive HTML deliverables. Consultants and agencies upload AI-generated HTML reports, dashboards, and audits and receive a branded, password-protected, expiring link to share with their clients. The platform is operated by Dominik Jasaitis (dominik.jasaitis@gmail.com), based in Lithuania (EU), as a solo SaaS product.

Website: https://luvasilk.com

The platform runs entirely on Cloudflare Workers + R2 + KV (zero self-managed infrastructure). The serving domain (`luvasilk.com`) is used exclusively to stream user-uploaded HTML artifacts to end-clients. The application/upload interface lives on a separate registrable domain (`app.luvayou.com`).

### Reason for PSL Inclusion

Luvasilk serves uploaded HTML files containing user-supplied JavaScript from `luvasilk.com`. These files are arbitrary HTML produced by AI tools (Claude, ChatGPT, etc.) and are not audited before delivery. The security model depends on treating each artifact path as an isolated origin:

1. **Cookie isolation** — the application domain (`app.luvayou.com`) and the serving domain (`luvasilk.com`) are intentionally on different registrable domains so that a malicious artifact cannot read application-layer cookies. PSL inclusion ensures browsers enforce this isolation correctly even if subdomains are introduced in future.

2. **Safe Browsing isolation** — without PSL inclusion, a single phishing artifact uploaded to `luvasilk.com/slug` could cause Google Safe Browsing to flag the entire `luvasilk.com` origin, taking every customer's links offline simultaneously. This failure mode has affected other HTML-hosting services. PSL inclusion ensures that a flagged artifact affects only its own effective TLD+1, not the entire domain.

3. **Rate-limit isolation** — Let's Encrypt and Cloudflare both apply limits at the registrable-domain level. PSL inclusion ensures future subdomain-per-customer configurations (planned for step 6 of the build roadmap) do not hit shared limits.

There is no intent to work around third-party limits in a policy-violating way; the submission is made to achieve correct security isolation for an artifact-hosting service, which is the exact use case the PSL private section was designed for.

### DNS Verification

I will add `_psl.luvasilk.com IN TXT "https://github.com/publicsuffix/list/pull/NUMBER"` (substituting this PR's number) immediately after this PR is opened, and post a `dig TXT _psl.luvasilk.com` verification comment on the PR within 24 hours.

DNS for `luvasilk.com` is managed via Cloudflare (nameservers changed today; propagation is in progress).

### Domain Registration

`luvasilk.com` is registered through Hostinger with more than two years of registration remaining. The `_psl` TXT record will be maintained for the operational life of the service.