### PR TITLE
Add bettercms.site (BetterCMS)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12499,6 +12499,10 @@ bearblog.dev
 // Submitted by Hazel Cora <hazy@besties.house>
 pages.gay
 
+// BetterCMS : https://bettercms.ai
+// Submitted by BetterCMS Engineering <admin@bettercms.ai>
+bettercms.site
+
 // BinaryLane : http://www.binarylane.com
 // Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
 bnr.la


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 - None.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] We have read and understood the guidelines and this template.
 * [x] We are the domain owner (or an authorised representative) of `bettercms.site` and will maintain this section: keep the `_psl` TXT record in DNS, keep the domain registered (current expiry: 2028-05-16), keep `admin@bettercms.ai` reachable, and submit updates or a removal if this changes.

### Description of Organization

BetterCMS (https://bettercms.ai) is a hosted content management and website platform. Customers build a site in the BetterCMS dashboard (or connect a repository) and BetterCMS builds and hosts it. Every hosted customer site is published on its own subdomain of `bettercms.site`, for example `acme.bettercms.site`, until the customer attaches their own domain. Organization contact: admin@bettercms.ai.

### Reason for PSL Inclusion

`bettercms.site` is a multi-tenant hosting domain: each subdomain is a different, unrelated customer's website, served from Cloudflare Workers/R2, and customers control the HTML and JavaScript on their own subdomain. Without a PSL entry, browsers treat `bettercms.site` as a registrable domain, so one customer's site can set cookies for `.bettercms.site` that are sent to every other customer's site, and sibling sites share the same "site" for cookie SameSite and storage-partitioning purposes. Listing `bettercms.site` in the private section makes each `<customer>.bettercms.site` its own site, which is the same reason `netlify.app`, `pages.dev`, `vercel.app`, `bearblog.dev` and similar hosting domains are listed. This is not intended to work around any third-party limit: TLS for the domain is a single wildcard certificate issued through Cloudflare, and no per-subdomain certificate issuance takes place.

### DNS verification via dig

The `_psl` TXT record points at this pull request and is in place:

```
dig +short TXT _psl.bettercms.site
"https://github.com/publicsuffix/list/pull/3235"
```

### Syntax check

The entry is inserted in the PRIVATE section in alphabetical order by organization name (after "Besties", before "BinaryLane"), with the standard two-line header (organization/URL and submitter). `make test` style checks: single ASCII label, no trailing whitespace, blank line separators kept.
