### PR TITLE
Add inferenceusercontent.com (Inference Shell Inc.)

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -14135,6 +14135,10 @@ in-vpn.net
 in-dsl.org
 in-vpn.org
 
+// Inference Shell Inc. : https://inference.sh
+// Submitted by Ömer Karisman <info@inference.sh>
+inferenceusercontent.com
+
 // Inferno Communications : https://inferno.co.uk
 // Submitted by Connor McFarlane <noc@inferno.co.uk>
 oninferno.net


### PR DESCRIPTION
Adding `inferenceusercontent.com` to the PRIVATE section.

**Who we are.** Inference Shell Inc., operating inference.sh (https://inference.sh), a platform for running and building AI apps and agents, with more than 40,000 registered users. Any of them can publish an artifact, and each published artifact takes a subdomain of the domain in this request.

**Why the domain exists.** One of our features, artifacts, lets a person or an agent publish a small self-contained HTML and JavaScript page to a URL and share it with a team, an organisation, or publicly. The page content is authored by our users and by AI agents acting for them. It is untrusted by us, by design.

**Why each artifact gets its own subdomain.** We serve each published artifact from `<artifact-id>.inferenceusercontent.com`, a separate registrable-domain from the one carrying our application and session cookies (`inference.sh`). One subdomain per artifact means each page runs in its own browser origin, so a hostile or buggy page cannot read another page's DOM, `localStorage` or `IndexedDB`. This is the same shape used by other hosts of user-authored content.

**Why we need the PSL entry.** Origin separation does not cover cookies. Cookies are scoped by domain rather than by origin, so without a PSL entry a page at `a.inferenceusercontent.com` can set a cookie with `Domain=.inferenceusercontent.com` and every other artifact on the domain will receive it. Because the subdomains are mutually untrusted by construction, that is a shared write channel between different customers' pages: usable to correlate a viewer across unrelated artifacts, or to feed values to a page that reads its own cookies. There is no server-side mitigation, since `document.cookie` is set entirely in the browser. Listing the domain as a public suffix is the only way to make browsers refuse the parent-domain cookie.

**Scope of the domain.** `inferenceusercontent.com` serves nothing but published artifact documents and their static assets. No application, no API, no authentication endpoint and no cookie of ours is ever set on it. Requests are authorised by a short-lived signed token in the URL, specifically so that the content origin never needs a cookie.

**Validation.** A `_psl.inferenceusercontent.com` TXT record containing the URL of this pull request is being added now.

**Domain.** `inferenceusercontent.com` is registered to us and served by Cloudflare nameservers, registrar-locked with auto-renew enabled.

Linted with `linter/pslint.py`, exit 0. Entry is placed alphabetically by organisation name in the PRIVATE section, between "Individual Network Berlin e.V." and "Inferno Communications".
