### PR TITLE
Add binakit.app

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12472,6 +12472,10 @@ bearblog.dev
 // Submitted by Hazel Cora <hazy@besties.house>
 pages.gay
 
+// Binakit : https://binakit.com
+// Submitted by Ali Shan <alishanvr@gmail.com>
+binakit.app
+
 // BinaryLane : http://www.binarylane.com
 // Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
 bnr.la


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found:
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://binakit.com (footer — hello@binakit.com, role-based, monitored)
  <!-- END FILL IN -->

---

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization
<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
Binakit (operated by WPRobo Ltd) is an AI website builder: customers describe a website, the platform generates it as real code (HTML, WordPress, React or Astro), and can publish it as a hosted site. Every published customer site is served on its own subdomain of binakit.app (e.g. `their-site.binakit.app`) with content fully controlled by that customer, comparable to GitHub Pages / Netlify-style user subdomain hosting. The submitter is Ali Shan, founder of Binakit and owner of the binakit.app domain; WPRobo is a WordPress development company (WooCommerce Pro Partner) and Binakit is its product.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://binakit.com
<!-- END FILL IN -->

## Reason for PSL Inclusion
<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
Cookie and security-context isolation between customer-controlled sites: each binakit.app subdomain hosts content authored by a different, mutually-untrusting customer. Listing binakit.app in the PRIVATE section ensures browsers treat each subdomain as its own registrable domain, so one customer's site cannot set cookies affecting another's, and third parties (CAs, browsers, security tooling) treat the subdomains independently. binakit.com (the application itself) is intentionally NOT included — only the customer-sites domain. The domain registration will be maintained at 2+ years remaining and the `_psl` TXT record kept in place for as long as the entry stands.

Transparency on scale: the platform launches publicly on 2026-09-29; we filed early because PSL review and downstream propagation lead-times are long, and because cookie isolation is a security property we want in place before customer sites accumulate — not retrofitted after. If the maintainers prefer to hold this until the distinct-user threshold in the Guidelines is demonstrably met, we're happy to keep the PR updated with real numbers post-launch.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: users (keep this line and its END FILL IN) -->
Pre-launch (public launch 2026-09-29); early filing explained above.
<!-- END FILL IN -->

## DNS Verification via dig

```
$ dig +short TXT _psl.binakit.app
"https://github.com/publicsuffix/list/pull/3244"
```
