### PR TITLE
Add myboom.shop (Boom CRM)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12496,6 +12496,10 @@ square.site
 // Submitted by Joshua Weiss <admin.engineering@bluebite.com>
 bluebite.io
 
+// Boom CRM : https://myboom.shop/
+// Submitted by Fernando Mahfuz <fernandomahfuz@hotmail.com>
+myboom.shop
+
 // Boomla : https://boomla.com
 // Submitted by Tibor Halter <thalter@boomla.com>
 boomla.net


### PR DESCRIPTION
Boom CRM is a Brazilian CRM/e-commerce platform. Each customer gets an online store served at `<slug>.myboom.shop`, where the store owner controls the content of their own subdomain.

Because different, unrelated merchants control sibling subdomains, browsers should treat them as separate sites — otherwise `SameSite` cookie protections and cookie scoping do not isolate one merchant from another.

**Domain:** `myboom.shop`
**Section:** PRIVATE
**Operator:** Boom CRM — https://myboom.shop/

Only `myboom.shop` is being submitted. Our application domain (`boomcrm.app`) is intentionally NOT included: its subdomains are all operated by us and it carries a session cookie scoped to the registrable domain, which a PSL entry would break.

`_psl` DNS TXT record pointing to this PR will be added right after submission, per the guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8WEJxfZ1sxEzVSwvKC1Mw