### PR TITLE
Add dev.wavn.app (Wavn, Inc.)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -16288,6 +16288,10 @@ wal.app
 // Submitted by Lorentz Kinde <security@wasmer.io>
 wasmer.app
 
+// Wavn, Inc. : https://wavn.app/
+// Submitted by Wael Alebrahim <admin@wavn.app>
+dev.wavn.app
+
 // Webflow, Inc. : https://www.webflow.com
 // Submitted by Webflow Security Team <security@webflow.com>
 webflow.io


### PR DESCRIPTION
### Why

Wavn, Inc. hosts customer-created pages on subdomains of dev.wavn.app,
one page per subdomain, each belonging to a different customer.

Without a PSL entry, browsers and cookie libraries treat dev.wavn.app as
a registrable domain. A cookie set with Domain=dev.wavn.app from one
customer's page is therefore accepted and sent to every other customer's
page. Listing dev.wavn.app makes each subdomain its own site, which is
the same arrangement as github.io and pages.dev.

### Expected behaviour

Before:
  getPublicSuffix("a.dev.wavn.app")     -> "wavn.app"
  registrable domain                     -> "wavn.app"
  Cookie Domain=dev.wavn.app             -> accepted, shared across siblings

After:
  getPublicSuffix("a.dev.wavn.app")     -> "dev.wavn.app"
  registrable domain                     -> "a.dev.wavn.app"
  Cookie Domain=dev.wavn.app             -> rejected as a public suffix

### Domain

wavn.app is registered until 2 June 2029, more than two years beyond the
date of this submission. We will keep the registration more than one
year ahead for as long as this entry stands.

### _psl record

A TXT record at _psl.dev.wavn.app pointing at this pull request will be
added as soon as this PR has a number, and left in place permanently.