### PR TITLE
Add cloudstorm.cloud to the PRIVATE section

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12716,6 +12716,10 @@ objects.rma.cloudscale.ch
 lpg.objectstorage.ch
 rma.objectstorage.ch
 
+// CloudStorm (SIX4 Technologies LLC) : https://cloudstorm.cloud
+// Submitted by Al Ceric <support@cloudstorm.cloud>
+cloudstorm.cloud
+
 // Clovyr : https://clovyr.io
 // Submitted by Patrick Nielsen <patrick@clovyr.io>
 wnext.app


### PR DESCRIPTION
# Public Suffix List (PSL) Submission

### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [x] DNS verification via dig

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the `_psl` TXT record in place in the respective zone(s).

__Submitter affirms the following:__ 

 * [x] We are listing *any* third-party limits that we seek to work around in our rationale such as those between iOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)
 <!-- FILL IN (CAN BE EMPTY): Third-party limits worked around (keep this line and its END FILL IN) -->
 We are not seeking to work around any third-party limit. Disclosed for transparency only: Let's
 Encrypt per-registered-domain issuance limits would, at scale, apply collectively to certificates
 our customers obtain themselves for their own `-d` hostnames. Our current volume is orders of
 magnitude below any such limit, we have not approached Let's Encrypt about it, and no
 platform-issued certificate depends on this listing. No Cloudflare limit applies: our platform TLS
 is served by a Universal SSL wildcard that already covers every hostname we issue.
 <!-- END FILL IN -->

 * [x] This request was _not_ submitted with the objective of working around other third-party limits.

 * [x] The submitter acknowledges that it is their responsibility to maintain the domains within their section. This includes removing names which are no longer used, retaining the _psl DNS entry, and responding to e-mails to the supplied address. Failure to maintain entries may result in removal of individual entries or the entire section.

 * [x] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms to them.
 * [x] The submission follows the [Guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting.

 * [x] A role-based email address has been used and this inbox is actively monitored with a response time of no more than 30 days.

**Abuse Contact:**

* [x] Abuse contact information (email or web form) is available and easily accessible.

  URL where abuse contact or abuse reporting form can be found: 
  <!-- FILL IN: Abuse contact URL (keep this line and its END FILL IN) -->
  https://oncloudstorm.com/docs/abuse
  <!-- END FILL IN -->

---

For PRIVATE section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to roll back, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [x] *Yes, I understand*. I could break my organization's website cookies and cause other issues, and the rollback timing is acceptable. *Proceed anyway*.
---

## Description of Organization

<!-- FILL IN: Description of Organization (keep this line and its END FILL IN) -->
CloudStorm is an infrastructure-as-a-service platform operated by SIX4 Technologies LLC. It provisions virtual compute instances, static site and shop hosting, and hosted AI agents for business customers, who administer them through a web portal. I am the founder of SIX4 Technologies LLC, which owns and controls cloudstorm.cloud, and I operate the platform directly; this submission is made in that capacity.

Every customer-controlled resource is issued a platform hostname as a single label directly beneath cloudstorm.cloud. The label encodes the customer-chosen resource name, an eight-character account identifier, and a short type suffix — for example web01-b2f7d35b-d.cloudstorm.cloud for a compute instance, myshop-34cbd6ab-w.cloudstorm.cloud for a hosted shop, or agent7-b2f7d35b-ai for a hosted AI agent. Customers serve their own web content from these hostnames.

The customers occupying this namespace are unrelated businesses with no trust relationship to one another. cloudstorm.cloud exists solely to carry this delegated customer namespace: its apex redirects to our corporate site at oncloudstorm.com, it hosts no application of our own, and it sets no cookies of its own. Abuse reports concerning any hostname in the namespace are received at abuse@cloudstorm.cloud, and the reporting process is published at https://oncloudstorm.com/docs/abuse.
<!-- END FILL IN -->

**Organization Website:**
<!-- FILL IN: Organization Website (keep this line and its END FILL IN) -->
https://oncloudstorm.com
<!-- END FILL IN -->

## Reason for PSL Inclusion

<!-- FILL IN: Reason for PSL Inclusion (keep this line and its END FILL IN) -->
The purpose of this request is cookie isolation between mutually untrusted tenants.

Because cloudstorm.cloud is presently a single registrable domain, a customer serving content at one hostname can set a cookie scoped to Domain=.cloudstorm.cloud. Every visitor's browser will then transmit that cookie to every other customer's hostname in the same namespace. One tenant can therefore write into another tenant's cookie jar, and a tenant receiving such a cookie cannot distinguish it from one it set itself. Listing cloudstorm.cloud makes each hostname its own registrable domain, so the shared cookie namespace ceases to exist and the boundary matches the trust boundary that already exists between these customers.

This request does not seek certificate issuance capacity, and no platform certificate depends on it. Our hostnames are covered by a pre-existing wildcard certificate that requires no per-name issuance, so the listing changes nothing about how we obtain TLS. We are asking for the cookie and registrable-domain boundary only.

cloudstorm.cloud has more than two years remaining on its registration term, and we commit to maintaining it with at least one year remaining for as long as it is listed. We will keep the _psl TXT record in place in the zone, and we accept responsibility for maintaining this section, including removing names that fall out of use and responding to correspondence at the role-based address above within 30 days.

We understand that this change is slow or impractical to roll back, and that it alters cookie and certificate scoping behaviour on this domain in downstream software on schedules outside the PSL maintainers' control. cloudstorm.cloud carries no application of ours, sets no cookies of its own, and its apex merely redirects to oncloudstorm.com, so we accept that risk knowingly.
<!-- END FILL IN -->

**Number of THOUSANDS of distinct users this request is being made to serve:**
<!-- FILL IN: Number of thousands of distinct users (keep this line and its END FILL IN) -->
2.3
<!-- END FILL IN -->

## DNS Verification

<!-- FILL IN: DNS verification records (keep this line and its END FILL IN) -->
```
dig +short TXT _psl.cloudstorm.cloud
"https://github.com/publicsuffix/list/pull/3261"
```
<!-- END FILL IN -->
