### PR TITLE
 Remove alpha-myqnapcloud.com and dev-myqnapcloud.com

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -15358,8 +15358,6 @@ qcx.io
 // QNAP System Inc : https://www.qnap.com
 // Submitted by Nick Chang <cloudadmin@qnap.com>
 myqnapcloud.cn
-alpha-myqnapcloud.com
-dev-myqnapcloud.com
 mycloudnas.com
 mynascloud.com
 myqnapcloud.com


### PR DESCRIPTION
# Remove alpha-myqnapcloud.com and dev-myqnapcloud.com
## Removed Domains
* alpha-myqnapcloud.com
* dev-myqnapcloud.com
## Reason for Removal
These two domains are only used for internal testing